### PR TITLE
feat(ui): Bootstrap 5 rewrite with Simple-DataTables, per-column filters, and UX improvements

### DIFF
--- a/src/az_mapping/static/css/style.css
+++ b/src/az_mapping/static/css/style.css
@@ -1,673 +1,157 @@
 /* ===================================================================
-   Azure AZ Mapping Viewer – Styles
+   Azure AZ Mapping Viewer – Custom styles (Bootstrap 5.3 overrides)
    =================================================================== */
 
+/* ---- Custom properties ---- */
 :root {
-    --azure-blue: #0078d4;
-    --azure-dark: #004578;
-    --azure-light: #deecf9;
-    --bg: #f4f5f7;
-    --card-bg: #ffffff;
-    --text: #323130;
-    --text-muted: #605e5c;
-    --border: #e1dfdd;
-    --success: #107c10;
-    --warning: #ffb900;
-    --danger: #d13438;
-    --radius: 8px;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.12);
-    --sidebar-w: 340px;
-    --transition: 0.2s ease;
-    --group-box-left-fill: #f8f9fa;
-    --group-box-right-fill: #f0f7f0;
-    --table-hover: #fafafa;
-    --error-bg: #fde7e9;
-    --consistency-bg: #f0f9f0;
-    --input-bg: #fff;
-    --node-label-fill: var(--text);
+    --az-blue: #0078d4;
+    --az-dark: #004578;
 }
 
-/* ---- Dark theme variables ---- */
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) {
-        --azure-light: #1a3a5c;
-        --bg: #1e1e1e;
-        --card-bg: #252526;
-        --text: #d4d4d4;
-        --text-muted: #9d9d9d;
-        --border: #3e3e42;
-        --success: #4ec94e;
-        --warning: #ffd60a;
-        --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-        --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.4);
-        --group-box-left-fill: #2d2d30;
-        --group-box-right-fill: #1e2e1e;
-        --table-hover: #2a2d2e;
-        --error-bg: #3b1c1e;
-        --consistency-bg: #1e2e1e;
-        --input-bg: #3c3c3c;
-        --node-label-fill: #d4d4d4;
-    }
-}
-[data-theme="dark"] {
-    --azure-light: #1a3a5c;
-    --bg: #1e1e1e;
-    --card-bg: #252526;
-    --text: #d4d4d4;
-    --text-muted: #9d9d9d;
-    --border: #3e3e42;
-    --success: #4ec94e;
-    --warning: #ffd60a;
-    --shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.4);
-    --group-box-left-fill: #2d2d30;
-    --group-box-right-fill: #1e2e1e;
-    --table-hover: #2a2d2e;
-    --error-bg: #3b1c1e;
-    --consistency-bg: #1e2e1e;
-    --input-bg: #3c3c3c;
-    --node-label-fill: #d4d4d4;
+/* ---- Topology sidebar ---- */
+.topo-sidebar {
+    position: sticky;
+    top: 1rem;
 }
 
-/* ---- Reset ---- */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+/* ---- Subscription checklist ---- */
+.subscription-checklist {
+    max-height: 50vh;
+    overflow-y: auto;
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    padding: 0.35rem 0.5rem;
+}
 
-html {
-    height: 100%;
+.subscription-checklist label {
+    display: block;
+    padding: 0.15rem 0;
+    cursor: pointer;
+    font-size: 0.82rem;
+    white-space: nowrap;
     overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background: var(--bg);
-    color: var(--text);
-    line-height: 1.5;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-
-/* ---- Header ---- */
-.app-header {
-    background: linear-gradient(135deg, var(--azure-dark), var(--azure-blue));
-    color: #fff;
-    padding: 1.25rem 2rem;
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    flex-shrink: 0;
-}
-.header-content {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-}
-.header-content h1 {
-    font-size: 1.35rem;
-    font-weight: 600;
-}
-
-.header-subtitle {
-    margin-top: 0.25rem;
+/* ---- Region combobox dropdown ---- */
+#region-dropdown,
+#planner-sub-dropdown {
+    max-height: 260px;
+    overflow-y: auto;
     font-size: 0.85rem;
-    opacity: 0.85;
 }
 
-.footer-disclaimer {
-    margin-top: 0.4rem;
-    font-size: 0.7rem;
+#region-dropdown .dropdown-item,
+#planner-sub-dropdown .dropdown-item {
+    padding: 0.3rem 0.75rem;
+    cursor: pointer;
+}
+
+.region-name {
     opacity: 0.6;
-    font-style: italic;
-    text-align: center;
+    font-size: 0.8em;
 }
 
-/* ---- Layout ---- */
-.app-container {
-    display: flex;
-    flex: 1;
-    gap: 0;
-    min-height: 0;
-    overflow: hidden;
+/* ---- Graph sizing (constrain on large screens) ---- */
+.graph-container {
+    max-width: 720px;
 }
 
-/* ---- Filters panel ---- */
-.filters-panel {
-    width: var(--sidebar-w);
-    min-width: var(--sidebar-w);
-    background: var(--card-bg);
-    border-right: 1px solid var(--border);
-    padding: 1.25rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    overflow-y: auto;
-    transition: width 0.3s ease, min-width 0.3s ease, padding 0.3s ease;
-    position: relative;
-}
-
-/* Sidebar toggle button */
-.sidebar-toggle {
-    position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
-    width: 28px;
-    height: 28px;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--card-bg);
-    color: var(--text-muted);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition), color var(--transition), transform 0.3s ease;
-    z-index: 2;
-    padding: 0;
-    flex-shrink: 0;
-}
-.sidebar-toggle:hover {
-    background: var(--azure-light);
-    color: var(--azure-blue);
-}
-
-/* Sidebar content wrapper */
-.sidebar-content {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    overflow: hidden;
-    opacity: 1;
-    transition: opacity 0.2s ease;
-}
-
-/* Collapsed state */
-.filters-panel.collapsed {
-    width: 48px;
-    min-width: 48px;
-    padding: 1.25rem 0.6rem;
-    overflow: hidden;
-}
-.filters-panel.collapsed .sidebar-content {
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-}
-.filters-panel.collapsed .sidebar-toggle {
-    position: static;
-    margin: 0 auto;
-    transform: rotate(180deg);
-}
-
-.filter-section h3 {
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--text-muted);
-    margin-bottom: 0.6rem;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-}
-
-.filter-section input[type="search"],
-.filter-section select {
+.graph-container svg {
     width: 100%;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 0.875rem;
-    background: var(--input-bg);
-    color: var(--text);
-    transition: border-color var(--transition);
-}
-.filter-section input[type="search"]:focus,
-.filter-section select:focus {
-    outline: none;
-    border-color: var(--azure-blue);
-    box-shadow: 0 0 0 2px rgba(0, 120, 212, 0.15);
-}
-.filter-section select option:disabled {
-    color: var(--text-muted);
-    font-style: italic;
+    height: auto;
 }
 
-/* ---- Filter inline SVG icons ---- */
-.filter-icon {
-    color: var(--text-muted);
-}
-
-/* ---- Region combobox ---- */
-.region-combobox {
-    position: relative;
-}
-.region-dropdown {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    z-index: 10;
-    max-height: 220px;
-    overflow-y: auto;
-    margin: 2px 0 0;
-    padding: 0.25rem 0;
-    list-style: none;
-    background: var(--card-bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow-lg);
-}
-.region-dropdown.open {
-    display: block;
-}
-.region-dropdown li {
-    padding: 0.4rem 0.75rem;
-    font-size: 0.85rem;
-    cursor: pointer;
-    transition: background var(--transition);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-.region-dropdown li:hover,
-.region-dropdown li.active {
-    background: var(--azure-light);
-    color: var(--azure-dark);
-}
-.region-dropdown li .region-name {
-    color: var(--text-muted);
-    font-size: 0.78rem;
-    margin-left: 0.3rem;
-}
-
-.checkbox-actions {
-    display: flex;
-    gap: 0.5rem;
-    margin: 0.4rem 0;
-}
-.checkbox-actions button {
-    background: none;
-    border: none;
-    color: var(--azure-blue);
-    font-size: 0.8rem;
-    cursor: pointer;
-    padding: 0;
-    text-decoration: underline;
-}
-.checkbox-actions button:hover { color: var(--azure-dark); }
-
-.checkbox-list {
-    max-height: 300px;
-    overflow-y: auto;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.25rem 0;
-}
-
-.checkbox-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.35rem 0.75rem;
-    cursor: pointer;
-    font-size: 0.85rem;
-    transition: background var(--transition);
-}
-.checkbox-item:hover { background: var(--azure-light); }
-.checkbox-item input[type="checkbox"] {
-    accent-color: var(--azure-blue);
-    width: 15px;
-    height: 15px;
-    flex-shrink: 0;
-}
-.checkbox-item .sub-name {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.selection-count {
-    font-size: 0.78rem;
-    color: var(--text-muted);
-    text-align: right;
-    margin-top: 0.2rem;
-}
-
-/* ---- Primary button ---- */
-.primary-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    width: 100%;
-    padding: 0.65rem 1rem;
-    background: var(--azure-blue);
-    color: #fff;
-    border: none;
-    border-radius: var(--radius);
-    font-size: 0.9rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background var(--transition), opacity var(--transition);
-}
-.primary-btn:hover:not(:disabled) { background: var(--azure-dark); }
-.primary-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-
-/* ---- Error panel ---- */
-.error-panel {
-    background: var(--error-bg);
-    border: 1px solid var(--danger);
-    border-radius: var(--radius);
-    padding: 0.75rem;
-    font-size: 0.82rem;
-    color: var(--danger);
-    word-break: break-word;
-}
-
-/* ---- Results panel ---- */
-.results-panel {
-    flex: 1;
-    padding: 1.5rem 2rem;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    overflow: hidden;
-}
-
-/* ---- Page navigation tabs ---- */
-.page-nav {
-    display: flex;
-    gap: 0;
-    border-bottom: 2px solid var(--border);
-    margin-bottom: 1.5rem;
-    flex-shrink: 0;
-}
-.page-nav-tab {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.6rem 1.25rem;
-    background: none;
-    border: none;
-    border-bottom: 3px solid transparent;
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: color var(--transition), border-color var(--transition), background var(--transition);
-    margin-bottom: -2px;
-}
-.page-nav-tab:hover {
-    color: var(--azure-blue);
-    background: var(--azure-light);
-}
-.page-nav-tab.active {
-    color: var(--azure-blue);
-    border-bottom-color: var(--azure-blue);
-}
-.page-nav-tab svg {
-    flex-shrink: 0;
-}
-
-/* ---- Page content containers ---- */
-.page-content {
-    flex: 1;
-    min-height: 0;
-}
-#page-topology {
-    overflow-y: auto;
-}
-#page-planner {
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-#planner-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-}
-
-/* ---- Proceed to Planner bar ---- */
-.proceed-bar {
-    display: flex;
-    justify-content: center;
-    padding: 1rem 0;
-}
-.proceed-btn {
-    width: auto;
-    padding: 0.65rem 1.5rem;
-}
-
-/* ---- Region Health Summary ---- */
-.health-summary-card {
-    margin-bottom: 1.5rem;
-    flex-shrink: 0;
-}
-.health-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 1rem;
-}
-.health-stat {
-    text-align: center;
-    padding: 0.5rem;
-}
-.health-stat-value {
-    font-size: 1.35rem;
-    font-weight: 700;
-    color: var(--text);
-    margin-bottom: 0.2rem;
-}
-.health-stat-label {
-    font-size: 0.78rem;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-.health-badge {
-    display: inline-block;
-    padding: 0.2rem 0.65rem;
-    border-radius: 20px;
-    font-size: 0.82rem;
-    font-weight: 600;
-    white-space: nowrap;
-}
-.health-good {
-    background: #dff6dd;
-    color: #1a7f37;
-}
-.health-warn {
-    background: #fff8c5;
-    color: #9a6700;
-}
-
-.empty-state {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    padding: 4rem 2rem;
-    text-align: center;
-    color: var(--text-muted);
-}
-
-.result-card {
-    background: var(--card-bg);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow);
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-.result-card h2 {
-    font-size: 1.05rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    color: var(--azure-dark);
-}
-
-.card-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 1rem;
-}
-.card-header h2 {
-    margin-bottom: 0;
-}
-
-.export-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.75rem;
-    background: var(--card-bg);
-    color: var(--azure-blue);
-    border: 1px solid var(--azure-blue);
-    border-radius: var(--radius);
-    font-size: 0.8rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background var(--transition), color var(--transition);
-}
-.export-btn:hover {
-    background: var(--azure-blue);
-    color: #fff;
-}
-
-/* ---- Graph ---- */
-#graph-container {
-    width: 100%;
-    overflow-x: auto;
-}
-#graph-container svg {
-    display: block;
-    margin: 0 auto;
-    max-width: 100%;
-}
-
-/* ---- Group boxes ---- */
+/* ---- D3 graph styles ---- */
 .group-box-left {
-    fill: var(--group-box-left-fill);
-    stroke: var(--azure-blue);
+    fill: var(--bs-tertiary-bg);
     stroke-width: 2;
-    stroke-dasharray: none;
-    transition: opacity var(--transition);
+    stroke-opacity: 0.8;
 }
+
 .group-box-right {
-    fill: var(--group-box-right-fill);
-    stroke: #388e3c;
+    fill: var(--bs-tertiary-bg);
+    stroke: var(--az-blue);
     stroke-width: 2;
+    stroke-opacity: 0.5;
 }
-.group-label-left {
-    font-size: 12px;
-    font-weight: 700;
-    text-transform: none;
-    letter-spacing: 0.01em;
-}
+
+.group-label-left,
 .group-label-right {
     font-size: 12px;
-    font-weight: 700;
-    fill: #388e3c;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+    font-weight: 600;
 }
 
-/* ---- Zone nodes ---- */
+.group-label-right {
+    fill: var(--az-blue);
+}
+
 .node-rect-left {
-    fill: var(--azure-light);
-    stroke: var(--azure-blue);
-    stroke-width: 1.5;
+    fill: var(--bs-body-bg);
+    stroke-width: 2;
 }
+
 .node-rect-right {
-    stroke-width: 1.5;
+    stroke-width: 2;
 }
+
 .node-label {
     font-size: 13px;
     font-weight: 500;
-    fill: var(--node-label-fill);
-    pointer-events: none;
+    fill: var(--bs-body-color);
 }
 
 .link {
-    transition: opacity var(--transition), stroke-width var(--transition);
-}
-.link.dimmed { opacity: 0.08 !important; }
-.link.highlighted { stroke-width: 4 !important; opacity: 1 !important; }
-
-/* Interactive node groups – smooth opacity transitions */
-.sub-group,
-.lz-node-group,
-.pz-node-group {
-    transition: opacity var(--transition);
+    transition: opacity 0.15s;
 }
 
-/* ---- Graph legend ---- */
-.graph-legend {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1.5rem;
-    padding-top: 0.75rem;
-    border-top: 1px solid var(--border);
-    margin-top: 1rem;
+.link.dimmed {
+    opacity: 0.08 !important;
 }
+
+.link.highlighted {
+    opacity: 1 !important;
+    stroke-width: 3.5;
+}
+
+/* ---- Legend ---- */
 .legend-item {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.35rem;
     font-size: 0.82rem;
     cursor: pointer;
-    padding: 0.2rem 0.4rem;
-    border-radius: 4px;
-    transition: background var(--transition);
 }
-.legend-item:hover { background: var(--azure-light); }
+
 .legend-swatch {
+    display: inline-block;
     width: 14px;
     height: 14px;
     border-radius: 3px;
-    flex-shrink: 0;
 }
 
-/* ---- Table ---- */
-.table-container { overflow-x: auto; }
-
+/* ---- Zone mapping table ---- */
 .mapping-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: 0.85rem;
 }
-.mapping-table th {
-    background: var(--azure-light);
-    color: var(--azure-dark);
-    font-weight: 600;
-    text-align: left;
-    padding: 0.6rem 0.85rem;
-    border-bottom: 2px solid var(--azure-blue);
+
+.mapping-table .sub-name-cell {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 }
-.mapping-table td {
-    padding: 0.55rem 0.85rem;
-    border-bottom: 1px solid var(--border);
-}
-.mapping-table tr:hover td { background: var(--table-hover); }
 
+/* Physical zone colour badges */
 .zone-badge {
     display: inline-block;
-    padding: 0.2rem 0.65rem;
-    border-radius: 20px;
-    font-size: 0.8rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.78rem;
     font-weight: 500;
     color: #fff;
-    white-space: nowrap;
 }
 
-/* Consistent physical zone colors */
 .pz-1 { background: #0078d4; }
 .pz-2 { background: #107c10; }
 .pz-3 { background: #d83b01; }
@@ -675,852 +159,288 @@ body {
 .pz-5 { background: #008272; }
 .pz-6 { background: #b4009e; }
 
-.mapping-table .sub-name-cell {
-    font-weight: 500;
-    max-width: 260px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* ---- Consistency indicator ---- */
-.consistency-row td {
-    background: var(--consistency-bg);
+.consistency-row .same {
+    color: var(--bs-success);
     font-weight: 600;
-    font-size: 0.82rem;
-    color: var(--text-muted);
 }
-.consistency-row td.same { color: var(--success); }
-.consistency-row td.different { color: var(--warning); }
 
-/* ---- Loading indicator ---- */
-.loading-indicator {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    padding: 2rem;
-    color: var(--text-muted);
-    font-size: 0.9rem;
-}
-.spinner {
-    width: 22px;
-    height: 22px;
-    border: 3px solid var(--border);
-    border-top-color: var(--azure-blue);
-    border-radius: 50%;
-    animation: spin 0.6s linear infinite;
-}
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* ---- Footer ---- */
-.app-footer {
-    position: relative;
-    text-align: center;
-    padding: 0.85rem 1rem;
-    font-size: 0.82rem;
-    color: var(--text-muted);
-    background: var(--card-bg);
-    border-top: 1px solid var(--border);
-    flex-shrink: 0;
-}
-.app-footer::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(90deg, var(--azure-blue), #107c10, var(--azure-blue));
-}
-.footer-content {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    flex-wrap: wrap;
-}
-.footer-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    color: var(--text-muted);
-    text-decoration: none;
-    font-weight: 500;
-    transition: color var(--transition);
-}
-.footer-link:hover {
-    color: var(--azure-blue);
-}
-.footer-link svg {
-    flex-shrink: 0;
-}
-.footer-sep {
-    color: var(--border);
-    font-size: 1rem;
-    line-height: 1;
-}
-.footer-license {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.15rem 0.55rem;
-    background: var(--azure-light);
-    color: var(--azure-dark);
-    border-radius: 20px;
-    font-size: 0.72rem;
+.consistency-row .different {
+    color: var(--bs-warning);
     font-weight: 600;
-    letter-spacing: 0.02em;
 }
 
-/* ---- Theme toggle ---- */
-.theme-toggle {
-    background: none;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
-    color: #fff;
-    cursor: pointer;
-    padding: 0.3rem 0.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background var(--transition), border-color var(--transition);
-    line-height: 1;
-}
-.theme-toggle:hover {
-    background: rgba(255, 255, 255, 0.15);
-    border-color: rgba(255, 255, 255, 0.5);
-}
-.theme-toggle svg {
-    width: 18px;
-    height: 18px;
-}
-/* Icon visibility managed by JS */
-.icon-sun, .icon-moon {
-    width: 18px;
-    height: 18px;
-}
-
-/* Dark mode adjustments for filter section icons */
-[data-theme="dark"] .filter-section img {
-    filter: invert(0.8);
-}
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .filter-section img {
-        filter: invert(0.8);
-    }
-}
-
-/* Dark mode: footer GitHub icon */
-[data-theme="dark"] .footer-link svg {
-    fill: var(--text-muted);
-}
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .footer-link svg {
-        fill: var(--text-muted);
-    }
-}
-
-/* Dark mode: table header */
-[data-theme="dark"] .mapping-table th {
-    background: var(--azure-light);
-    color: #58a6ff;
-}
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .mapping-table th {
-        background: var(--azure-light);
-        color: #58a6ff;
-    }
-}
-
-/* Dark mode: result card h2 */
-[data-theme="dark"] .result-card h2 {
-    color: #58a6ff;
-}
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .result-card h2 {
-        color: #58a6ff;
-    }
-}
-
-/* Header left section */
-.header-left {
-    flex: 1;
-}
-
-/* ---- Responsive ---- */
-@media (max-width: 900px) {
-    .app-container {
-        flex-direction: column;
-        overflow-y: auto;
-    }
-    .filters-panel {
-        width: 100%;
-        min-width: 100%;
-        border-right: none;
-        border-bottom: 1px solid var(--border);
-    }
-    .filters-panel.collapsed {
-        width: 100%;
-        min-width: 100%;
-        padding: 0.75rem 1.25rem;
-    }
-    .filters-panel.collapsed .sidebar-toggle {
-        transform: rotate(90deg);
-    }
-    .filters-panel .sidebar-toggle svg {
-        /* Point down on mobile when expanded */
-    }
-    .health-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-
-/* ---- SKU Section ---- */
-.sku-section {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    margin-bottom: 0;
-}
-.sku-section .card-header {
-    flex-shrink: 0;
-}
-.sku-section .card-header h2 {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.section-toggle {
-    background: none;
-    border: none;
-    color: var(--text);
-    cursor: pointer;
-    padding: 0.25rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: transform var(--transition);
-}
-
-.section-toggle .toggle-icon {
-    transition: transform var(--transition);
-}
-
-.sku-section.collapsed .section-toggle .toggle-icon {
-    transform: rotate(-90deg);
-}
-
-.sku-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-}
-
-.sku-section.collapsed .sku-content {
-    display: none;
-}
-
-.sku-controls {
-    display: flex;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-    flex-wrap: wrap;
-    flex-shrink: 0;
-}
-
-.sku-controls select {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--input-bg);
-    color: var(--text);
-    font-size: 0.875rem;
-    min-width: 200px;
-    cursor: pointer;
-}
-
-.sku-controls select:focus {
-    outline: none;
-    border-color: var(--azure-blue);
-    box-shadow: 0 0 0 3px rgba(0, 120, 212, 0.1);
-}
-
-.sku-controls input[type="search"] {
-    flex: 1;
-    min-width: 200px;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--input-bg);
-    color: var(--text);
-    font-size: 0.875rem;
-}
-
-.sku-controls input[type="search"]:focus {
-    outline: none;
-    border-color: var(--azure-blue);
-    box-shadow: 0 0 0 3px rgba(0, 120, 212, 0.1);
-}
-
-.secondary-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.5rem 1rem;
-    background: var(--card-bg);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all var(--transition);
-}
-
-.secondary-btn:hover {
-    background: var(--azure-light);
-    border-color: var(--azure-blue);
-}
-
-.secondary-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
-.empty-state-small {
-    text-align: center;
-    padding: 2rem;
-    color: var(--text-muted);
-    font-size: 0.875rem;
-}
-
-.empty-state-small p {
-    margin: 0;
-}
-
-.sku-table-container {
-    flex: 1;
-    min-height: 0;
-    overflow: auto;
-}
-
+/* ---- SKU table ---- */
 .sku-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: 0.82rem;
 }
 
 .sku-table th {
-    background: var(--azure-light);
-    color: var(--azure-dark);
-    font-weight: 600;
-    text-align: left;
-    padding: 0.6rem 0.85rem;
-    border-bottom: 2px solid var(--azure-blue);
     white-space: nowrap;
-    user-select: none;
+    vertical-align: middle;
 }
 
-.sku-table th[style*="cursor:pointer"]:hover {
-    background: var(--azure-blue);
-    color: #fff;
+/* ---- Simple-DataTables overrides ---- */
+.datatable-container {
+    overflow-x: auto;
 }
 
-.sku-table th.sort-active {
-    color: var(--azure-blue);
+.datatable-wrapper .datatable-top {
+    padding: 0.5rem 0;
 }
 
-.sku-table td {
-    padding: 0.55rem 0.85rem;
-    border-bottom: 1px solid var(--border);
+.datatable-wrapper .datatable-bottom {
+    padding: 0.25rem 0;
 }
 
-.sku-table tr:hover td {
-    background: var(--table-hover);
+.datatable-wrapper .datatable-info {
+    font-size: 0.82rem;
+    color: var(--bs-secondary-color);
+}
+
+/* ---- Per-column filter row ---- */
+.datatable-filter-row td {
+    padding: 0.2rem 0.25rem;
+}
+
+.datatable-column-filter {
+    width: 100%;
+    padding: 0.15rem 0.35rem;
+    font-size: 0.78rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+}
+
+.datatable-column-filter:focus {
+    border-color: var(--az-blue);
+    box-shadow: 0 0 0 0.15rem rgba(0, 120, 212, 0.2);
+    outline: none;
+}
+
+.datatable-column-filter::placeholder {
+    color: var(--bs-secondary-color);
+    opacity: 0.6;
+    font-size: 0.75rem;
 }
 
 .zone-available {
-    color: var(--success);
-    font-weight: 600;
-}
-
-.zone-unavailable {
-    color: var(--text-muted);
-    opacity: 0.5;
+    color: var(--bs-success) !important;
+    text-align: center;
+    font-size: 1rem;
 }
 
 .zone-restricted {
-    color: var(--warning);
-    font-weight: 600;
-    font-size: 1.1rem;
-}
-
-/* ---- Spot Placement Score badges ---- */
-.spot-badge {
-    display: inline-block;
-    padding: 0.15rem 0.55rem;
-    border-radius: 20px;
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    white-space: nowrap;
-    text-transform: capitalize;
-}
-.spot-high {
-    background: var(--success);
-    color: #fff;
-}
-.spot-medium {
-    background: var(--warning);
-    color: #1a1a1a;
-}
-.spot-low {
-    background: var(--danger);
-    color: #fff;
-}
-.spot-unknown {
-    background: var(--border);
-    color: var(--text-muted);
-}
-
-/* Spot controls */
-.sku-controls-sep {
-    width: 1px;
-    align-self: stretch;
-    background: var(--border);
-    margin: 0 0.25rem;
-}
-.spot-instance-label {
-    display: flex;
-    align-items: center;
-    font-size: 0.82rem;
-    color: var(--text-muted);
-    white-space: nowrap;
-}
-.spot-instance-input {
-    width: 70px;
-    padding: 0.5rem 0.5rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--input-bg);
-    color: var(--text);
-    font-size: 0.875rem;
+    color: var(--bs-warning) !important;
     text-align: center;
-}
-.spot-instance-input:focus {
-    outline: none;
-    border-color: var(--azure-blue);
-    box-shadow: 0 0 0 3px rgba(0, 120, 212, 0.1);
+    font-size: 0.9rem;
 }
 
-/* Spot score cell – clickable */
+.zone-unavailable {
+    color: var(--bs-secondary) !important;
+    text-align: center;
+    font-size: 0.85rem;
+    opacity: 0.5;
+}
+
+/* ---- SKU name as a link button ---- */
+.sku-name-btn {
+    background: none;
+    border: none;
+    color: var(--az-blue);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+}
+
+.sku-name-btn:hover {
+    text-decoration-style: solid;
+}
+
+/* ---- Spot score badges ---- */
 .spot-cell-btn {
     background: none;
-    border: 1px dashed var(--border);
-    border-radius: 6px;
-    padding: 0.2rem 0.55rem;
+    border: 1px dashed var(--bs-border-color);
+    border-radius: 4px;
+    padding: 0.15rem 0.5rem;
     cursor: pointer;
-    color: var(--azure-blue);
     font-size: 0.78rem;
-    transition: all var(--transition);
+    color: var(--bs-body-color);
 }
+
 .spot-cell-btn:hover {
-    background: var(--azure-light);
-    border-color: var(--azure-blue);
+    border-style: solid;
+    border-color: var(--az-blue);
 }
+
 .spot-cell-btn.has-score {
-    border: none;
-    padding: 0;
+    border-style: solid;
 }
+
+.spot-badge {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.spot-high { background: #d4edda; color: #155724; }
+.spot-medium { background: #fff3cd; color: #856404; }
+.spot-low { background: #f8d7da; color: #721c24; }
+.spot-unknown { background: var(--bs-secondary-bg); color: var(--bs-body-color); }
+
 .spot-zone-label {
     font-size: 0.7rem;
-    color: var(--text-muted);
+    opacity: 0.7;
     margin-right: 0.15rem;
-    margin-left: 0.3rem;
 }
-.spot-zone-label:first-child {
-    margin-left: 0;
-}
+
 .spot-modal-grid {
     display: grid;
     grid-template-columns: auto 1fr;
     gap: 0.3rem 0.5rem;
     align-items: center;
 }
-.spot-modal-zone {
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    text-align: right;
-}
 
-/* ---- SKU Pricing controls ---- */
-.sku-price-toggle {
-    white-space: nowrap;
-    font-size: 0.85rem;
-    cursor: pointer;
-    margin: 0;
-    padding: 0.4rem 0;
-}
-.sku-currency-select {
-    padding: 0.35rem 0.5rem;
-    font-size: 0.85rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--card-bg);
-    color: var(--text);
-    min-width: 4.5rem;
-}
-.sku-currency-select:focus {
-    outline: none;
-    border-color: var(--azure-blue);
-}
-.price-cell {
-    font-family: "SF Mono", "Cascadia Code", "Fira Code", monospace;
-    font-size: 0.82rem;
-    text-align: right;
-    white-space: nowrap;
-}
-
-/* ---- Modal ---- */
-.modal-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    z-index: 100;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.modal-dialog {
-    background: var(--card-bg);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow-lg);
-    padding: 1.5rem;
-    width: 340px;
-    max-width: 90vw;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-}
-.modal-dialog h3 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--azure-dark);
-    margin: 0;
-}
-.modal-sku-name {
-    font-weight: 600;
-    font-size: 0.95rem;
-    color: var(--text);
-    margin: 0;
-}
-.modal-dialog label {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
-.modal-actions {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 0.25rem;
-}
-.modal-actions .primary-btn {
-    flex: 1;
-    padding: 0.5rem;
-}
-.modal-actions .secondary-btn {
-    flex: 1;
-    padding: 0.5rem;
-    justify-content: center;
-}
-
-/* ---- Pricing Detail Modal ---- */
-.pricing-modal-dialog {
-    width: 580px;
-    max-height: 90vh;
-    overflow-y: auto;
-}
-.pricing-modal-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-.pricing-modal-header h3 {
-    margin: 0;
-}
-.modal-close-btn {
-    background: none;
-    border: none;
-    font-size: 1.4rem;
-    line-height: 1;
-    color: var(--text-muted);
-    cursor: pointer;
-    padding: 0.15rem 0.4rem;
+/* ---- Confidence badge ---- */
+.confidence-badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
     border-radius: 4px;
-    transition: all var(--transition);
-}
-.modal-close-btn:hover {
-    background: var(--error-bg);
-    color: var(--danger);
-}
-.pricing-modal-currency {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.85rem;
-}
-.pricing-modal-currency label {
-    color: var(--text-muted);
-    white-space: nowrap;
-}
-.pricing-detail-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.875rem;
-}
-.pricing-detail-table th {
-    background: var(--azure-light);
-    color: var(--azure-dark);
+    font-size: 0.78rem;
     font-weight: 600;
-    text-align: left;
-    padding: 0.5rem 0.75rem;
-    border-bottom: 2px solid var(--azure-blue);
-    white-space: nowrap;
-}
-.pricing-detail-table td {
-    padding: 0.45rem 0.75rem;
-    border-bottom: 1px solid var(--border);
-}
-.pricing-detail-table tr:hover td {
-    background: var(--table-hover);
 }
 
-/* SKU name clickable button in table */
-.sku-name-btn {
-    background: none;
-    border: none;
-    color: var(--azure-blue);
-    font-weight: 600;
-    font-size: inherit;
-    cursor: pointer;
-    padding: 0;
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-underline-offset: 2px;
-}
-.sku-name-btn:hover {
-    color: var(--azure-dark);
-    text-decoration-style: solid;
+.confidence-high { background: #d4edda; color: #155724; }
+.confidence-medium { background: #fff3cd; color: #856404; }
+.confidence-low { background: #f8d7da; color: #721c24; }
+.confidence-very-low { background: #f5c6cb; color: #721c24; }
+
+/* ---- Confidence breakdown / VM profile inside pricing modal ---- */
+.confidence-section {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--bs-border-color);
 }
 
-/* ---- VM Profile Section ---- */
+.confidence-title {
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+}
+
+.confidence-info-icon {
+    font-size: 0.8rem;
+    cursor: help;
+}
+
+.confidence-breakdown-table .bi-info-circle {
+    font-size: 0.72rem;
+    cursor: help;
+}
+
+.confidence-breakdown-table {
+    font-size: 0.82rem;
+}
+
+.confidence-missing {
+    font-size: 0.78rem;
+    color: var(--bs-secondary-color);
+    margin-top: 0.4rem;
+}
+
 .vm-profile-section {
-    margin-top: 1rem;
-    border-top: 1px solid var(--border);
-    padding-top: 0.75rem;
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--bs-border-color);
 }
+
 .vm-profile-title {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--azure-dark);
-    margin: 0 0 0.5rem 0;
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
 }
+
 .vm-profile-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 0.75rem;
 }
+
 .vm-profile-card {
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.6rem 0.75rem;
+    background: var(--bs-tertiary-bg);
+    border-radius: var(--bs-border-radius);
+    padding: 0.75rem;
 }
+
 .vm-profile-card-title {
-    font-size: 0.78rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--azure-blue);
-    margin-bottom: 0.35rem;
-    padding-bottom: 0.25rem;
-    border-bottom: 1px solid var(--border);
+    font-weight: 600;
+    font-size: 0.82rem;
+    margin-bottom: 0.4rem;
+    color: var(--az-blue);
 }
+
 .vm-profile-row {
     display: flex;
     justify-content: space-between;
-    align-items: center;
     padding: 0.15rem 0;
     font-size: 0.8rem;
-    gap: 0.5rem;
+    border-bottom: 1px solid var(--bs-border-color-translucent);
 }
+
 .vm-profile-label {
-    color: var(--text-muted);
-    white-space: nowrap;
+    color: var(--bs-secondary-color);
 }
-.vm-profile-value {
-    font-weight: 500;
-    text-align: right;
-    word-break: break-word;
+
+.vm-profile-row-stacked {
+    flex-direction: column;
+    gap: 0.2rem;
 }
+
 .vm-badge {
     display: inline-block;
-    padding: 0.1rem 0.45rem;
-    border-radius: 12px;
-    font-size: 0.72rem;
-    font-weight: 600;
-    white-space: nowrap;
-}
-.vm-badge-yes {
-    background: var(--success);
-    color: #fff;
-}
-.vm-badge-no {
-    background: var(--danger);
-    color: #fff;
-}
-.vm-badge-unknown {
-    background: var(--border);
-    color: var(--text-muted);
-}
-.vm-badge-limited {
-    background: var(--warning);
-    color: #1a1a1a;
-}
-
-/* Dark mode: SKU table header */
-[data-theme="dark"] .sku-table th {
-    background: var(--azure-light);
-    color: #58a6ff;
-}
-
-[data-theme="dark"] .modal-dialog h3 {
-    color: #58a6ff;
-}
-[data-theme="dark"] .pricing-detail-table th {
-    background: var(--azure-light);
-    color: #58a6ff;
-}
-[data-theme="dark"] .vm-profile-title,
-[data-theme="dark"] .vm-profile-card-title {
-    color: #58a6ff;
-}
-[data-theme="dark"] .vm-profile-card {
-    background: var(--card-bg);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .sku-table th {
-        background: var(--azure-light);
-        color: #58a6ff;
-    }
-    :root:not([data-theme="light"]) .modal-dialog h3 {
-        color: #58a6ff;
-    }
-    :root:not([data-theme="light"]) .pricing-detail-table th {
-        background: var(--azure-light);
-        color: #58a6ff;
-    }
-    :root:not([data-theme="light"]) .vm-profile-title,
-    :root:not([data-theme="light"]) .vm-profile-card-title {
-        color: #58a6ff;
-    }
-    :root:not([data-theme="light"]) .vm-profile-card {
-        background: var(--card-bg);
-    }
-}
-
-/* ---------------------------------------------------------------------------
-   Confidence Score
-   --------------------------------------------------------------------------- */
-.confidence-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.15rem 0.5rem;
-    border-radius: 12px;
-    font-size: 0.78rem;
-    font-weight: 600;
-    white-space: nowrap;
-}
-.confidence-badge small {
-    font-weight: 500;
-    font-size: 0.68rem;
-    opacity: 0.85;
-}
-.confidence-high       { background: #dff6dd; color: #1a7f37; }
-.confidence-medium     { background: #fff8c5; color: #9a6700; }
-.confidence-low        { background: #ffebe9; color: #cf222e; }
-.confidence-very-low   { background: #ffcccb; color: #82071e; }
-
-.confidence-section {
-    margin-top: 1.25rem;
-}
-.confidence-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 0.5rem;
-}
-.confidence-breakdown-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.82rem;
-    margin-bottom: 0.5rem;
-}
-.confidence-breakdown-table th {
-    text-align: left;
-    padding: 0.35rem 0.5rem;
-    background: var(--azure-light);
-    color: var(--azure);
-    font-weight: 600;
+    padding: 0 0.35rem;
+    border-radius: 3px;
     font-size: 0.75rem;
-    border-bottom: 2px solid var(--border);
-}
-.confidence-breakdown-table td {
-    padding: 0.3rem 0.5rem;
-    border-bottom: 1px solid var(--border);
-}
-.confidence-missing {
-    font-size: 0.78rem;
-    color: var(--text-muted);
-    font-style: italic;
-    margin: 0;
+    font-weight: 500;
 }
 
-/* Dark mode – confidence */
-[data-theme="dark"] .confidence-high     { background: #1a3d1f; color: #3fb950; }
-[data-theme="dark"] .confidence-medium   { background: #3d3012; color: #d29922; }
-[data-theme="dark"] .confidence-low      { background: #3d1519; color: #f85149; }
-[data-theme="dark"] .confidence-very-low { background: #4d0e14; color: #ff7b72; }
-[data-theme="dark"] .confidence-title { color: #58a6ff; }
-[data-theme="dark"] .confidence-breakdown-table th {
-    background: var(--azure-light);
-    color: #58a6ff;
+.vm-badge-yes { background: #d4edda; color: #155724; }
+.vm-badge-no { background: #f8d7da; color: #721c24; }
+.vm-badge-unknown { background: var(--bs-secondary-bg); color: var(--bs-body-color); }
+.vm-badge-limited { background: #fff3cd; color: #856404; }
+.vm-badge-block {
+    display: block;
+    white-space: normal;
+    word-break: break-word;
+    text-align: left;
+    line-height: 1.4;
 }
-[data-theme="dark"] .health-good { background: #1a3d1f; color: #3fb950; }
-[data-theme="dark"] .health-warn { background: #3d3012; color: #d29922; }
-[data-theme="dark"] .page-nav-tab.active { color: #58a6ff; border-bottom-color: #58a6ff; }
-[data-theme="dark"] .page-nav-tab:hover { color: #58a6ff; }
+.restriction-item + .restriction-item {
+    margin-top: 0.2rem;
+    padding-top: 0.2rem;
+    border-top: 1px dashed rgba(133, 100, 4, 0.3);
+}
 
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .confidence-high     { background: #1a3d1f; color: #3fb950; }
-    :root:not([data-theme="light"]) .confidence-medium   { background: #3d3012; color: #d29922; }
-    :root:not([data-theme="light"]) .confidence-low      { background: #3d1519; color: #f85149; }
-    :root:not([data-theme="light"]) .confidence-very-low { background: #4d0e14; color: #ff7b72; }
-    :root:not([data-theme="light"]) .confidence-title { color: #58a6ff; }
-    :root:not([data-theme="light"]) .confidence-breakdown-table th {
-        background: var(--azure-light);
-        color: #58a6ff;
-    }
-    :root:not([data-theme="light"]) .health-good { background: #1a3d1f; color: #3fb950; }
-    :root:not([data-theme="light"]) .health-warn { background: #3d3012; color: #d29922; }
-    :root:not([data-theme="light"]) .page-nav-tab.active { color: #58a6ff; border-bottom-color: #58a6ff; }
-    :root:not([data-theme="light"]) .page-nav-tab:hover { color: #58a6ff; }
+.price-cell {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
 }
+
+/* ---- Pricing detail table in modal ---- */
+.pricing-detail-table {
+    font-size: 0.85rem;
+}
+
+/* ---- Dark theme tweaks for custom badges ---- */
+[data-bs-theme="dark"] .spot-high { background: #1e4620; color: #a3d9a5; }
+[data-bs-theme="dark"] .spot-medium { background: #4a3c00; color: #ffe066; }
+[data-bs-theme="dark"] .spot-low { background: #4a1c1e; color: #f5a3a7; }
+[data-bs-theme="dark"] .confidence-high { background: #1e4620; color: #a3d9a5; }
+[data-bs-theme="dark"] .confidence-medium { background: #4a3c00; color: #ffe066; }
+[data-bs-theme="dark"] .confidence-low { background: #4a1c1e; color: #f5a3a7; }
+[data-bs-theme="dark"] .confidence-very-low { background: #3b1c1e; color: #f5a3a7; }
+[data-bs-theme="dark"] .vm-badge-yes { background: #1e4620; color: #a3d9a5; }
+[data-bs-theme="dark"] .vm-badge-no { background: #4a1c1e; color: #f5a3a7; }
+[data-bs-theme="dark"] .vm-badge-limited { background: #4a3c00; color: #ffe066; }

--- a/src/az_mapping/static/js/app.js
+++ b/src/az_mapping/static/js/app.js
@@ -1,21 +1,24 @@
 /* ===================================================================
-   Azure AZ Mapping Viewer – Frontend Logic
+   Azure AZ Mapping Viewer – Frontend Logic  (Bootstrap 5 rewrite)
    =================================================================== */
 
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
-let subscriptions = [];          // [{id, name}]
-let selectedSubscriptions = new Set();
-let regions = [];                // [{name, displayName}]
-let tenants = [];                // [{id, name}]
-let lastMappingData = null;      // cached result from /api/mappings
-let selectedSkuSubscription = null; // subscription selected for SKU loading
-let lastSkuData = null;          // cached SKU data
-let skuSortColumn = null;        // current SKU table sort column
-let skuSortAsc = true;           // sort direction
-let lastSpotScores = null;       // cached spot placement scores {scores: {sku: score}, errors: []}
-let currentPage = 'topology';   // active page: 'topology' | 'planner'
+let subscriptions = [];                     // [{id, name}] – all subs for current tenant
+let regions = [];                           // [{name, displayName}]
+let tenants = [];                           // [{id, name, authenticated}]
+
+// --- Topology tab state ---
+let topoSelectedSubs = new Set();           // selected subscription IDs for topology
+let lastMappingData = null;                 // cached /api/mappings result
+
+// --- Planner tab state ---
+let plannerSubscriptionId = null;           // single selected subscription ID
+let plannerZoneMappings = null;             // zone mappings fetched independently for planner
+let lastSkuData = null;                     // cached SKU list
+let lastSpotScores = null;                  // {scores: {sku: {zone: label}}, errors: []}
+let _skuDataTable = null;                   // Simple-DataTables instance
 
 // ---------------------------------------------------------------------------
 // Deployment Confidence Score – client-side recomputation
@@ -45,21 +48,16 @@ function recomputeConfidence(sku) {
     const spotLabel = _bestSpotLabel(zoneScores);
 
     const signals = {};
-    // quota
     if (remaining != null) {
         if (remaining <= 0) signals.quota = 0;
         else signals.quota = Math.min((remaining / Math.max(vcpus, 1)) / 10, 1) * 100;
     }
-    // spot
     const spotMap = { high: 100, medium: 60, low: 25 };
     if (spotLabel && spotMap[spotLabel.toLowerCase()] != null) {
         signals.spot = spotMap[spotLabel.toLowerCase()];
     }
-    // zones
     signals.zones = Math.min(zones.length / 3, 1) * 100;
-    // restrictions
     signals.restrictions = restrictions.length > 0 ? 0 : 100;
-    // pricePressure
     if (pricing.paygo != null && pricing.spot != null && pricing.paygo > 0) {
         const ratio = pricing.spot / pricing.paygo;
         signals.pricePressure = Math.max(0, Math.min(1, (0.8 - ratio) / 0.6)) * 100;
@@ -80,7 +78,6 @@ function recomputeConfidence(sku) {
         weightedSum += contrib;
         breakdown.push({ signal: k, score: Math.round(signals[k] * 10) / 10, weight: Math.round(ew * 1000) / 1000, contribution: Math.round(contrib * 10) / 10 });
     }
-
     const score = totalWeight > 0 ? Math.round(weightedSum) : 0;
     let label = "Very Low";
     for (const [th, lbl] of _CONF_LABELS) {
@@ -90,7 +87,7 @@ function recomputeConfidence(sku) {
 }
 
 // ---------------------------------------------------------------------------
-// Theme management
+// Theme management  (Bootstrap uses data-bs-theme)
 // ---------------------------------------------------------------------------
 function getEffectiveTheme() {
     const stored = localStorage.getItem("theme");
@@ -99,31 +96,25 @@ function getEffectiveTheme() {
 }
 
 function applyTheme(theme) {
-    document.documentElement.setAttribute("data-theme", theme);
-    // Toggle icon visibility
-    const sun = document.querySelector(".icon-sun");
-    const moon = document.querySelector(".icon-moon");
-    if (sun && moon) {
-        sun.style.display = theme === "dark" ? "block" : "none";
-        moon.style.display = theme === "dark" ? "none" : "block";
+    document.documentElement.setAttribute("data-bs-theme", theme);
+    const iconDark = document.getElementById("icon-dark");
+    const iconLight = document.getElementById("icon-light");
+    if (iconDark && iconLight) {
+        iconDark.classList.toggle("d-none", theme === "dark");
+        iconLight.classList.toggle("d-none", theme !== "dark");
     }
 }
 
 function toggleTheme() {
-    const current = getEffectiveTheme();
-    const next = current === "dark" ? "light" : "dark";
+    const next = getEffectiveTheme() === "dark" ? "light" : "dark";
     localStorage.setItem("theme", next);
     applyTheme(next);
 }
 
-// Apply theme immediately (before DOMContentLoaded) to prevent flash
+// Apply immediately to prevent flash
 applyTheme(getEffectiveTheme());
-
-// Listen for system preference changes
 window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
-    if (!localStorage.getItem("theme")) {
-        applyTheme(getEffectiveTheme());
-    }
+    if (!localStorage.getItem("theme")) applyTheme(getEffectiveTheme());
 });
 
 // ---------------------------------------------------------------------------
@@ -132,179 +123,57 @@ window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () 
 document.addEventListener("DOMContentLoaded", init);
 
 async function init() {
-    document.getElementById("sub-filter").addEventListener("input", onFilterSubs);
+    // Topology subscription filter
+    document.getElementById("topo-sub-filter").addEventListener("input", e => renderTopoSubList(e.target.value));
+
+    // Tenant change
     document.getElementById("tenant-select").addEventListener("change", onTenantChange);
-    document.getElementById("sku-subscription-select").addEventListener("change", onSkuSubscriptionChange);
-    
-    // SKU filter with debounce (250ms)
-    let skuFilterTimeout;
-    const skuFilterInput = document.getElementById("sku-filter");
-    if (skuFilterInput) {
-        skuFilterInput.addEventListener("input", () => {
-            clearTimeout(skuFilterTimeout);
-            skuFilterTimeout = setTimeout(() => {
-                if (lastSkuData) {
-                    const subscriptionId = selectedSkuSubscription || [...selectedSubscriptions][0];
-                    const subscriptionName = subscriptionId ? getSubName(subscriptionId) : "Unknown";
-                    renderSkuTable(lastSkuData, subscriptionName);
-                }
-            }, 250);
-        });
-    }
-    
+
+    // Event delegation for SKU table interactive cells
+    document.getElementById("sku-table-container").addEventListener("click", (e) => {
+        const btn = e.target.closest("[data-action]");
+        if (!btn) return;
+        const sku = btn.dataset.sku;
+        if (btn.dataset.action === "pricing") openPricingModal(sku);
+        else if (btn.dataset.action === "spot") openSpotModal(sku);
+    });
+
+    // Init shared region combobox
     initRegionCombobox();
 
-    // Load tenants first
+    // Init planner subscription combobox
+    initPlannerSubCombobox();
+
+    // Hash-based tab routing
+    const tabEl = document.querySelector('#mainTabs');
+    if (tabEl) {
+        tabEl.addEventListener('shown.bs.tab', (e) => {
+            const target = e.target.getAttribute('data-bs-target');
+            window.history.replaceState(null, '', target === '#tab-planner' ? '#planner' : '#topology');
+        });
+    }
+    // Activate tab from hash
+    const hash = window.location.hash;
+    if (hash === '#planner') {
+        const plannerTab = document.getElementById('planner-tab');
+        if (plannerTab) new bootstrap.Tab(plannerTab).show();
+    }
+
+    // Load tenants
     await fetchTenants();
 
-    // Restore tenant from URL before loading regions/subs
-    const urlState = getUrlParams();
-    if (urlState.tenant) {
-        const select = document.getElementById("tenant-select");
-        if ([...select.options].some(o => o.value === urlState.tenant)) {
-            select.value = urlState.tenant;
-        }
-    }
-
-    // Load regions and subscriptions in parallel – independent of each other
+    // Load regions + subscriptions in parallel
     await Promise.all([fetchRegions(), fetchSubscriptions()]);
 
-    // Restore state from URL parameters
-    if (urlState.region) {
-        if (regions.some(r => r.name === urlState.region)) {
-            selectRegion(urlState.region);
-        }
-    }
-    if (urlState.subscriptions.length) {
-        urlState.subscriptions.forEach(id => {
-            if (subscriptions.some(s => s.id === id)) {
-                selectedSubscriptions.add(id);
-            }
-        });
-        renderSubscriptionList();
-        updateSkuSubscriptionSelector();
-    }
-    updateLoadButton();
-
-    // Auto-load mappings if both region and subscriptions are set
-    if (urlState.region && urlState.subscriptions.length && !document.getElementById("load-btn").disabled) {
-        await loadMappings();
-    }
-
-    // Handle initial route from URL hash
-    const initialPage = window.location.hash.substring(1);
-    navigateTo(['topology', 'planner'].includes(initialPage) ? initialPage : 'topology');
+    updateTopoLoadButton();
+    updatePlannerLoadButton();
 }
 
 // ---------------------------------------------------------------------------
-// Page routing (hash-based)
+// URL hash helper  (only stores active tab, no query params)
 // ---------------------------------------------------------------------------
-function navigateTo(page) {
-    if (!['topology', 'planner'].includes(page)) page = 'topology';
-    currentPage = page;
-
-    // Update hash without triggering full reload
-    const newHash = '#' + page;
-    if (window.location.hash !== newHash) {
-        history.replaceState(null, '', window.location.pathname + window.location.search + newHash);
-    }
-
-    // Show/hide pages
-    document.getElementById('page-topology').style.display = page === 'topology' ? '' : 'none';
-    document.getElementById('page-planner').style.display = page === 'planner' ? '' : 'none';
-
-    // Update active tab
-    document.querySelectorAll('.page-nav-tab').forEach(tab => {
-        tab.classList.toggle('active', tab.dataset.page === page);
-    });
-
-    // When entering planner, update content visibility
-    if (page === 'planner') {
-        if (lastMappingData && lastMappingData.length > 0) {
-            document.getElementById('planner-empty').style.display = 'none';
-            document.getElementById('planner-content').style.display = '';
-            renderRegionHealthSummary();
-        } else {
-            document.getElementById('planner-empty').style.display = 'flex';
-            document.getElementById('planner-content').style.display = 'none';
-        }
-    }
-}
-
-function renderRegionHealthSummary() {
-    const container = document.getElementById('region-health-summary');
-    if (!container) return;
-    if (!lastMappingData || lastMappingData.length === 0) {
-        container.innerHTML = '';
-        return;
-    }
-
-    const regionName = document.getElementById('region-select').value;
-    const regionDisplay = document.getElementById('region-search').value || regionName;
-    const validData = lastMappingData.filter(d => d.mappings && d.mappings.length > 0);
-    const physicalZones = [...new Set(validData.flatMap(d => d.mappings.map(m => m.physicalZone)))].sort();
-    const logicalZones = [...new Set(validData.flatMap(d => d.mappings.map(m => m.logicalZone)))].sort();
-
-    let allConsistent = true;
-    logicalZones.forEach(z => {
-        const physicals = validData.map(sub => sub.mappings.find(m => m.logicalZone === z))
-            .filter(Boolean).map(m => m.physicalZone);
-        if (new Set(physicals).size > 1) allConsistent = false;
-    });
-
-    const consistencyHtml = allConsistent
-        ? '<span class="health-badge health-good">\u2713 Consistent</span>'
-        : '<span class="health-badge health-warn">\u26A0 Differences detected</span>';
-
-    container.innerHTML = `<div class="health-summary-card result-card">
-        <h2>Region Health Summary</h2>
-        <div class="health-grid">
-            <div class="health-stat"><div class="health-stat-value">${escapeHtml(regionDisplay)}</div><div class="health-stat-label">Region</div></div>
-            <div class="health-stat"><div class="health-stat-value">${physicalZones.length}</div><div class="health-stat-label">Physical Zones</div></div>
-            <div class="health-stat"><div class="health-stat-value">${validData.length}</div><div class="health-stat-label">Subscriptions</div></div>
-            <div class="health-stat"><div class="health-stat-value">${consistencyHtml}</div><div class="health-stat-label">Zone Consistency</div></div>
-        </div>
-    </div>`;
-}
-
-window.addEventListener('hashchange', () => {
-    const page = window.location.hash.substring(1) || 'topology';
-    navigateTo(page);
-});
-
-// ---------------------------------------------------------------------------
-// Sidebar collapse / expand
-// ---------------------------------------------------------------------------
-function toggleSidebar() {
-    const panel = document.getElementById("filters-panel");
-    const btn = document.getElementById("sidebar-toggle");
-    const isCollapsed = panel.classList.toggle("collapsed");
-    btn.title = isCollapsed ? "Expand filters" : "Collapse filters";
-}
-
-// ---------------------------------------------------------------------------
-// URL parameter helpers
-// ---------------------------------------------------------------------------
-function getUrlParams() {
-    const params = new URLSearchParams(window.location.search);
-    return {
-        tenant: params.get("tenant") || "",
-        region: params.get("region") || "",
-        subscriptions: params.get("subscriptions") ? params.get("subscriptions").split(",") : []
-    };
-}
-
-function syncUrlParams() {
-    const tenant = document.getElementById("tenant-select").value;
-    const region = document.getElementById("region-select").value;
-    const subs = [...selectedSubscriptions];
-    const params = new URLSearchParams();
-    if (tenant) params.set("tenant", tenant);
-    if (region) params.set("region", region);
-    if (subs.length) params.set("subscriptions", subs.join(","));
-    const qs = params.toString();
-    const newUrl = window.location.pathname + (qs ? "?" + qs : "");
-    window.history.replaceState(null, "", newUrl);
+function getActiveTabFromHash() {
+    return window.location.hash === "#planner" ? "planner" : "topology";
 }
 
 // ---------------------------------------------------------------------------
@@ -332,58 +201,22 @@ async function apiPost(url, body) {
     return resp.json();
 }
 
-function showError(msg) {
-    const panel = document.getElementById("error-panel");
-    panel.textContent = msg;
-    panel.style.display = "block";
-}
-function hideError() {
-    document.getElementById("error-panel").style.display = "none";
+function showError(targetId, msg) {
+    const el = document.getElementById(targetId);
+    if (!el) return;
+    el.textContent = msg;
+    el.classList.remove("d-none");
 }
 
-/** Return '&tenantId=xxx' or '' depending on current selection. */
+function hideError(targetId) {
+    const el = document.getElementById(targetId);
+    if (el) el.classList.add("d-none");
+}
+
 function tenantQS(prefix) {
     const tid = document.getElementById("tenant-select").value;
     if (!tid) return "";
     return (prefix || "&") + "tenantId=" + encodeURIComponent(tid);
-}
-
-// ---------------------------------------------------------------------------
-// Subscriptions
-// ---------------------------------------------------------------------------
-async function fetchSubscriptions() {
-    try {
-        subscriptions = await apiFetch("/api/subscriptions" + tenantQS("?"));
-        renderSubscriptionList();
-    } catch (err) {
-        showError("Failed to load subscriptions: " + err.message);
-        document.getElementById("sub-loading").innerHTML =
-            '<span style="color:var(--danger)">Error loading subscriptions</span>';
-    }
-}
-
-function renderSubscriptionList(filter) {
-    const container = document.getElementById("sub-list");
-    const list = filter
-        ? subscriptions.filter(s => s.name.toLowerCase().includes(filter.toLowerCase()))
-        : subscriptions;
-
-    if (!list.length && !filter) {
-        container.innerHTML = '<div class="loading-indicator"><span>No subscriptions found</span></div>';
-        return;
-    }
-
-    container.innerHTML = list.map(s => {
-        const checked = selectedSubscriptions.has(s.id) ? "checked" : "";
-        const escapedName = escapeHtml(s.name);
-        return `<label class="checkbox-item" title="${escapedName}">
-            <input type="checkbox" value="${s.id}" ${checked}
-                   onchange="toggleSubscription('${s.id}')">
-            <span class="sub-name">${escapedName}</span>
-        </label>`;
-    }).join("");
-
-    updateSubCount();
 }
 
 function escapeHtml(str) {
@@ -392,91 +225,13 @@ function escapeHtml(str) {
     return div.innerHTML;
 }
 
-function onFilterSubs(e) {
-    renderSubscriptionList(e.target.value);
+function truncate(str, max) {
+    return str.length > max ? str.substring(0, max - 1) + "\u2026" : str;
 }
 
-function toggleSubscription(id) {
-    if (selectedSubscriptions.has(id)) {
-        selectedSubscriptions.delete(id);
-    } else {
-        selectedSubscriptions.add(id);
-    }
-    updateSubCount();
-    updateLoadButton();
-    syncUrlParams();
-    updateSkuSubscriptionSelector();
-}
-
-function selectAllVisible() {
-    document.querySelectorAll("#sub-list input[type=checkbox]").forEach(cb => {
-        cb.checked = true;
-        selectedSubscriptions.add(cb.value);
-    });
-    updateSubCount();
-    updateLoadButton();
-    syncUrlParams();
-    updateSkuSubscriptionSelector();
-}
-
-function deselectAll() {
-    selectedSubscriptions.clear();
-    document.querySelectorAll("#sub-list input[type=checkbox]").forEach(cb => {
-        cb.checked = false;
-    });
-    updateSubCount();
-    updateLoadButton();
-    syncUrlParams();
-    updateSkuSubscriptionSelector();
-}
-
-function updateSubCount() {
-    document.getElementById("sub-count").textContent =
-        `${selectedSubscriptions.size} selected`;
-}
-
-function updateSkuSubscriptionSelector() {
-    const selector = document.getElementById("sku-subscription-select");
-    const selectedSubs = [...selectedSubscriptions];
-    
-    // Clear existing options
-    selector.innerHTML = '<option value="">Select subscription…</option>';
-    
-    // Show selector only if multiple subscriptions are selected
-    if (selectedSubs.length > 1) {
-        selector.style.display = "block";
-        
-        // Populate options with selected subscriptions
-        selectedSubs.forEach(subId => {
-            const sub = subscriptions.find(s => s.id === subId);
-            if (sub) {
-                const option = document.createElement("option");
-                option.value = subId;
-                option.textContent = sub.name;
-                selector.appendChild(option);
-            }
-        });
-        
-        // Set selected value if exists and is still in selection
-        if (selectedSkuSubscription && selectedSubs.includes(selectedSkuSubscription)) {
-            selector.value = selectedSkuSubscription;
-        } else {
-            // Default to first subscription
-            selectedSkuSubscription = selectedSubs[0];
-            selector.value = selectedSkuSubscription;
-        }
-    } else {
-        selector.style.display = "none";
-        // Set to single selected subscription or null
-        selectedSkuSubscription = selectedSubs.length === 1 ? selectedSubs[0] : null;
-    }
-}
-
-function onSkuSubscriptionChange() {
-    const selector = document.getElementById("sku-subscription-select");
-    selectedSkuSubscription = selector.value;
-    // Reset SKU data when subscription changes
-    resetSkuSection();
+function getSubName(id) {
+    const s = subscriptions.find(s => s.id === id);
+    return s ? s.name : id.substring(0, 8) + "\u2026";
 }
 
 // ---------------------------------------------------------------------------
@@ -484,17 +239,14 @@ function onSkuSubscriptionChange() {
 // ---------------------------------------------------------------------------
 async function fetchTenants() {
     const select = document.getElementById("tenant-select");
-    select.innerHTML = '<option value="">Loading tenants…</option>';
+    select.innerHTML = '<option value="">Loading tenants\u2026</option>';
     try {
         const result = await apiFetch("/api/tenants");
         tenants = result.tenants || [];
         const defaultTid = result.defaultTenantId || "";
-
-        // Filter to authenticated tenants for auto-hide logic
         const authTenants = tenants.filter(t => t.authenticated);
         if (authTenants.length <= 1) {
-            // Single reachable tenant – auto-select and hide the selector
-            select.closest(".filter-section").style.display = "none";
+            document.getElementById("tenant-section").classList.add("d-none");
             if (authTenants.length === 1) {
                 select.innerHTML = `<option value="${authTenants[0].id}">${escapeHtml(authTenants[0].name)}</option>`;
                 select.value = authTenants[0].id;
@@ -504,121 +256,87 @@ async function fetchTenants() {
         select.innerHTML = tenants.map(t => {
             const disabled = t.authenticated ? "" : "disabled";
             const label = t.authenticated
-                ? `${escapeHtml(t.name)} (${t.id.slice(0, 8)}…)`
-                : `${escapeHtml(t.name)} — no valid auth`;
+                ? `${escapeHtml(t.name)} (${t.id.slice(0, 8)}\u2026)`
+                : `${escapeHtml(t.name)} \u2014 no valid auth`;
             return `<option value="${t.id}" ${disabled}>${label}</option>`;
         }).join("");
-        // Auto-select the tenant matching the current credential
         if (defaultTid && tenants.some(t => t.id === defaultTid && t.authenticated)) {
             select.value = defaultTid;
         }
-    } catch (err) {
-        // Non-blocking: if tenants fail, just hide the selector
-        select.closest(".filter-section").style.display = "none";
+    } catch {
+        document.getElementById("tenant-section").classList.add("d-none");
     }
 }
 
 async function onTenantChange() {
-    // Reset downstream state
-    selectedSubscriptions.clear();
+    // Reset all downstream state
+    topoSelectedSubs.clear();
     lastMappingData = null;
+    plannerSubscriptionId = null;
+    plannerZoneMappings = null;
+    lastSkuData = null;
+    lastSpotScores = null;
+
     document.getElementById("region-select").value = "";
     document.getElementById("region-search").value = "";
-    document.getElementById("sub-filter").value = "";
+    document.getElementById("topo-sub-filter").value = "";
+    document.getElementById("planner-sub-select").value = "";
+    document.getElementById("planner-sub-search").value = "";
 
-    // Reset topology page
-    document.getElementById("topology-content").style.display = "none";
-    document.getElementById("topology-empty").style.display = "flex";
+    // Reset UI panels
+    showPanel("topo", "empty");
+    showPanel("planner", "empty");
+    hideError("topo-error");
+    hideError("planner-error");
 
-    // Reset planner page
-    document.getElementById("planner-content").style.display = "none";
-    document.getElementById("planner-empty").style.display = "flex";
-    document.getElementById("region-health-summary").innerHTML = "";
-    resetSkuSection();
-
-    hideError();
-    syncUrlParams();
-
-    // Reload regions and subscriptions for the new tenant
     await Promise.all([fetchRegions(), fetchSubscriptions()]);
-    updateLoadButton();
+    updateTopoLoadButton();
+    updatePlannerLoadButton();
 }
 
 // ---------------------------------------------------------------------------
-// Regions  (loaded once at startup, never reloaded)
+// Regions  (single shared combobox)
 // ---------------------------------------------------------------------------
 async function fetchRegions() {
-    const searchInput = document.getElementById("region-search");
-    searchInput.placeholder = "Loading regions…";
-    searchInput.disabled = true;
+    const inp = document.getElementById("region-search");
+    inp.placeholder = "Loading regions\u2026";
+    inp.disabled = true;
 
     try {
         regions = await apiFetch("/api/regions" + tenantQS("?"));
-        searchInput.placeholder = "Type to search regions…";
-        searchInput.disabled = false;
+        inp.placeholder = "Type to search regions\u2026";
+        inp.disabled = false;
         renderRegionDropdown("");
     } catch (err) {
-        showError("Failed to load regions: " + err.message);
-        searchInput.placeholder = "Error loading regions";
+        inp.placeholder = "Error loading regions";
     }
 }
 
-function renderRegionDropdown(filter) {
-    const dropdown = document.getElementById("region-dropdown");
-    const lc = filter.toLowerCase();
-    const matches = lc
-        ? regions.filter(r => r.displayName.toLowerCase().includes(lc) || r.name.toLowerCase().includes(lc))
-        : regions;
-    dropdown.innerHTML = matches.map(r =>
-        `<li data-value="${r.name}">${escapeHtml(r.displayName)} <span class="region-name">(${r.name})</span></li>`
-    ).join("");
-    // Attach click handlers
-    dropdown.querySelectorAll("li").forEach(li => {
-        li.addEventListener("click", () => selectRegion(li.dataset.value));
-    });
-}
-
-function selectRegion(name) {
-    const r = regions.find(r => r.name === name);
-    if (!r) return;
-    document.getElementById("region-select").value = name;
-    document.getElementById("region-search").value = `${r.displayName} (${r.name})`;
-    closeRegionDropdown();
-    onRegionChange();
-}
-
-function openRegionDropdown() {
-    document.getElementById("region-dropdown").classList.add("open");
-}
-function closeRegionDropdown() {
-    document.getElementById("region-dropdown").classList.remove("open");
-}
-
+// ---------------------------------------------------------------------------
+// Shared region combobox
+// ---------------------------------------------------------------------------
 function initRegionCombobox() {
     const searchInput = document.getElementById("region-search");
     const dropdown = document.getElementById("region-dropdown");
 
     searchInput.addEventListener("focus", () => {
-        // If a region was selected, select the text so the user can type over it
         searchInput.select();
         renderRegionDropdown(searchInput.value.includes("(") ? "" : searchInput.value);
-        openRegionDropdown();
+        dropdown.classList.add("show");
     });
     searchInput.addEventListener("input", () => {
-        // Clear the hidden select when user types
         document.getElementById("region-select").value = "";
         renderRegionDropdown(searchInput.value);
-        openRegionDropdown();
+        dropdown.classList.add("show");
         onRegionChange();
     });
-    // Keyboard navigation
     searchInput.addEventListener("keydown", (e) => {
         const items = dropdown.querySelectorAll("li");
         const active = dropdown.querySelector("li.active");
         let idx = [...items].indexOf(active);
         if (e.key === "ArrowDown") {
             e.preventDefault();
-            if (!dropdown.classList.contains("open")) openRegionDropdown();
+            if (!dropdown.classList.contains("show")) dropdown.classList.add("show");
             if (active) active.classList.remove("active");
             idx = (idx + 1) % items.length;
             items[idx]?.classList.add("active");
@@ -631,91 +349,156 @@ function initRegionCombobox() {
             items[idx]?.scrollIntoView({ block: "nearest" });
         } else if (e.key === "Enter") {
             e.preventDefault();
-            if (active) {
-                selectRegion(active.dataset.value);
-            } else if (items.length === 1) {
-                selectRegion(items[0].dataset.value);
-            }
+            if (active) selectRegion(active.dataset.value);
+            else if (items.length === 1) selectRegion(items[0].dataset.value);
         } else if (e.key === "Escape") {
-            closeRegionDropdown();
+            dropdown.classList.remove("show");
             searchInput.blur();
         }
     });
-    // Close dropdown when clicking outside
     document.addEventListener("click", (e) => {
-        if (!e.target.closest("#region-combobox")) {
-            closeRegionDropdown();
-        }
+        if (!e.target.closest("#region-combobox")) dropdown.classList.remove("show");
     });
 }
 
+function renderRegionDropdown(filter) {
+    const dropdown = document.getElementById("region-dropdown");
+    const lc = (filter || "").toLowerCase();
+    const matches = lc
+        ? regions.filter(r => r.displayName.toLowerCase().includes(lc) || r.name.toLowerCase().includes(lc))
+        : regions;
+    dropdown.innerHTML = matches.map(r =>
+        `<li class="dropdown-item" data-value="${r.name}">${escapeHtml(r.displayName)} <span class="region-name">(${r.name})</span></li>`
+    ).join("");
+    dropdown.querySelectorAll("li").forEach(li => {
+        li.addEventListener("click", () => selectRegion(li.dataset.value));
+    });
+}
+
+function selectRegion(name) {
+    const r = regions.find(r => r.name === name);
+    if (!r) return;
+    document.getElementById("region-select").value = name;
+    document.getElementById("region-search").value = `${r.displayName} (${r.name})`;
+    document.getElementById("region-dropdown").classList.remove("show");
+    onRegionChange();
+}
+
 function onRegionChange() {
-    updateLoadButton();
-    syncUrlParams();
-    // Reset SKU data when region changes to avoid confusion
-    resetSkuSection();
-}
-
-function resetSkuSection() {
-    lastSkuData = null;
-    lastSpotScores = null;
-    skuSortColumn = null;
-    skuSortAsc = true;
-    document.getElementById("sku-empty").style.display = "block";
-    document.getElementById("sku-table-container").style.display = "none";
-    document.getElementById("sku-loading").style.display = "none";
-}
-
-function updateLoadButton() {
-    const btn = document.getElementById("load-btn");
-    const region = document.getElementById("region-select").value;
-    btn.disabled = !(selectedSubscriptions.size > 0 && region);
+    // Region is shared – update both tabs
+    updateTopoLoadButton();
+    resetPlannerResults();
+    updatePlannerLoadButton();
 }
 
 // ---------------------------------------------------------------------------
-// Load mappings
+// Panel visibility helper
 // ---------------------------------------------------------------------------
-async function loadMappings() {
-    const region = document.getElementById("region-select").value;
-    if (!region || selectedSubscriptions.size === 0) return;
+function showPanel(prefix, state) {
+    // state: "empty" | "loading" | "results"
+    const ids = [`${prefix}-empty`, `${prefix}-loading`, `${prefix}-results`];
+    ids.forEach(id => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        if (id.endsWith(state)) el.classList.remove("d-none");
+        else el.classList.add("d-none");
+    });
+    // Toggle planner CSV export button visibility
+    const csvBtn = document.getElementById(`${prefix}-csv-btn`);
+    if (csvBtn) csvBtn.classList.toggle("d-none", state !== "results");
+}
 
-    hideError();
-    document.getElementById("topology-empty").style.display = "none";
-    document.getElementById("topology-content").style.display = "none";
-    document.getElementById("topology-loading").style.display = "flex";
-    
-    // Reset SKU section when mappings are reloaded
-    resetSkuSection();
+// =========================================================================
+// TOPOLOGY TAB
+// =========================================================================
 
+// ---------------------------------------------------------------------------
+// Topology subscriptions (multi-select checklist)
+// ---------------------------------------------------------------------------
+async function fetchSubscriptions() {
     try {
-        const subs = [...selectedSubscriptions].join(",");
-        lastMappingData = await apiFetch(`/api/mappings?region=${region}&subscriptions=${subs}${tenantQS()}`);
-
-        document.getElementById("topology-loading").style.display = "none";
-        document.getElementById("topology-content").style.display = "block";
-
-        renderGraph(lastMappingData);
-        renderTable(lastMappingData);
-
-        // If currently on planner, refresh planner content
-        if (currentPage === 'planner') {
-            document.getElementById('planner-empty').style.display = 'none';
-            document.getElementById('planner-content').style.display = '';
-            renderRegionHealthSummary();
-        }
+        subscriptions = await apiFetch("/api/subscriptions" + tenantQS("?"));
+        renderTopoSubList();
+        renderPlannerSubDropdown("");
     } catch (err) {
-        document.getElementById("topology-loading").style.display = "none";
-        document.getElementById("topology-empty").style.display = "flex";
-        showError("Failed to load mappings: " + err.message);
+        showError("topo-error", "Failed to load subscriptions: " + err.message);
     }
 }
 
+function renderTopoSubList(filter) {
+    const container = document.getElementById("topo-sub-list");
+    const list = filter
+        ? subscriptions.filter(s => s.name.toLowerCase().includes(filter.toLowerCase()))
+        : subscriptions;
+
+    if (!list.length && !filter) {
+        container.innerHTML = '<span class="text-body-secondary small">No subscriptions found</span>';
+        return;
+    }
+    container.innerHTML = list.map(s => {
+        const checked = topoSelectedSubs.has(s.id) ? "checked" : "";
+        return `<label title="${escapeHtml(s.name)}">
+            <input type="checkbox" class="form-check-input me-1" value="${s.id}" ${checked}
+                   onchange="topoToggleSub('${s.id}')">
+            ${escapeHtml(s.name)}
+        </label>`;
+    }).join("");
+    updateTopoSubCount();
+}
+
+function topoToggleSub(id) {
+    if (topoSelectedSubs.has(id)) topoSelectedSubs.delete(id);
+    else topoSelectedSubs.add(id);
+    updateTopoSubCount();
+    updateTopoLoadButton();
+}
+
+function topoSelectAllVisible() {
+    document.querySelectorAll("#topo-sub-list input[type=checkbox]").forEach(cb => {
+        cb.checked = true;
+        topoSelectedSubs.add(cb.value);
+    });
+    updateTopoSubCount();
+    updateTopoLoadButton();
+}
+
+function topoDeselectAll() {
+    topoSelectedSubs.clear();
+    document.querySelectorAll("#topo-sub-list input[type=checkbox]").forEach(cb => { cb.checked = false; });
+    updateTopoSubCount();
+    updateTopoLoadButton();
+}
+
+function updateTopoSubCount() {
+    document.getElementById("topo-sub-count").textContent = `${topoSelectedSubs.size} selected`;
+}
+
+function updateTopoLoadButton() {
+    const btn = document.getElementById("topo-load-btn");
+    const region = document.getElementById("region-select").value;
+    btn.disabled = !(topoSelectedSubs.size > 0 && region);
+}
+
 // ---------------------------------------------------------------------------
-// Utility: subscription name lookup
+// Load topology mappings
 // ---------------------------------------------------------------------------
-function getSubName(id) {
-    const s = subscriptions.find(s => s.id === id);
-    return s ? s.name : id.substring(0, 8) + "…";
+async function loadMappings() {
+    const region = document.getElementById("region-select").value;
+    if (!region || topoSelectedSubs.size === 0) return;
+
+    hideError("topo-error");
+    showPanel("topo", "loading");
+
+    try {
+        const subs = [...topoSelectedSubs].join(",");
+        lastMappingData = await apiFetch(`/api/mappings?region=${region}&subscriptions=${subs}${tenantQS()}`);
+        showPanel("topo", "results");
+        renderGraph(lastMappingData);
+        renderTable(lastMappingData);
+    } catch (err) {
+        showPanel("topo", "empty");
+        showError("topo-error", "Failed to load mappings: " + err.message);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -740,21 +523,20 @@ function renderGraph(data) {
     container.innerHTML = "";
     legendContainer.innerHTML = "";
 
-    // Filter out entries with no mappings
     const validData = data.filter(d => d.mappings && d.mappings.length > 0);
     if (!validData.length) {
-        container.innerHTML = '<div class="empty-state"><p>No zone mappings available.</p></div>';
+        container.innerHTML = '<p class="text-body-secondary text-center py-3">No zone mappings available.</p>';
         return;
     }
 
-    // Collect unique zones
     const logicalZones = [...new Set(validData.flatMap(d => d.mappings.map(m => m.logicalZone)))].sort();
     const physicalZones = [...new Set(validData.flatMap(d => d.mappings.map(m => m.physicalZone)))].sort();
 
-    // Measure text widths to size nodes dynamically
+    // Measure text widths
     const measurer = d3.select(container).append("svg").attr("class", "measurer").style("position", "absolute").style("visibility", "hidden");
     const measureText = (txt, fontSize) => {
-        const t = measurer.append("text").attr("font-size", fontSize).attr("font-weight", 500).attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif").text(txt);
+        const t = measurer.append("text").attr("font-size", fontSize).attr("font-weight", 500)
+            .attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif").text(txt);
         const w = t.node().getComputedTextLength();
         t.remove();
         return w;
@@ -767,22 +549,20 @@ function renderGraph(data) {
     const maxSubText = Math.max(100, ...subLabels.map(l => measureText(l, 12)));
     measurer.remove();
 
-    // Layout constants – widths adapt to content
-    const nodePadX = 24;           // horizontal padding inside a node
+    const nodePadX = 24;
     const leftNodeW = Math.ceil(Math.max(maxLZText, maxSubText) + nodePadX);
     const rightNodeW = Math.ceil(maxPZText + nodePadX);
     const nodeH = 36;
-    const nodeGapY = 12;           // vertical gap between zone nodes inside a group
-    const groupGapY = 28;          // vertical gap between subscription groups
-    const groupPadTop = 36;        // space for subscription label inside group box
+    const nodeGapY = 12;
+    const groupGapY = 28;
+    const groupPadTop = 36;
     const groupPadX = 12;
     const groupPadBot = 12;
-    const linkGap = 180;           // horizontal gap for links between left and right columns
+    const linkGap = 180;
     const margin = { top: 20, right: 20, bottom: 20, left: 20 };
 
     const colorScale = d3.scaleOrdinal(d3.schemeTableau10).domain(validData.map(d => d.subscriptionId));
 
-    // Physical-zone palette for right-side nodes
     const pzColors = ["#0078d4", "#107c10", "#d83b01", "#8764b8", "#008272", "#b4009e"];
     function pzColor(pz) {
         const m = pz.match(/(\d+)$/);
@@ -790,146 +570,100 @@ function renderGraph(data) {
         return pzColors[(idx - 1) % pzColors.length];
     }
 
-    // ---- Compute left-side layout: subscription groups ----
-    const groups = [];   // { subIdx, subId, subName, y, h, nodes: [{zone, y}] }
+    // Left-side layout: subscription groups
+    const groups = [];
     let cursorY = 0;
     validData.forEach((sub, subIdx) => {
-        const zones = sub.mappings.map(m => m.logicalZone)
-            .filter((v, i, a) => a.indexOf(v) === i).sort();
+        const zones = sub.mappings.map(m => m.logicalZone).filter((v, i, a) => a.indexOf(v) === i).sort();
         const contentH = zones.length * nodeH + (zones.length - 1) * nodeGapY;
         const boxH = groupPadTop + contentH + groupPadBot;
         const nodes = zones.map((z, zi) => ({
             zone: z,
             y: cursorY + groupPadTop + zi * (nodeH + nodeGapY) + nodeH / 2,
         }));
-        groups.push({
-            subIdx,
-            subId: sub.subscriptionId,
-            subName: getSubName(sub.subscriptionId),
-            y: cursorY,
-            h: boxH,
-            nodes,
-        });
+        groups.push({ subIdx, subId: sub.subscriptionId, subName: getSubName(sub.subscriptionId), y: cursorY, h: boxH, nodes });
         cursorY += boxH + groupGapY;
     });
     const leftTotalH = cursorY - groupGapY;
 
-    // ---- Compute right-side layout: physical zone nodes ----
+    // Right-side layout: physical zone nodes
     const rightContentH = physicalZones.length * nodeH + (physicalZones.length - 1) * nodeGapY;
     const rightBoxPadTop = 36;
     const rightBoxPadBot = 14;
     const rightBoxH = rightBoxPadTop + rightContentH + rightBoxPadBot;
-    // Vertically centre right column relative to left column
     const rightBoxY = Math.max(0, (leftTotalH - rightBoxH) / 2);
     const physicalNodes = physicalZones.map((pz, i) => ({
         zone: pz,
         y: rightBoxY + rightBoxPadTop + i * (nodeH + nodeGapY) + nodeH / 2,
     }));
 
-    // ---- SVG dimensions ----
+    // SVG dimensions
     const groupBoxW = leftNodeW + groupPadX * 2;
     const rightBoxW = rightNodeW + groupPadX * 2;
     const totalW = margin.left + groupBoxW + linkGap + rightBoxW + margin.right;
     const totalH = Math.max(leftTotalH, rightBoxY + rightBoxH) + margin.top + margin.bottom;
-
     const leftX = margin.left;
     const rightX = margin.left + groupBoxW + linkGap;
 
-    const svg = d3.select(container)
-        .append("svg")
+    const svg = d3.select(container).append("svg")
         .attr("viewBox", `0 0 ${totalW} ${totalH}`)
         .attr("preserveAspectRatio", "xMidYMid meet");
+    const g = svg.append("g").attr("transform", `translate(0, ${margin.top})`);
 
-    const g = svg.append("g")
-        .attr("transform", `translate(0, ${margin.top})`);
-
-    // ---- Draw right-side group box (Physical Zones) ----
+    // Right-side group box
     const rightGroup = g.append("g").attr("transform", `translate(${rightX}, ${rightBoxY})`);
-    rightGroup.append("rect")
-        .attr("x", 0).attr("y", 0)
-        .attr("width", rightBoxW).attr("height", rightBoxH)
-        .attr("rx", 10)
-        .attr("class", "group-box-right");
-    rightGroup.append("text")
-        .attr("x", rightBoxW / 2).attr("y", 22)
-        .attr("text-anchor", "middle")
-        .attr("class", "group-label-right")
-        .text("Physical Zones");
+    rightGroup.append("rect").attr("width", rightBoxW).attr("height", rightBoxH)
+        .attr("rx", 10).attr("class", "group-box-right");
+    rightGroup.append("text").attr("x", rightBoxW / 2).attr("y", 22)
+        .attr("text-anchor", "middle").attr("class", "group-label-right").text("Physical Zones");
 
-    // ---- Draw physical zone nodes ----
+    // Physical zone nodes
     physicalNodes.forEach(pn => {
-        const ng = g.append("g")
-            .attr("transform", `translate(${rightX + groupPadX}, ${pn.y})`)
-            .attr("class", "pz-node-group")
-            .attr("data-pz", pn.zone)
-            .style("cursor", "pointer");
-        ng.append("rect")
-            .attr("x", 0).attr("y", -nodeH / 2)
-            .attr("width", rightNodeW).attr("height", nodeH)
-            .attr("rx", 6)
+        const ng = g.append("g").attr("transform", `translate(${rightX + groupPadX}, ${pn.y})`)
+            .attr("class", "pz-node-group").attr("data-pz", pn.zone).style("cursor", "pointer");
+        ng.append("rect").attr("x", 0).attr("y", -nodeH / 2)
+            .attr("width", rightNodeW).attr("height", nodeH).attr("rx", 6)
             .attr("class", "node-rect-right")
             .attr("style", `fill: ${pzColor(pn.zone)}20; stroke: ${pzColor(pn.zone)};`);
-        ng.append("text")
-            .attr("x", rightNodeW / 2).attr("y", 5)
-            .attr("text-anchor", "middle")
-            .attr("class", "node-label")
-            .text(pn.zone);
+        ng.append("text").attr("x", rightNodeW / 2).attr("y", 5)
+            .attr("text-anchor", "middle").attr("class", "node-label").text(pn.zone);
         ng.on("mouseenter", () => highlightByPZ(pn.zone));
         ng.on("mouseleave", clearHighlight);
     });
 
-    // ---- Draw left-side subscription groups ----
+    // Left-side subscription groups
     groups.forEach(grp => {
-        const gg = g.append("g")
-            .attr("transform", `translate(${leftX}, ${grp.y})`)
-            .attr("class", "sub-group")
-            .attr("data-sub", grp.subIdx)
-            .style("cursor", "pointer");
-        // Group box
-        gg.append("rect")
-            .attr("x", 0).attr("y", 0)
-            .attr("width", groupBoxW).attr("height", grp.h)
-            .attr("rx", 10)
-            .attr("class", "group-box-left")
+        const gg = g.append("g").attr("transform", `translate(${leftX}, ${grp.y})`)
+            .attr("class", "sub-group").attr("data-sub", grp.subIdx).style("cursor", "pointer");
+        gg.append("rect").attr("width", groupBoxW).attr("height", grp.h)
+            .attr("rx", 10).attr("class", "group-box-left")
             .attr("style", `stroke: ${colorScale(grp.subId)};`);
-        // Subscription label
-        gg.append("text")
-            .attr("x", groupBoxW / 2).attr("y", 22)
-            .attr("text-anchor", "middle")
-            .attr("class", "group-label-left")
-            .attr("fill", colorScale(grp.subId))
-            .text(truncate(grp.subName, 22));
+        gg.append("text").attr("x", groupBoxW / 2).attr("y", 22)
+            .attr("text-anchor", "middle").attr("class", "group-label-left")
+            .attr("fill", colorScale(grp.subId)).text(truncate(grp.subName, 22));
         gg.append("title").text(grp.subName);
-        gg.on("mouseenter", () => highlightSub(grp.subIdx, validData.length, validData));
+        gg.on("mouseenter", () => highlightSub(grp.subIdx, validData));
         gg.on("mouseleave", clearHighlight);
     });
 
-    // ---- Draw logical zone nodes inside each group ----
+    // Logical zone nodes
     groups.forEach(grp => {
         grp.nodes.forEach(ln => {
-            const ng = g.append("g")
-                .attr("transform", `translate(${leftX + groupPadX}, ${ln.y})`)
-                .attr("class", "lz-node-group")
-                .attr("data-sub", grp.subIdx)
-                .attr("data-lz", ln.zone)
+            const ng = g.append("g").attr("transform", `translate(${leftX + groupPadX}, ${ln.y})`)
+                .attr("class", "lz-node-group").attr("data-sub", grp.subIdx).attr("data-lz", ln.zone)
                 .style("cursor", "pointer");
-            ng.append("rect")
-                .attr("x", 0).attr("y", -nodeH / 2)
-                .attr("width", leftNodeW).attr("height", nodeH)
-                .attr("rx", 6)
+            ng.append("rect").attr("x", 0).attr("y", -nodeH / 2)
+                .attr("width", leftNodeW).attr("height", nodeH).attr("rx", 6)
                 .attr("class", "node-rect-left")
                 .attr("style", `stroke: ${colorScale(grp.subId)};`);
-            ng.append("text")
-                .attr("x", leftNodeW / 2).attr("y", 5)
-                .attr("text-anchor", "middle")
-                .attr("class", "node-label")
-                .text(`Zone ${ln.zone}`);
+            ng.append("text").attr("x", leftNodeW / 2).attr("y", 5)
+                .attr("text-anchor", "middle").attr("class", "node-label").text(`Zone ${ln.zone}`);
             ng.on("mouseenter", () => highlightByLZ(grp.subIdx, ln.zone, validData));
             ng.on("mouseleave", clearHighlight);
         });
     });
 
-    // ---- Draw links ----
+    // Links
     const linksGroup = g.append("g").attr("class", "links-group");
     groups.forEach(grp => {
         const sub = validData[grp.subIdx];
@@ -937,122 +671,65 @@ function renderGraph(data) {
             const srcNode = grp.nodes.find(n => n.zone === m.logicalZone);
             const tgtNode = physicalNodes.find(n => n.zone === m.physicalZone);
             if (!srcNode || !tgtNode) return;
-
-            const sourceX = leftX + groupPadX + leftNodeW;
-            const sourceY = srcNode.y;
-            const targetX = rightX + groupPadX;
-            const targetY = tgtNode.y;
-
             linksGroup.append("path")
-                .attr("d", d3.linkHorizontal()({ source: [sourceX, sourceY], target: [targetX, targetY] }))
+                .attr("d", d3.linkHorizontal()({ source: [leftX + groupPadX + leftNodeW, srcNode.y], target: [rightX + groupPadX, tgtNode.y] }))
                 .attr("stroke", colorScale(sub.subscriptionId))
-                .attr("stroke-width", 2.5)
-                .attr("fill", "none")
-                .attr("opacity", 0.55)
+                .attr("stroke-width", 2.5).attr("fill", "none").attr("opacity", 0.55)
                 .attr("class", `link link-sub-${grp.subIdx}`)
-                .attr("data-sub", grp.subIdx)
-                .attr("data-lz", m.logicalZone)
-                .attr("data-pz", m.physicalZone)
-                .append("title")
-                .text(`${grp.subName}: Zone ${m.logicalZone} → ${m.physicalZone}`);
+                .attr("data-sub", grp.subIdx).attr("data-lz", m.logicalZone).attr("data-pz", m.physicalZone)
+                .append("title").text(`${grp.subName}: Zone ${m.logicalZone} \u2192 ${m.physicalZone}`);
         });
     });
 
-    // ---- Legend (HTML) ----
+    // Legend
     validData.forEach((sub, i) => {
         const item = document.createElement("div");
         item.className = "legend-item";
-        item.dataset.subIdx = i;
         item.innerHTML = `<span class="legend-swatch" style="background:${colorScale(sub.subscriptionId)}"></span>
             <span>${escapeHtml(getSubName(sub.subscriptionId))}</span>`;
-        item.addEventListener("mouseenter", () => highlightSub(i, validData.length, validData));
-        item.addEventListener("mouseleave", () => clearHighlight());
+        item.addEventListener("mouseenter", () => highlightSub(i, validData));
+        item.addEventListener("mouseleave", clearHighlight);
         legendContainer.appendChild(item);
     });
-}
-
-function truncate(str, max) {
-    return str.length > max ? str.substring(0, max - 1) + "…" : str;
 }
 
 // ---------------------------------------------------------------------------
 // Highlight helpers
 // ---------------------------------------------------------------------------
-
-/** Highlight all links for a given subscription index. */
-function highlightSub(subIdx, total, validData) {
-    // Dim all links, highlight only this sub's links
+function highlightSub(subIdx, validData) {
     d3.selectAll(".link").classed("dimmed", true).classed("highlighted", false);
     d3.selectAll(`.link-sub-${subIdx}`).classed("dimmed", false).classed("highlighted", true);
-
-    // Dim other subscription groups
-    d3.selectAll(".sub-group").style("opacity", function() {
-        return +d3.select(this).attr("data-sub") === subIdx ? 1 : 0.25;
-    });
-    d3.selectAll(".lz-node-group").style("opacity", function() {
-        return +d3.select(this).attr("data-sub") === subIdx ? 1 : 0.25;
-    });
-
-    // Highlight the PZ nodes that this sub connects to
+    d3.selectAll(".sub-group").style("opacity", function () { return +d3.select(this).attr("data-sub") === subIdx ? 1 : 0.25; });
+    d3.selectAll(".lz-node-group").style("opacity", function () { return +d3.select(this).attr("data-sub") === subIdx ? 1 : 0.25; });
     const targetPZs = new Set();
-    if (validData && validData[subIdx]) {
-        validData[subIdx].mappings.forEach(m => targetPZs.add(m.physicalZone));
-    }
-    d3.selectAll(".pz-node-group").style("opacity", function() {
-        return targetPZs.has(d3.select(this).attr("data-pz")) ? 1 : 0.25;
-    });
+    if (validData?.[subIdx]) validData[subIdx].mappings.forEach(m => targetPZs.add(m.physicalZone));
+    d3.selectAll(".pz-node-group").style("opacity", function () { return targetPZs.has(d3.select(this).attr("data-pz")) ? 1 : 0.25; });
 }
 
-/** Highlight the link from a specific LZ in a specific sub, and the target PZ. */
 function highlightByLZ(subIdx, lz, validData) {
-    // Dim everything first
     d3.selectAll(".link").classed("dimmed", true).classed("highlighted", false);
     d3.selectAll(".sub-group").style("opacity", 0.25);
     d3.selectAll(".lz-node-group").style("opacity", 0.25);
     d3.selectAll(".pz-node-group").style("opacity", 0.25);
-
-    // Find the matching link(s) and highlight
-    d3.selectAll(".link").each(function() {
+    d3.selectAll(".link").each(function () {
         const el = d3.select(this);
-        if (+el.attr("data-sub") === subIdx && el.attr("data-lz") === lz) {
-            el.classed("dimmed", false).classed("highlighted", true);
-        }
+        if (+el.attr("data-sub") === subIdx && el.attr("data-lz") === lz) el.classed("dimmed", false).classed("highlighted", true);
     });
-
-    // Highlight the source subscription group and LZ node
-    d3.selectAll(".sub-group").filter(function() {
-        return +d3.select(this).attr("data-sub") === subIdx;
-    }).style("opacity", 1);
-    d3.selectAll(".lz-node-group").filter(function() {
-        return +d3.select(this).attr("data-sub") === subIdx && d3.select(this).attr("data-lz") === lz;
-    }).style("opacity", 1);
-
-    // Highlight the target PZ node
+    d3.selectAll(".sub-group").filter(function () { return +d3.select(this).attr("data-sub") === subIdx; }).style("opacity", 1);
+    d3.selectAll(".lz-node-group").filter(function () { return +d3.select(this).attr("data-sub") === subIdx && d3.select(this).attr("data-lz") === lz; }).style("opacity", 1);
     const targetPZ = validData[subIdx]?.mappings.find(m => m.logicalZone === lz)?.physicalZone;
-    if (targetPZ) {
-        d3.selectAll(".pz-node-group").filter(function() {
-            return d3.select(this).attr("data-pz") === targetPZ;
-        }).style("opacity", 1);
-    }
+    if (targetPZ) d3.selectAll(".pz-node-group").filter(function () { return d3.select(this).attr("data-pz") === targetPZ; }).style("opacity", 1);
 }
 
-/** Highlight all links pointing to a given physical zone, and their source LZ nodes. */
 function highlightByPZ(pz) {
-    // Dim everything first
     d3.selectAll(".link").classed("dimmed", true).classed("highlighted", false);
     d3.selectAll(".sub-group").style("opacity", 0.25);
     d3.selectAll(".lz-node-group").style("opacity", 0.25);
     d3.selectAll(".pz-node-group").style("opacity", 0.25);
-
-    // Highlight the hovered PZ node
-    d3.selectAll(".pz-node-group").filter(function() {
-        return d3.select(this).attr("data-pz") === pz;
-    }).style("opacity", 1);
-
-    // Find matching links and collect source sub+lz pairs
+    d3.selectAll(".pz-node-group").filter(function () { return d3.select(this).attr("data-pz") === pz; }).style("opacity", 1);
     const matchedSubs = new Set();
     const matchedLZKeys = new Set();
-    d3.selectAll(".link").each(function() {
+    d3.selectAll(".link").each(function () {
         const el = d3.select(this);
         if (el.attr("data-pz") === pz) {
             el.classed("dimmed", false).classed("highlighted", true);
@@ -1060,20 +737,10 @@ function highlightByPZ(pz) {
             matchedLZKeys.add(el.attr("data-sub") + "::" + el.attr("data-lz"));
         }
     });
-
-    // Highlight matching sub groups
-    d3.selectAll(".sub-group").filter(function() {
-        return matchedSubs.has(+d3.select(this).attr("data-sub"));
-    }).style("opacity", 1);
-
-    // Highlight matching LZ nodes
-    d3.selectAll(".lz-node-group").filter(function() {
-        const key = d3.select(this).attr("data-sub") + "::" + d3.select(this).attr("data-lz");
-        return matchedLZKeys.has(key);
-    }).style("opacity", 1);
+    d3.selectAll(".sub-group").filter(function () { return matchedSubs.has(+d3.select(this).attr("data-sub")); }).style("opacity", 1);
+    d3.selectAll(".lz-node-group").filter(function () { return matchedLZKeys.has(d3.select(this).attr("data-sub") + "::" + d3.select(this).attr("data-lz")); }).style("opacity", 1);
 }
 
-/** Reset all highlight states. */
 function clearHighlight() {
     d3.selectAll(".link").classed("dimmed", false).classed("highlighted", false);
     d3.selectAll(".sub-group").style("opacity", 1);
@@ -1087,37 +754,24 @@ function clearHighlight() {
 function renderTable(data) {
     const container = document.getElementById("table-container");
     container.innerHTML = "";
-
     const validData = data.filter(d => d.mappings && d.mappings.length > 0);
     if (!validData.length) {
-        container.innerHTML = '<p class="empty-state">No zone mappings available.</p>';
+        container.innerHTML = '<p class="text-body-secondary">No zone mappings available.</p>';
         return;
     }
-
     const logicalZones = [...new Set(validData.flatMap(d => d.mappings.map(m => m.logicalZone)))].sort();
 
-    // Build table
     const table = document.createElement("table");
-    table.className = "mapping-table";
+    table.className = "table table-sm table-hover mapping-table";
 
-    // Header
     const thead = table.createTHead();
     const headerRow = thead.insertRow();
-    headerRow.insertCell().textContent = "Subscription";
-    headerRow.insertCell().textContent = "Subscription ID";
-    logicalZones.forEach(z => {
+    ["Subscription", "Subscription ID", ...logicalZones.map(z => `Logical Zone ${z}`)].forEach(txt => {
         const th = document.createElement("th");
-        th.textContent = `Logical Zone ${z}`;
+        th.textContent = txt;
         headerRow.appendChild(th);
     });
-    // Replace td with th in header
-    headerRow.querySelectorAll("td").forEach(td => {
-        const th = document.createElement("th");
-        th.textContent = td.textContent;
-        td.replaceWith(th);
-    });
 
-    // Body
     const tbody = table.createTBody();
     validData.forEach(sub => {
         const row = tbody.insertRow();
@@ -1125,13 +779,9 @@ function renderTable(data) {
         nameCell.textContent = getSubName(sub.subscriptionId);
         nameCell.className = "sub-name-cell";
         nameCell.title = getSubName(sub.subscriptionId);
-
         const idCell = row.insertCell();
         idCell.textContent = sub.subscriptionId;
-        idCell.style.fontSize = "0.78rem";
-        idCell.style.color = "var(--text-muted)";
-        idCell.style.fontFamily = "monospace";
-
+        idCell.style.cssText = "font-size:0.78rem;opacity:0.6;font-family:monospace;";
         logicalZones.forEach(z => {
             const cell = row.insertCell();
             const mapping = sub.mappings.find(m => m.logicalZone === z);
@@ -1141,13 +791,13 @@ function renderTable(data) {
                 badge.textContent = mapping.physicalZone;
                 cell.appendChild(badge);
             } else {
-                cell.textContent = "—";
-                cell.style.color = "var(--text-muted)";
+                cell.textContent = "\u2014";
+                cell.style.opacity = "0.5";
             }
         });
     });
 
-    // Consistency footer row (only if >1 subscription)
+    // Consistency footer
     if (validData.length > 1) {
         const tfoot = table.createTFoot();
         const footRow = tfoot.insertRow();
@@ -1155,24 +805,19 @@ function renderTable(data) {
         const label = footRow.insertCell();
         label.colSpan = 2;
         label.textContent = "Consistency";
-
         logicalZones.forEach(z => {
             const cell = footRow.insertCell();
-            const physicals = validData
-                .map(sub => sub.mappings.find(m => m.logicalZone === z))
-                .filter(Boolean)
-                .map(m => m.physicalZone);
+            const physicals = validData.map(sub => sub.mappings.find(m => m.logicalZone === z)).filter(Boolean).map(m => m.physicalZone);
             const unique = [...new Set(physicals)];
             if (unique.length <= 1) {
-                cell.textContent = "✓ Same";
+                cell.textContent = "\u2713 Same";
                 cell.className = "same";
             } else {
-                cell.textContent = `⚠ ${unique.length} different`;
+                cell.textContent = `\u26A0 ${unique.length} different`;
                 cell.className = "different";
             }
         });
     }
-
     container.appendChild(table);
 }
 
@@ -1182,27 +827,18 @@ function renderTable(data) {
 function exportGraphPNG() {
     const svgEl = document.querySelector("#graph-container svg");
     if (!svgEl) return;
-
-    // Serialize SVG with inline styles
     const clone = svgEl.cloneNode(true);
-
-    // Collect all computed styles from the original and inline them on the clone
     inlineStyles(svgEl, clone);
-
-    // Set explicit dimensions for the canvas
     const box = svgEl.viewBox.baseVal;
-    const scale = 2; // retina-quality
+    const scale = 2;
     const w = box.width * scale;
     const h = box.height * scale;
-
     clone.setAttribute("width", w);
     clone.setAttribute("height", h);
     clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-
     const svgData = new XMLSerializer().serializeToString(clone);
     const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
     const url = URL.createObjectURL(blob);
-
     const img = new Image();
     img.onload = () => {
         const canvas = document.createElement("canvas");
@@ -1213,7 +849,6 @@ function exportGraphPNG() {
         ctx.fillRect(0, 0, w, h);
         ctx.drawImage(img, 0, 0, w, h);
         URL.revokeObjectURL(url);
-
         const region = document.getElementById("region-select").value || "az-mapping";
         const a = document.createElement("a");
         a.download = `az-mapping-${region}.png`;
@@ -1223,16 +858,10 @@ function exportGraphPNG() {
     img.src = url;
 }
 
-/** Recursively copy computed styles from src elements onto dst (clone) elements. */
 function inlineStyles(src, dst) {
     const computed = window.getComputedStyle(src);
-    const dominated = ["fill", "stroke", "stroke-width", "stroke-dasharray",
-        "opacity", "font-size", "font-weight", "font-family", "text-anchor",
-        "dominant-baseline", "letter-spacing"];
-    dominated.forEach(prop => {
-        const val = computed.getPropertyValue(prop);
-        if (val) dst.style.setProperty(prop, val);
-    });
+    ["fill", "stroke", "stroke-width", "stroke-dasharray", "opacity", "font-size", "font-weight", "font-family", "text-anchor", "dominant-baseline", "letter-spacing"]
+        .forEach(prop => { const v = computed.getPropertyValue(prop); if (v) dst.style.setProperty(prop, v); });
     for (let i = 0; i < src.children.length; i++) {
         if (dst.children[i]) inlineStyles(src.children[i], dst.children[i]);
     }
@@ -1243,156 +872,210 @@ function inlineStyles(src, dst) {
 // ---------------------------------------------------------------------------
 function exportTableCSV() {
     if (!lastMappingData) return;
-
     const validData = lastMappingData.filter(d => d.mappings && d.mappings.length > 0);
     if (!validData.length) return;
-
     const logicalZones = [...new Set(validData.flatMap(d => d.mappings.map(m => m.logicalZone)))].sort();
-
-    // Header row
-    const headers = ["Subscription", "Subscription ID",
-        ...logicalZones.map(z => `Logical Zone ${z}`)];
-
-    // Data rows
+    const headers = ["Subscription", "Subscription ID", ...logicalZones.map(z => `Logical Zone ${z}`)];
     const rows = validData.map(sub => {
-        const name = getSubName(sub.subscriptionId);
-        const cols = logicalZones.map(z => {
-            const m = sub.mappings.find(m => m.logicalZone === z);
-            return m ? m.physicalZone : "";
-        });
-        return [name, sub.subscriptionId, ...cols];
+        const cols = logicalZones.map(z => { const m = sub.mappings.find(m => m.logicalZone === z); return m ? m.physicalZone : ""; });
+        return [getSubName(sub.subscriptionId), sub.subscriptionId, ...cols];
     });
+    downloadCSV([headers, ...rows], `az-mapping-${document.getElementById("region-select").value || "export"}.csv`);
+}
 
-    // Build CSV string
-    const csvContent = [headers, ...rows]
-        .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(","))
-        .join("\n");
-
-    const region = document.getElementById("region-select").value || "az-mapping";
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+function downloadCSV(data, filename) {
+    const csv = data.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const a = document.createElement("a");
-    a.download = `az-mapping-${region}.csv`;
+    a.download = filename;
     a.href = URL.createObjectURL(blob);
     a.click();
     URL.revokeObjectURL(a.href);
 }
 
-// ---------------------------------------------------------------------------
-// SKU Section
-// ---------------------------------------------------------------------------
+// =========================================================================
+// PLANNER TAB
+// =========================================================================
 
-function toggleSkuSection() {
-    const section = document.querySelector(".sku-section");
-    section.classList.toggle("collapsed");
+// ---------------------------------------------------------------------------
+// Planner subscription combobox (single-select)
+// ---------------------------------------------------------------------------
+function initPlannerSubCombobox() {
+    const searchInput = document.getElementById("planner-sub-search");
+    const dropdown = document.getElementById("planner-sub-dropdown");
+
+    searchInput.addEventListener("focus", () => {
+        searchInput.select();
+        renderPlannerSubDropdown(searchInput.value.includes("(") ? "" : searchInput.value);
+        dropdown.classList.add("show");
+    });
+    searchInput.addEventListener("input", () => {
+        document.getElementById("planner-sub-select").value = "";
+        plannerSubscriptionId = null;
+        renderPlannerSubDropdown(searchInput.value);
+        dropdown.classList.add("show");
+        updatePlannerLoadButton();
+    });
+    searchInput.addEventListener("keydown", (e) => {
+        const items = dropdown.querySelectorAll("li");
+        const active = dropdown.querySelector("li.active");
+        let idx = [...items].indexOf(active);
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            if (!dropdown.classList.contains("show")) dropdown.classList.add("show");
+            if (active) active.classList.remove("active");
+            idx = (idx + 1) % items.length;
+            items[idx]?.classList.add("active");
+            items[idx]?.scrollIntoView({ block: "nearest" });
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            if (active) active.classList.remove("active");
+            idx = idx <= 0 ? items.length - 1 : idx - 1;
+            items[idx]?.classList.add("active");
+            items[idx]?.scrollIntoView({ block: "nearest" });
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (active) selectPlannerSub(active.dataset.value);
+            else if (items.length === 1) selectPlannerSub(items[0].dataset.value);
+        } else if (e.key === "Escape") {
+            dropdown.classList.remove("show");
+            searchInput.blur();
+        }
+    });
+    document.addEventListener("click", (e) => {
+        if (!e.target.closest("#planner-sub-combobox")) dropdown.classList.remove("show");
+    });
 }
 
-function getPhysicalZoneMap(subscriptionId) {
+function renderPlannerSubDropdown(filter) {
+    const dropdown = document.getElementById("planner-sub-dropdown");
+    const lc = (filter || "").toLowerCase();
+    const matches = lc
+        ? subscriptions.filter(s => s.name.toLowerCase().includes(lc) || s.id.toLowerCase().includes(lc))
+        : subscriptions;
+    dropdown.innerHTML = matches.map(s =>
+        `<li class="dropdown-item" data-value="${s.id}">${escapeHtml(s.name)} <span class="region-name">(${s.id.slice(0, 8)}\u2026)</span></li>`
+    ).join("");
+    dropdown.querySelectorAll("li").forEach(li => {
+        li.addEventListener("click", () => selectPlannerSub(li.dataset.value));
+    });
+    // Enable search input once subscriptions are loaded
+    const searchInput = document.getElementById("planner-sub-search");
+    if (subscriptions.length > 0) {
+        searchInput.placeholder = "Type to search subscriptions\u2026";
+        searchInput.disabled = false;
+    }
+}
+
+function selectPlannerSub(id) {
+    const s = subscriptions.find(s => s.id === id);
+    if (!s) return;
+    plannerSubscriptionId = id;
+    document.getElementById("planner-sub-select").value = id;
+    document.getElementById("planner-sub-search").value = s.name;
+    document.getElementById("planner-sub-dropdown").classList.remove("show");
+    resetPlannerResults();
+    updatePlannerLoadButton();
+}
+
+function updatePlannerLoadButton() {
+    const btn = document.getElementById("planner-load-btn");
+    const region = document.getElementById("region-select").value;
+    btn.disabled = !(plannerSubscriptionId && region);
+}
+
+function resetPlannerResults() {
+    lastSkuData = null;
+    lastSpotScores = null;
+    plannerZoneMappings = null;
+    if (_skuDataTable) {
+        try { _skuDataTable.destroy(); } catch {}
+        _skuDataTable = null;
+    }
+    showPanel("planner", "empty");
+}
+
+// ---------------------------------------------------------------------------
+// Load SKUs  (independently fetches zone mappings for headers)
+// ---------------------------------------------------------------------------
+async function loadSkus() {
+    const region = document.getElementById("region-select").value;
+    const tenant = document.getElementById("tenant-select").value;
+    const subscriptionId = plannerSubscriptionId;
+
+    if (!region || !subscriptionId) return;
+
+    hideError("planner-error");
+    showPanel("planner", "loading");
+
+    try {
+        // Fetch zone mappings for this sub to get physical zone headers
+        const mappingsPromise = apiFetch(`/api/mappings?region=${region}&subscriptions=${subscriptionId}${tenantQS()}`);
+
+        // Fetch SKUs
+        const params = new URLSearchParams({ region, subscriptionId });
+        if (tenant) params.append("tenantId", tenant);
+        const includePrices = document.getElementById("planner-include-prices")?.checked;
+        if (includePrices) {
+            params.append("includePrices", "true");
+            const currency = document.getElementById("planner-currency")?.value || "USD";
+            params.append("currencyCode", currency);
+        }
+        const skuPromise = apiFetch(`/api/skus?${params}`);
+
+        // Run in parallel
+        const [mappingsResult, skuResult] = await Promise.all([mappingsPromise, skuPromise]);
+
+        // Store zone mappings for this planner session
+        plannerZoneMappings = mappingsResult;
+
+        if (skuResult.error) throw new Error(skuResult.error);
+
+        lastSkuData = skuResult;
+        // Compute confidence scores
+        for (const sku of lastSkuData) recomputeConfidence(sku);
+
+        showPanel("planner", "results");
+        renderSkuTable(lastSkuData);
+    } catch (err) {
+        showPanel("planner", "empty");
+        showError("planner-error", `Failed to fetch SKUs: ${err.message}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Physical zone map for planner (uses plannerZoneMappings)
+// ---------------------------------------------------------------------------
+function getPlannerPhysicalZoneMap() {
     const map = {};
-    if (!lastMappingData) return map;
-    const subMapping = lastMappingData.find(d => d.subscriptionId === subscriptionId);
-    if (subMapping && subMapping.mappings) {
+    if (!plannerZoneMappings || !plannerZoneMappings.length) return map;
+    const subMapping = plannerZoneMappings.find(d => d.subscriptionId === plannerSubscriptionId);
+    if (subMapping?.mappings) {
         subMapping.mappings.forEach(m => { map[m.logicalZone] = m.physicalZone; });
     }
     return map;
 }
 
-async function loadSkus() {
-    const region = document.getElementById("region-select").value;
-    const tenant = document.getElementById("tenant-select").value;
-    const loadBtn = document.querySelector('.sku-controls .secondary-btn');
-    
-    if (!region) {
-        showError("Please select a region first.");
-        return;
-    }
-    
-    // Check if subscriptions are selected
-    if (selectedSubscriptions.size === 0) {
-        showError("Please select at least one subscription.");
-        return;
-    }
-    
-    // Ensure zone mappings are loaded first to get physical zone names
-    if (!lastMappingData) {
-        showError("Please load zone mappings first by clicking 'Load Mappings' button.");
-        return;
-    }
-    
-    // Use selected SKU subscription (or first if only one selected)
-    const subscriptionId = selectedSkuSubscription || [...selectedSubscriptions][0];
-    if (!subscriptionId) {
-        showError("Please select a subscription for SKU loading.");
-        return;
-    }
-    
-    const subscriptionName = getSubName(subscriptionId);
-    
-    // Disable button while loading
-    if (loadBtn) loadBtn.disabled = true;
-    
-    document.getElementById("sku-loading").style.display = "flex";
-    document.getElementById("sku-empty").style.display = "none";
-    document.getElementById("sku-table-container").style.display = "none";
-    
-    try {
-        const params = new URLSearchParams({ region, subscriptionId });
-        if (tenant) params.append("tenantId", tenant);
-        const includePrices = document.getElementById("sku-include-prices")?.checked;
-        if (includePrices) {
-            params.append("includePrices", "true");
-            const currency = document.getElementById("sku-currency")?.value || "USD";
-            params.append("currencyCode", currency);
-        }
-        
-        const data = await apiFetch(`/api/skus?${params}`);
-        
-        if (data.error) {
-            throw new Error(data.error);
-        }
-        
-        lastSkuData = data;
-        renderSkuTable(data, subscriptionName);
-        
-    } catch (err) {
-        showError(`Failed to fetch SKUs: ${err.message}`);
-        document.getElementById("sku-empty").style.display = "block";
-    } finally {
-        document.getElementById("sku-loading").style.display = "none";
-        if (loadBtn) loadBtn.disabled = false;
-    }
-}
-
 // ---------------------------------------------------------------------------
-// Spot Score Modal – per-SKU on-demand lookup with caching
+// Spot Score Modal
 // ---------------------------------------------------------------------------
 let _spotModalSku = null;
+let _spotModal = null;
 
 function openSpotModal(skuName) {
     _spotModalSku = skuName;
     document.getElementById("spot-modal-sku").textContent = skuName;
     document.getElementById("spot-modal-instances").value = "1";
-    document.getElementById("spot-modal-loading").style.display = "none";
-    document.getElementById("spot-modal-result").style.display = "none";
-    document.getElementById("spot-modal").style.display = "flex";
-    const input = document.getElementById("spot-modal-instances");
-    input.focus();
-    input.select();
+    document.getElementById("spot-modal-loading").classList.add("d-none");
+    document.getElementById("spot-modal-result").classList.add("d-none");
+    if (!_spotModal) _spotModal = new bootstrap.Modal(document.getElementById("spotModal"));
+    _spotModal.show();
+    setTimeout(() => {
+        const input = document.getElementById("spot-modal-instances");
+        input.focus();
+        input.select();
+    }, 300);
 }
-
-function closeSpotModal(event) {
-    // If called from overlay click, only close if clicking the overlay itself
-    if (event && event.target !== document.getElementById("spot-modal")) return;
-    document.getElementById("spot-modal").style.display = "none";
-    _spotModalSku = null;
-}
-
-function _onSpotModalKeydown(e) {
-    const modal = document.getElementById("spot-modal");
-    if (modal.style.display === "none") return;
-    if (e.key === "Escape") { closeSpotModal(); }
-    else if (e.key === "Enter") { e.preventDefault(); confirmSpotScore(); }
-}
-document.addEventListener("keydown", _onSpotModalKeydown);
 
 async function confirmSpotScore() {
     const skuName = _spotModalSku;
@@ -1400,350 +1083,69 @@ async function confirmSpotScore() {
 
     const region = document.getElementById("region-select").value;
     const tenant = document.getElementById("tenant-select").value;
-    const subscriptionId = selectedSkuSubscription || [...selectedSubscriptions][0];
+    const subscriptionId = plannerSubscriptionId;
     if (!subscriptionId || !region) return;
 
     const instanceCount = parseInt(document.getElementById("spot-modal-instances").value, 10) || 1;
-
-    document.getElementById("spot-modal-loading").style.display = "flex";
-    document.getElementById("spot-modal-result").style.display = "none";
+    document.getElementById("spot-modal-loading").classList.remove("d-none");
+    document.getElementById("spot-modal-result").classList.add("d-none");
 
     try {
         const payload = { region, subscriptionId, skus: [skuName], instanceCount };
         if (tenant) payload.tenantId = tenant;
-
         const result = await apiPost("/api/spot-scores", payload);
 
         // Accumulate into cache
-        if (!lastSpotScores) {
-            lastSpotScores = { scores: {}, errors: [] };
-        }
+        if (!lastSpotScores) lastSpotScores = { scores: {}, errors: [] };
         if (result.scores) {
             for (const [sku, zoneScores] of Object.entries(result.scores)) {
                 lastSpotScores.scores[sku] = { ...(lastSpotScores.scores[sku] || {}), ...zoneScores };
             }
         }
-        if (result.errors && result.errors.length > 0) {
-            lastSpotScores.errors.push(...result.errors);
-        }
+        if (result.errors?.length) lastSpotScores.errors.push(...result.errors);
 
-        // Show result in modal – per-zone scores
+        // Show result in modal
         const zoneScores = result.scores?.[skuName] || {};
         const resultEl = document.getElementById("spot-modal-result");
         const zones = Object.keys(zoneScores).sort();
         if (zones.length > 0) {
             resultEl.innerHTML = '<div class="spot-modal-grid">' + zones.map(z => {
                 const s = zoneScores[z] || "Unknown";
-                const cls = "spot-badge spot-" + s.toLowerCase();
-                return `<span class="spot-modal-zone">Z${escapeHtml(z)}</span><span class="${cls}">${escapeHtml(s)}</span>`;
+                return `<span class="spot-zone-label">Z${escapeHtml(z)}</span><span class="spot-badge spot-${s.toLowerCase()}">${escapeHtml(s)}</span>`;
             }).join("") + '</div>';
         } else {
-            resultEl.innerHTML = `<span class="spot-badge spot-unknown">Unknown</span>`;
+            resultEl.innerHTML = '<span class="spot-badge spot-unknown">Unknown</span>';
         }
-        resultEl.style.display = "block";
+        resultEl.classList.remove("d-none");
 
-        // Recompute confidence scores with spot data
+        // Recompute confidence and re-render
         if (lastSkuData) {
             for (const sku of lastSkuData) recomputeConfidence(sku);
+            renderSkuTable(lastSkuData);
         }
 
-        // Re-render table to update the cell
-        const subscriptionName = getSubName(subscriptionId);
-        renderSkuTable(lastSkuData, subscriptionName);
-
-        if (result.errors && result.errors.length > 0) {
-            showError("Spot score error: " + result.errors.join("; "));
-        }
+        if (result.errors?.length) showError("planner-error", "Spot score error: " + result.errors.join("; "));
     } catch (err) {
-        showError("Failed to fetch Spot Score: " + err.message);
+        showError("planner-error", "Failed to fetch Spot Score: " + err.message);
     } finally {
-        document.getElementById("spot-modal-loading").style.display = "none";
+        document.getElementById("spot-modal-loading").classList.add("d-none");
     }
-}
-
-function skuSortIndicator(col) {
-    if (skuSortColumn !== col) return "";
-    return skuSortAsc ? " ▲" : " ▼";
-}
-
-function onSkuSort(col, subscriptionName) {
-    if (skuSortColumn === col) {
-        skuSortAsc = !skuSortAsc;
-    } else {
-        skuSortColumn = col;
-        skuSortAsc = true;
-    }
-    renderSkuTable(lastSkuData, subscriptionName);
-}
-
-function skuSortValue(sku, col) {
-    switch (col) {
-        case "name":     return (sku.name || "").toLowerCase();
-        case "family":   return (sku.family || "").toLowerCase();
-        case "vCPUs":    return parseFloat(sku.capabilities.vCPUs || "0") || 0;
-        case "memory":   return parseFloat(sku.capabilities.MemoryGB || "0") || 0;
-        case "qLimit":   { const q = sku.quota || {}; return q.limit != null ? q.limit : -1; }
-        case "qUsed":    { const q = sku.quota || {}; return q.used  != null ? q.used  : -1; }
-        case "qRemain":  { const q = sku.quota || {}; return q.remaining != null ? q.remaining : -1; }
-        case "spot":     {
-            const zoneScores = (lastSpotScores?.scores || {})[sku.name] || {};
-            const vals = Object.values(zoneScores).map(s => {
-                const l = s.toLowerCase();
-                if (l === "high") return 3;
-                if (l === "medium") return 2;
-                if (l === "low") return 1;
-                return 0;
-            });
-            return vals.length > 0 ? Math.max(...vals) : 0;
-        }
-        case "paygo":    { const p = sku.pricing || {}; return p.paygo != null ? p.paygo : Infinity; }
-        case "spotPrice":{ const p = sku.pricing || {}; return p.spot  != null ? p.spot  : Infinity; }
-        case "confidence": { const c = sku.confidence || {}; return c.score != null ? c.score : -1; }
-        default:         return 0;
-    }
-}
-
-function renderSkuTable(skus, subscriptionName) {
-    const container = document.getElementById("sku-table-container");
-    const filterInput = document.getElementById("sku-filter");
-    
-    if (!skus || skus.length === 0) {
-        container.innerHTML = "<p class='empty-state-small'>No SKUs found for this region.</p>";
-        container.style.display = "block";
-        return;
-    }
-    
-    // Apply filter
-    const filterText = filterInput.value.toLowerCase();
-    let filteredSkus = skus.filter(sku => 
-        !filterText || sku.name.toLowerCase().includes(filterText)
-    );
-    
-    if (filteredSkus.length === 0) {
-        container.innerHTML = "<p class='empty-state-small'>No SKUs match the filter.</p>";
-        container.style.display = "block";
-        return;
-    }
-    
-    // Apply sorting
-    if (skuSortColumn) {
-        filteredSkus = [...filteredSkus].sort((a, b) => {
-            const va = skuSortValue(a, skuSortColumn);
-            const vb = skuSortValue(b, skuSortColumn);
-            let cmp = 0;
-            if (typeof va === "string") cmp = va.localeCompare(vb);
-            else cmp = va - vb;
-            return skuSortAsc ? cmp : -cmp;
-        });
-    }
-    
-    // Get physical zone mappings using helper function
-    const subscriptionId = selectedSkuSubscription || [...selectedSubscriptions][0];
-    const physicalZoneMap = getPhysicalZoneMap(subscriptionId);
-    
-    // Determine all logical zones from SKUs
-    const allLogicalZones = [...new Set(skus.flatMap(s => s.zones))].sort();
-    
-    // Map to physical zones
-    const physicalZones = allLogicalZones.map(lz => physicalZoneMap[lz] || `Zone ${lz}`);
-    
-    // Escaped subscription name for onclick attribute
-    const escapedSubForAttr = subscriptionName.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-    
-    // Build table with subscription context
-    let html = `<div style="margin-bottom: 0.75rem; padding: 0.5rem; background: var(--azure-light); border-radius: 6px; font-size: 0.875rem;">
-        <strong>Subscription:</strong> ${escapeHtml(subscriptionName)}
-    </div>`;
-    html += '<table class="sku-table">';
-    html += "<thead><tr>";
-    
-    const sortCols = [
-        ["name",    "SKU Name"],
-        ["family",  "Family"],
-        ["vCPUs",   "vCPUs"],
-        ["memory",  "Memory (GB)"],
-        ["qLimit",  "Quota Limit"],
-        ["qUsed",   "Quota Used"],
-        ["qRemain", "Quota Remaining"],
-        ["spot",    "Spot Score"],
-        ["confidence", "Confidence"],
-    ];
-    // Conditionally add price columns when pricing data is present
-    const hasPricing = filteredSkus.some(s => s.pricing);
-    if (hasPricing) {
-        const currency = filteredSkus.find(s => s.pricing)?.pricing?.currency || "USD";
-        sortCols.push(["paygo", `PAYGO ${currency}/h`]);
-        sortCols.push(["spotPrice", `Spot ${currency}/h`]);
-    }
-    sortCols.forEach(([col, label]) => {
-        const active = skuSortColumn === col ? ' class="sort-active"' : '';
-        html += `<th${active} style="cursor:pointer" onclick="onSkuSort('${col}','${escapedSubForAttr}')">${label}${skuSortIndicator(col)}</th>`;
-    });
-    
-    // Render headers with zone number and physical zone name (with line break)
-    allLogicalZones.forEach((lz, index) => {
-        const pz = physicalZones[index];
-        html += `<th>Zone ${escapeHtml(lz)}<br>${escapeHtml(pz)}</th>`;
-    });
-    
-    html += "</tr></thead><tbody>";
-    
-    filteredSkus.forEach(sku => {
-        const escapedSku = sku.name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-        html += "<tr>";
-        html += `<td><button type="button" class="sku-name-btn" onclick="openPricingModal('${escapedSku}')">${escapeHtml(sku.name)}</button></td>`;
-        html += `<td>${escapeHtml(sku.family || "—")}</td>`;
-        html += `<td>${escapeHtml(sku.capabilities.vCPUs || "—")}</td>`;
-        html += `<td>${escapeHtml(sku.capabilities.MemoryGB || "—")}</td>`;
-        
-        const quota = sku.quota || {};
-        html += `<td>${quota.limit != null ? quota.limit : "—"}</td>`;
-        html += `<td>${quota.used != null ? quota.used : "—"}</td>`;
-        html += `<td>${quota.remaining != null ? quota.remaining : "—"}</td>`;
-        
-        // Spot Placement Score – clickable, per-zone
-        const spotZoneScores = (lastSpotScores?.scores || {})[sku.name] || {};
-        const spotZones = Object.keys(spotZoneScores).sort();
-        if (spotZones.length > 0) {
-            const badges = spotZones.map(z => {
-                const s = spotZoneScores[z] || "Unknown";
-                const cls = "spot-badge spot-" + s.toLowerCase();
-                return `<span class="spot-zone-label">Z${escapeHtml(z)}</span><span class="${cls}">${escapeHtml(s)}</span>`;
-            }).join(" ");
-            html += `<td><button type="button" class="spot-cell-btn has-score" onclick="openSpotModal('${escapedSku}')" title="Click to refresh score">${badges}</button></td>`;
-        } else {
-            html += `<td><button type="button" class="spot-cell-btn" onclick="openSpotModal('${escapedSku}')" title="Get Spot Placement Score">Score?</button></td>`;
-        }
-        
-        // Confidence score badge
-        const conf = sku.confidence || {};
-        if (conf.score != null) {
-            const lbl = (conf.label || "").toLowerCase().replace(/\s+/g, "-");
-            html += `<td><span class="confidence-badge confidence-${lbl}" title="Deployment confidence: ${conf.score}/100">${conf.score} <small>${escapeHtml(conf.label || "")}</small></span></td>`;
-        } else {
-            html += '<td>—</td>';
-        }
-        
-        // Price columns (only if pricing data is present)
-        if (hasPricing) {
-            const pricing = sku.pricing || {};
-            html += `<td class="price-cell">${pricing.paygo != null ? pricing.paygo.toFixed(4) : '<span title="No price available">—</span>'}</td>`;
-            html += `<td class="price-cell">${pricing.spot != null ? pricing.spot.toFixed(4) : '<span title="No price available">—</span>'}</td>`;
-        }
-        
-        allLogicalZones.forEach(logicalZone => {
-            const isAvailable = sku.zones.includes(logicalZone);
-            const isRestricted = sku.restrictions.includes(logicalZone);
-            
-            if (isRestricted) {
-                html += '<td class="zone-restricted" title="Restricted: SKU not available in this zone" aria-label="Restricted">⚠</td>';
-            } else if (isAvailable) {
-                html += '<td class="zone-available" title="Available" aria-label="Available">✓</td>';
-            } else {
-                html += '<td class="zone-unavailable" title="Not available" aria-label="Not available">—</td>';
-            }
-        });
-        
-        html += "</tr>";
-    });
-    
-    html += "</tbody></table>";
-    container.innerHTML = html;
-    container.style.display = "block";
-}
-
-function exportSkuCSV() {
-    if (!lastSkuData || lastSkuData.length === 0) {
-        showError("No SKU data to export.");
-        return;
-    }
-    
-    // Get physical zone mappings using helper function
-    const subscriptionId = selectedSkuSubscription || [...selectedSubscriptions][0];
-    const physicalZoneMap = getPhysicalZoneMap(subscriptionId);
-    
-    const allLogicalZones = [...new Set(lastSkuData.flatMap(s => s.zones))].sort();
-    const physicalZones = allLogicalZones.map(lz => physicalZoneMap[lz] || `Zone ${lz}`);
-    
-    // Header row with zone number and physical zone information
-    const zoneHeaders = allLogicalZones.map((lz, index) => 
-        `Zone ${lz}\n${physicalZones[index]}`
-    );
-    const hasPricing = lastSkuData.some(s => s.pricing);
-    const priceCurrency = lastSkuData.find(s => s.pricing)?.pricing?.currency || "USD";
-    const priceHeaders = hasPricing
-        ? [`PAYGO ${priceCurrency}/h`, `Spot ${priceCurrency}/h`]
-        : [];
-    const headers = ["SKU Name", "Family", "vCPUs", "Memory (GB)",
-        "Quota Limit", "Quota Used", "Quota Remaining",
-        "Spot Score",
-        "Confidence Score", "Confidence Label",
-        ...priceHeaders,
-        ...zoneHeaders];
-    
-    // Data rows
-    const rows = lastSkuData.map(sku => {
-        const quota = sku.quota || {};
-        const zoneCols = allLogicalZones.map(logicalZone => {
-            const isAvailable = sku.zones.includes(logicalZone);
-            const isRestricted = sku.restrictions.includes(logicalZone);
-            
-            if (isRestricted) return "Restricted";
-            if (isAvailable) return "Available";
-            return "Unavailable";
-        });
-        
-        return [
-            sku.name,
-            sku.family || "",
-            sku.capabilities.vCPUs || "",
-            sku.capabilities.MemoryGB || "",
-            quota.limit != null ? quota.limit : "",
-            quota.used != null ? quota.used : "",
-            quota.remaining != null ? quota.remaining : "",
-            Object.entries((lastSpotScores?.scores || {})[sku.name] || {}).sort(([a],[b]) => a.localeCompare(b)).map(([z, s]) => `Z${z}:${s}`).join(" ") || "",
-            (sku.confidence || {}).score != null ? sku.confidence.score : "",
-            (sku.confidence || {}).label || "",
-            ...(hasPricing ? [
-                sku.pricing?.paygo != null ? sku.pricing.paygo : "",
-                sku.pricing?.spot != null ? sku.pricing.spot : "",
-            ] : []),
-            ...zoneCols
-        ];
-    });
-    
-    // Build CSV string
-    const csvContent = [headers, ...rows]
-        .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(","))
-        .join("\n");
-    
-    const region = document.getElementById("region-select").value || "skus";
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-    const a = document.createElement("a");
-    a.download = `az-skus-${region}.csv`;
-    a.href = URL.createObjectURL(blob);
-    a.click();
-    URL.revokeObjectURL(a.href);
 }
 
 // ---------------------------------------------------------------------------
 // SKU Pricing Detail Modal
 // ---------------------------------------------------------------------------
 let _pricingModalSku = null;
+let _pricingModal = null;
 
 function openPricingModal(skuName) {
     _pricingModalSku = skuName;
     document.getElementById("pricing-modal-sku").textContent = skuName;
-    document.getElementById("pricing-modal-loading").style.display = "none";
-    document.getElementById("pricing-modal-content").style.display = "none";
-    document.getElementById("pricing-modal").style.display = "flex";
+    document.getElementById("pricing-modal-loading").classList.add("d-none");
+    document.getElementById("pricing-modal-content").classList.add("d-none");
+    if (!_pricingModal) _pricingModal = new bootstrap.Modal(document.getElementById("pricingModal"));
+    _pricingModal.show();
     fetchPricingDetail();
-}
-
-function closePricingModal(event) {
-    if (event && event.target !== document.getElementById("pricing-modal")) return;
-    document.getElementById("pricing-modal").style.display = "none";
-    _pricingModalSku = null;
 }
 
 function refreshPricingModal() {
@@ -1753,27 +1155,25 @@ function refreshPricingModal() {
 async function fetchPricingDetail() {
     const skuName = _pricingModalSku;
     if (!skuName) return;
-
     const region = document.getElementById("region-select").value;
     const currency = document.getElementById("pricing-modal-currency-select").value;
     if (!region) return;
 
-    document.getElementById("pricing-modal-loading").style.display = "flex";
-    document.getElementById("pricing-modal-content").style.display = "none";
+    document.getElementById("pricing-modal-loading").classList.remove("d-none");
+    document.getElementById("pricing-modal-content").classList.add("d-none");
 
     try {
         const params = new URLSearchParams({ region, skuName, currencyCode: currency });
-        const subId = selectedSkuSubscription || [...selectedSubscriptions][0];
-        if (subId) params.set("subscriptionId", subId);
+        if (plannerSubscriptionId) params.set("subscriptionId", plannerSubscriptionId);
         const tqs = tenantQS("&");
         const data = await apiFetch(`/api/sku-pricing?${params}${tqs}`);
         renderPricingDetail(data);
     } catch (err) {
         const content = document.getElementById("pricing-modal-content");
-        content.innerHTML = `<p style="color:var(--danger);font-size:0.85rem;">Failed to load pricing: ${escapeHtml(err.message)}</p>`;
-        content.style.display = "block";
+        content.innerHTML = `<p class="text-danger small">Failed to load pricing: ${escapeHtml(err.message)}</p>`;
+        content.classList.remove("d-none");
     } finally {
-        document.getElementById("pricing-modal-loading").style.display = "none";
+        document.getElementById("pricing-modal-loading").classList.add("d-none");
     }
 }
 
@@ -1783,37 +1183,35 @@ function renderPricingDetail(data) {
     const HOURS_PER_MONTH = 730;
 
     const rows = [
-        { label: "Pay-As-You-Go",         hourly: data.paygo },
-        { label: "Spot",                   hourly: data.spot },
-        { label: "Reserved Instance 1Y",   hourly: data.ri_1y },
-        { label: "Reserved Instance 3Y",   hourly: data.ri_3y },
-        { label: "Savings Plan 1Y",        hourly: data.sp_1y },
-        { label: "Savings Plan 3Y",        hourly: data.sp_3y },
+        { label: "Pay-As-You-Go", hourly: data.paygo },
+        { label: "Spot", hourly: data.spot },
+        { label: "Reserved Instance 1Y", hourly: data.ri_1y },
+        { label: "Reserved Instance 3Y", hourly: data.ri_3y },
+        { label: "Savings Plan 1Y", hourly: data.sp_1y },
+        { label: "Savings Plan 3Y", hourly: data.sp_3y },
     ];
 
-    let html = '<table class="pricing-detail-table">';
-    html += `<thead><tr><th>Type</th><th>${escapeHtml(currency)}/hour</th><th>${escapeHtml(currency)}/month</th></tr></thead>`;
-    html += "<tbody>";
+    let html = '<table class="table table-sm pricing-detail-table">';
+    html += `<thead><tr><th>Type</th><th>${escapeHtml(currency)}/hour</th><th>${escapeHtml(currency)}/month</th></tr></thead><tbody>`;
     rows.forEach(r => {
-        const hourStr = r.hourly != null ? r.hourly.toFixed(4) : "—";
-        const monthStr = r.hourly != null ? (r.hourly * HOURS_PER_MONTH).toFixed(2) : "—";
+        const hourStr = r.hourly != null ? r.hourly.toFixed(4) : "\u2014";
+        const monthStr = r.hourly != null ? (r.hourly * HOURS_PER_MONTH).toFixed(2) : "\u2014";
         html += `<tr><td>${escapeHtml(r.label)}</td><td class="price-cell">${hourStr}</td><td class="price-cell">${monthStr}</td></tr>`;
     });
     html += "</tbody></table>";
 
-    // VM Profile section
-    if (data.profile) {
-        html += renderVmProfile(data.profile);
-    }
+    if (data.profile) html += renderVmProfile(data.profile);
 
-    // Confidence breakdown section
     const confSku = (lastSkuData || []).find(s => s.name === _pricingModalSku);
-    if (confSku && confSku.confidence) {
-        html += renderConfidenceBreakdown(confSku.confidence);
-    }
+    if (confSku?.confidence) html += renderConfidenceBreakdown(confSku.confidence);
 
     content.innerHTML = html;
-    content.style.display = "block";
+    content.classList.remove("d-none");
+
+    // Init Bootstrap tooltips for confidence info icons
+    content.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+        new bootstrap.Tooltip(el, { delay: { show: 0, hide: 100 }, placement: "top" });
+    });
 }
 
 function renderVmProfile(profile) {
@@ -1824,80 +1222,65 @@ function renderVmProfile(profile) {
     function badge(val, trueLabel, falseLabel) {
         if (val === true) return `<span class="vm-badge vm-badge-yes">${escapeHtml(trueLabel || "Yes")}</span>`;
         if (val === false) return `<span class="vm-badge vm-badge-no">${escapeHtml(falseLabel || "No")}</span>`;
-        return `<span class="vm-badge vm-badge-unknown">—</span>`;
+        return '<span class="vm-badge vm-badge-unknown">\u2014</span>';
     }
-
     function row(label, value) {
-        return `<div class="vm-profile-row"><span class="vm-profile-label">${escapeHtml(label)}</span><span class="vm-profile-value">${value}</span></div>`;
+        return `<div class="vm-profile-row"><span class="vm-profile-label">${escapeHtml(label)}</span><span>${value}</span></div>`;
     }
-
     function val(v, suffix) {
-        if (v == null) return '<span class="vm-badge vm-badge-unknown">—</span>';
+        if (v == null) return '<span class="vm-badge vm-badge-unknown">\u2014</span>';
         return escapeHtml(String(v) + (suffix || ""));
     }
-
-    // Format bytes/sec to MB/s
     function bytesToMBs(v) {
-        if (v == null) return '<span class="vm-badge vm-badge-unknown">—</span>';
-        const mb = Number(v) / (1024 * 1024);
-        return escapeHtml(mb.toFixed(0) + " MB/s");
+        if (v == null) return '<span class="vm-badge vm-badge-unknown">\u2014</span>';
+        return escapeHtml((Number(v) / (1024 * 1024)).toFixed(0) + " MB/s");
     }
-
-    // Format bytes to GB
     function bytesToGB(v) {
-        if (v == null) return '<span class="vm-badge vm-badge-unknown">—</span>';
-        const gb = Number(v) / (1024 * 1024 * 1024);
-        return escapeHtml(gb.toFixed(0) + " GB");
+        if (v == null) return '<span class="vm-badge vm-badge-unknown">\u2014</span>';
+        return escapeHtml((Number(v) / (1024 * 1024 * 1024)).toFixed(0) + " GB");
     }
-
-    // Format Mbps to Gbps
     function mbpsToGbps(v) {
-        if (v == null) return '<span class="vm-badge vm-badge-unknown">—</span>';
+        if (v == null) return '<span class="vm-badge vm-badge-unknown">\u2014</span>';
         const gbps = Number(v) / 1000;
         return escapeHtml(gbps >= 1 ? gbps.toFixed(1) + " Gbps" : v + " Mbps");
     }
 
-    // Restrictions summary
     let restrictionSummary = '<span class="vm-badge vm-badge-yes">None</span>';
     if (restrictions.length > 0) {
         const parts = restrictions.map(r => {
-            const rType = r.type || "Unknown";
-            const reason = r.reasonCode || "";
-            const rZones = (r.zones || []).join(", ");
-            let desc = rType;
-            if (reason) desc += ` (${reason})`;
-            if (rZones) desc += ` zones: ${rZones}`;
-            return escapeHtml(desc);
+            let desc = r.type || "Unknown";
+            if (r.reasonCode) desc += ` (${r.reasonCode})`;
+            if (r.zones?.length) desc += ` zones: ${r.zones.join(", ")}`;
+            return `<div class="restriction-item">${escapeHtml(desc)}</div>`;
         });
-        restrictionSummary = `<span class="vm-badge vm-badge-limited">${parts.join("; ")}</span>`;
+        restrictionSummary = `<span class="vm-badge vm-badge-limited vm-badge-block">${parts.join("")}</span>`;
     }
 
     let html = '<div class="vm-profile-section">';
     html += '<h4 class="vm-profile-title">VM Profile</h4>';
     html += '<div class="vm-profile-grid">';
 
-    // Compute card
     html += '<div class="vm-profile-card">';
     html += '<div class="vm-profile-card-title">Compute</div>';
     html += row("vCPUs", val(caps.vCPUs));
     html += row("Memory", val(caps.MemoryGB, " GB"));
     html += row("Architecture", val(caps.CpuArchitectureType));
-    const gpuCount = caps.GPUs != null ? caps.GPUs : caps.GpuCount;
-    html += row("GPUs", val(gpuCount));
+    html += row("GPUs", val(caps.GPUs ?? caps.GpuCount));
     html += '</div>';
 
-    // Deployment card
     html += '<div class="vm-profile-card">';
     html += '<div class="vm-profile-card-title">Deployment</div>';
-    const zonesStr = zones.length > 0 ? zones.join(", ") : "None";
-    html += row("Zones", val(zonesStr));
+    html += row("Zones", val(zones.length > 0 ? zones.join(", ") : "None"));
     html += row("HyperV Gen.", val(caps.HyperVGenerations));
     html += row("Encryption at Host", badge(caps.EncryptionAtHostSupported));
-    html += row("Confidential", val(caps.ConfidentialComputingType || (caps.ConfidentialComputingType === false ? "None" : null)));
-    html += row("Restrictions", restrictionSummary);
+    html += row("Confidential", val(caps.ConfidentialComputingType || null));
+    if (restrictions.length > 0) {
+        html += `<div class="vm-profile-row vm-profile-row-stacked"><span class="vm-profile-label">Restrictions</span>${restrictionSummary}</div>`;
+    } else {
+        html += row("Restrictions", restrictionSummary);
+    }
     html += '</div>';
 
-    // Storage card
     html += '<div class="vm-profile-card">';
     html += '<div class="vm-profile-card-title">Storage</div>';
     html += row("Premium IO", badge(caps.PremiumIO));
@@ -1911,12 +1294,10 @@ function renderVmProfile(profile) {
     html += row("Temp Disk", val(caps.TempDiskSizeInGiB, " GiB"));
     html += '</div>';
 
-    // Network card
     html += '<div class="vm-profile-card">';
     html += '<div class="vm-profile-card-title">Network</div>';
     html += row("Accelerated Net.", badge(caps.AcceleratedNetworkingEnabled));
-    const nics = caps.MaxNetworkInterfaces != null ? caps.MaxNetworkInterfaces : caps.MaximumNetworkInterfaces;
-    html += row("Max NICs", val(nics));
+    html += row("Max NICs", val(caps.MaxNetworkInterfaces ?? caps.MaximumNetworkInterfaces));
     html += row("Max Bandwidth", mbpsToGbps(caps.MaxBandwidthMbps));
     html += row("RDMA", badge(caps.RdmaEnabled));
     html += '</div>';
@@ -1928,31 +1309,255 @@ function renderVmProfile(profile) {
 function renderConfidenceBreakdown(conf) {
     const lbl = (conf.label || "").toLowerCase().replace(/\s+/g, "-");
     let html = '<div class="confidence-section">';
-    html += `<h4 class="confidence-title">Deployment Confidence <span class="confidence-badge confidence-${lbl}">${conf.score} ${escapeHtml(conf.label || "")}</span></h4>`;
-
-    if (conf.breakdown && conf.breakdown.length > 0) {
-        html += '<table class="confidence-breakdown-table">';
-        html += '<thead><tr><th>Signal</th><th>Score</th><th>Weight</th><th>Contribution</th></tr></thead><tbody>';
+    html += `<h4 class="confidence-title">Deployment Confidence <span class="confidence-badge confidence-${lbl}">${conf.score} ${escapeHtml(conf.label || "")}</span> <i class="bi bi-info-circle text-body-secondary confidence-info-icon" data-bs-toggle="tooltip" data-bs-title="Composite score (0\u2013100) predicting deployment success based on weighted signals. Higher is better."></i></h4>`;
+    if (conf.breakdown?.length) {
+        html += '<table class="table table-sm confidence-breakdown-table"><thead><tr><th>Signal</th><th>Score</th><th>Weight</th><th>Contribution</th></tr></thead><tbody>';
         const signalLabels = { quota: "Quota Headroom", spot: "Spot Placement", zones: "Zone Breadth", restrictions: "Restrictions", pricePressure: "Price Pressure" };
+        const signalDescriptions = {
+            quota: "Remaining quota relative to vCPU count. Low quota means deployments may be blocked.",
+            spot: "Best spot eviction score across zones. High means lower eviction risk.",
+            zones: "Number of availability zones where the SKU is offered (out of 3).",
+            restrictions: "Whether any subscription or zone-level restrictions apply to this SKU.",
+            pricePressure: "Spot-to-PAYGO price ratio. A lower ratio indicates better spot savings."
+        };
         conf.breakdown.forEach(b => {
-            html += `<tr><td>${escapeHtml(signalLabels[b.signal] || b.signal)}</td><td>${b.score}</td><td>${(b.weight * 100).toFixed(1)}%</td><td>${b.contribution.toFixed(1)}</td></tr>`;
+            const desc = signalDescriptions[b.signal] || "";
+            html += `<tr><td>${escapeHtml(signalLabels[b.signal] || b.signal)} <i class="bi bi-info-circle text-body-secondary" data-bs-toggle="tooltip" data-bs-title="${escapeHtml(desc)}"></i></td><td>${b.score}</td><td>${(b.weight * 100).toFixed(1)}%</td><td>${b.contribution.toFixed(1)}</td></tr>`;
         });
         html += '</tbody></table>';
     }
-
-    if (conf.missing && conf.missing.length > 0) {
+    if (conf.missing?.length) {
         const signalLabels = { quota: "Quota Headroom", spot: "Spot Placement", zones: "Zone Breadth", restrictions: "Restrictions", pricePressure: "Price Pressure" };
         const names = conf.missing.map(m => signalLabels[m] || m).join(", ");
-        html += `<p class="confidence-missing">Missing signals (excluded from score): ${escapeHtml(names)}</p>`;
+        html += `<p class="confidence-missing"><i class="bi bi-exclamation-circle"></i> Missing signals (excluded from score): ${escapeHtml(names)}</p>`;
     }
-
     html += '</div>';
     return html;
 }
 
-document.addEventListener("keydown", (e) => {
-    const modal = document.getElementById("pricing-modal");
-    if (modal && modal.style.display !== "none" && e.key === "Escape") {
-        closePricingModal();
+// ---------------------------------------------------------------------------
+// Render SKU table  (powered by Simple-DataTables)
+// ---------------------------------------------------------------------------
+function renderSkuTable(skus) {
+    const container = document.getElementById("sku-table-container");
+
+    if (_skuDataTable) {
+        try { _skuDataTable.destroy(); } catch {}
+        _skuDataTable = null;
     }
-});
+
+    if (!skus || skus.length === 0) {
+        container.innerHTML = '<p class="text-body-secondary text-center py-3">No SKUs found for this region.</p>';
+        return;
+    }
+
+    const physicalZoneMap = getPlannerPhysicalZoneMap();
+    const allLogicalZones = [...new Set(skus.flatMap(s => s.zones))].sort();
+    const physicalZones = allLogicalZones.map(lz => physicalZoneMap[lz] || `Zone ${lz}`);
+    const hasPricing = skus.some(s => s.pricing);
+
+    // Build table HTML
+    let html = '<table id="sku-datatable" class="table table-sm table-hover sku-table">';
+    html += "<thead><tr>";
+
+    const headers = ["SKU Name", "Family", "vCPUs", "Memory (GB)",
+        "Quota Limit", "Quota Used", "Quota Remaining",
+        "Spot Score", "Confidence"];
+    if (hasPricing) {
+        const currency = skus.find(s => s.pricing)?.pricing?.currency || "USD";
+        headers.push(`PAYGO ${currency}/h`, `Spot ${currency}/h`);
+    }
+    allLogicalZones.forEach((lz, i) => {
+        headers.push(`Zone ${escapeHtml(lz)}<br>${escapeHtml(physicalZones[i])}`);
+    });
+    headers.forEach(h => { html += `<th>${h}</th>`; });
+    html += "</tr></thead><tbody>";
+
+    skus.forEach(sku => {
+        html += "<tr>";
+        // SKU Name (clickable via event delegation)
+        html += `<td><button type="button" class="sku-name-btn" data-action="pricing" data-sku="${escapeHtml(sku.name)}">${escapeHtml(sku.name)}</button></td>`;
+        html += `<td>${escapeHtml(sku.family || "\u2014")}</td>`;
+        html += `<td>${escapeHtml(sku.capabilities.vCPUs || "\u2014")}</td>`;
+        html += `<td>${escapeHtml(sku.capabilities.MemoryGB || "\u2014")}</td>`;
+        const quota = sku.quota || {};
+        html += `<td>${quota.limit != null ? quota.limit : "\u2014"}</td>`;
+        html += `<td>${quota.used != null ? quota.used : "\u2014"}</td>`;
+        html += `<td>${quota.remaining != null ? quota.remaining : "\u2014"}</td>`;
+
+        // Spot Score
+        const spotZoneScores = (lastSpotScores?.scores || {})[sku.name] || {};
+        const spotZones = Object.keys(spotZoneScores).sort();
+        if (spotZones.length > 0) {
+            const badges = spotZones.map(z => {
+                const s = spotZoneScores[z] || "Unknown";
+                return `<span class="spot-zone-label">Z${escapeHtml(z)}</span><span class="spot-badge spot-${s.toLowerCase()}">${escapeHtml(s)}</span>`;
+            }).join(" ");
+            html += `<td><button type="button" class="spot-cell-btn has-score" data-action="spot" data-sku="${escapeHtml(sku.name)}" title="Click to refresh">${badges}</button></td>`;
+        } else {
+            html += `<td><button type="button" class="spot-cell-btn" data-action="spot" data-sku="${escapeHtml(sku.name)}" title="Get Spot Placement Score">Score?</button></td>`;
+        }
+
+        // Confidence
+        const conf = sku.confidence || {};
+        if (conf.score != null) {
+            const lbl = (conf.label || "").toLowerCase().replace(/\s+/g, "-");
+            html += `<td><span class="confidence-badge confidence-${lbl}" title="Deployment confidence: ${conf.score}/100">${conf.score} <small>${escapeHtml(conf.label || "")}</small></span></td>`;
+        } else {
+            html += '<td>\u2014</td>';
+        }
+
+        // Prices
+        if (hasPricing) {
+            const pricing = sku.pricing || {};
+            html += `<td class="price-cell">${pricing.paygo != null ? pricing.paygo.toFixed(4) : '\u2014'}</td>`;
+            html += `<td class="price-cell">${pricing.spot != null ? pricing.spot.toFixed(4) : '\u2014'}</td>`;
+        }
+
+        // Zone availability
+        allLogicalZones.forEach(lz => {
+            const isRestricted = sku.restrictions.includes(lz);
+            const isAvailable = sku.zones.includes(lz);
+            if (isRestricted) html += '<td class="zone-restricted" data-bs-toggle="tooltip" data-bs-title="Restricted: this SKU has deployment restrictions in this zone"><i class="bi bi-exclamation-triangle-fill"></i></td>';
+            else if (isAvailable) html += '<td class="zone-available" data-bs-toggle="tooltip" data-bs-title="Available: this SKU can be deployed in this zone"><i class="bi bi-check-circle-fill"></i></td>';
+            else html += '<td class="zone-unavailable" data-bs-toggle="tooltip" data-bs-title="Not available: this SKU is not offered in this zone"><i class="bi bi-dash-circle"></i></td>';
+        });
+        html += "</tr>";
+    });
+    html += "</tbody></table>";
+    container.innerHTML = html;
+
+    // Column type configuration for proper numeric sorting
+    const colConfig = [
+        { select: [2, 3, 4, 5, 6], type: "number" },   // vCPUs, Memory, Quota
+        { select: 8, type: "number" },                   // Confidence (textContent starts with number)
+    ];
+    let nextCol = 9;
+    if (hasPricing) {
+        colConfig.push({ select: [nextCol, nextCol + 1], type: "number" });
+        nextCol += 2;
+    }
+
+    // Init Simple-DataTables
+    const tableEl = document.getElementById("sku-datatable");
+
+    // Build per-column header filter config
+    // Only text-filterable columns get an input; Zone columns are excluded
+    const filterableCols = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+    if (hasPricing) { filterableCols.push(nextCol - 2, nextCol - 1); }
+    const headerConfig = {};
+    filterableCols.forEach(idx => {
+        headerConfig[idx] = { type: "input", attr: { placeholder: "Filter\u2026", class: "datatable-column-filter" } };
+    });
+
+    _skuDataTable = new simpleDatatables.DataTable(tableEl, {
+        searchable: false,
+        paging: false,
+        labels: {
+            noRows: "No SKUs match",
+            info: "{rows} SKUs",
+        },
+        columns: colConfig,
+    });
+
+    // Build per-column filter row in thead
+    _buildColumnFilters(tableEl, filterableCols);
+
+    // Init Bootstrap tooltips on zone cells
+    tableEl.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+        new bootstrap.Tooltip(el, { delay: { show: 0, hide: 100 }, placement: "top" });
+    });
+}
+
+/**
+ * Inject a second <tr> into thead with <input> filters for specified columns.
+ * Filtering uses Simple-DataTables columns().search() when available,
+ * otherwise falls back to manual row-level filtering.
+ */
+function _buildColumnFilters(tableEl, filterableCols) {
+    const thead = tableEl.querySelector("thead");
+    if (!thead) return;
+
+    const headerCells = thead.querySelectorAll("tr:first-child th");
+    const filterRow = document.createElement("tr");
+    filterRow.className = "datatable-filter-row";
+
+    headerCells.forEach((_, idx) => {
+        const td = document.createElement("td");
+        if (filterableCols.includes(idx)) {
+            const input = document.createElement("input");
+            input.type = "search";
+            input.className = "datatable-column-filter";
+            input.placeholder = "Filter\u2026";
+            input.dataset.col = idx;
+            td.appendChild(input);
+        }
+        filterRow.appendChild(td);
+    });
+    thead.appendChild(filterRow);
+
+    // Debounced column filtering via row visibility
+    let _colFilterTimeout;
+    filterRow.addEventListener("input", () => {
+        clearTimeout(_colFilterTimeout);
+        _colFilterTimeout = setTimeout(() => _applyColumnFilters(tableEl, filterRow), 200);
+    });
+}
+
+function _applyColumnFilters(tableEl, filterRow) {
+    const inputs = filterRow.querySelectorAll("input[data-col]");
+    const filters = [];
+    inputs.forEach(inp => {
+        const val = inp.value.trim().toLowerCase();
+        if (val) filters.push({ col: parseInt(inp.dataset.col, 10), text: val });
+    });
+
+    const rows = tableEl.querySelectorAll("tbody tr");
+    rows.forEach(row => {
+        if (filters.length === 0) {
+            row.style.display = "";
+            return;
+        }
+        const cells = row.querySelectorAll("td");
+        const match = filters.every(f => {
+            const cell = cells[f.col];
+            if (!cell) return false;
+            return cell.textContent.toLowerCase().includes(f.text);
+        });
+        row.style.display = match ? "" : "none";
+    });
+}
+
+// ---------------------------------------------------------------------------
+// EXPORT: SKU → CSV
+// ---------------------------------------------------------------------------
+function exportSkuCSV() {
+    if (!lastSkuData || lastSkuData.length === 0) return;
+    const physicalZoneMap = getPlannerPhysicalZoneMap();
+    const allLogicalZones = [...new Set(lastSkuData.flatMap(s => s.zones))].sort();
+    const physicalZones = allLogicalZones.map(lz => physicalZoneMap[lz] || `Zone ${lz}`);
+    const hasPricing = lastSkuData.some(s => s.pricing);
+    const priceCurrency = lastSkuData.find(s => s.pricing)?.pricing?.currency || "USD";
+    const priceHeaders = hasPricing ? [`PAYGO ${priceCurrency}/h`, `Spot ${priceCurrency}/h`] : [];
+    const zoneHeaders = allLogicalZones.map((lz, i) => `Zone ${lz}\n${physicalZones[i]}`);
+    const headers = ["SKU Name", "Family", "vCPUs", "Memory (GB)",
+        "Quota Limit", "Quota Used", "Quota Remaining", "Spot Score",
+        "Confidence Score", "Confidence Label", ...priceHeaders, ...zoneHeaders];
+    const rows = lastSkuData.map(sku => {
+        const quota = sku.quota || {};
+        const zoneCols = allLogicalZones.map(lz => {
+            if (sku.restrictions.includes(lz)) return "Restricted";
+            if (sku.zones.includes(lz)) return "Available";
+            return "Unavailable";
+        });
+        return [
+            sku.name, sku.family || "", sku.capabilities.vCPUs || "", sku.capabilities.MemoryGB || "",
+            quota.limit ?? "", quota.used ?? "", quota.remaining ?? "",
+            Object.entries((lastSpotScores?.scores || {})[sku.name] || {}).sort(([a], [b]) => a.localeCompare(b)).map(([z, s]) => `Z${z}:${s}`).join(" ") || "",
+            sku.confidence?.score ?? "", sku.confidence?.label || "",
+            ...(hasPricing ? [sku.pricing?.paygo ?? "", sku.pricing?.spot ?? ""] : []),
+            ...zoneCols
+        ];
+    });
+    downloadCSV([headers, ...rows], `az-skus-${document.getElementById("region-select").value || "export"}.csv`);
+}

--- a/src/az_mapping/templates/index.html
+++ b/src/az_mapping/templates/index.html
@@ -1,321 +1,313 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Azure AZ Mapping Viewer</title>
     <link rel="icon" type="image/svg+xml" href="{{ url_for('static', path='img/favicon.svg') }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/simple-datatables@9/dist/style.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
     <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
 
-<header class="app-header">
-    <div class="header-left">
-        <div class="header-content">
-            <img class="header-icon" src="{{ url_for('static', path='img/favicon.svg') }}" width="28" height="28" alt="">
-            <h1>Azure AZ Mapping Viewer</h1>
-        </div>
-        <p class="header-subtitle">Visualize logical-to-physical Availability Zone mappings across subscriptions</p>
-    </div>
-    <button type="button" class="theme-toggle" id="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">
-        <!-- Sun icon (shown in dark mode) -->
-        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/>
-            <line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/>
-            <line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-        </svg>
-        <!-- Moon icon (shown in light mode) -->
-        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
-        </svg>
-    </button>
-</header>
-
-<div class="app-container">
-    <!-- Filters sidebar -->
-    <aside class="filters-panel" id="filters-panel">
-        <button type="button" class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Collapse filters">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="15 18 9 12 15 6"/>
-            </svg>
-        </button>
-        <div class="sidebar-content" id="sidebar-content">
-        <div class="filter-section">
-            <h3>
-                <img class="filter-icon" src="{{ url_for('static', path='img/entra-id.svg') }}" alt="Entra ID" width="16" height="16">
-                Tenant
-            </h3>
-            <select id="tenant-select">
-                <option value="">Loading tenants…</option>
-            </select>
-        </div>
-
-        <div class="filter-section">
-            <h3>
-                <img src="{{ url_for('static', path='img/region-management.svg') }}" width="16" height="16" alt="">
-                Region
-            </h3>
-            <div class="region-combobox" id="region-combobox">
-                <input type="search" id="region-search" placeholder="Loading regions…"
-                       autocomplete="off" spellcheck="false" disabled>
-                <input type="hidden" id="region-select" value="">
-                <ul class="region-dropdown" id="region-dropdown"></ul>
-            </div>
-        </div>
-
-        <div class="filter-section">
-            <h3>
-                <img src="{{ url_for('static', path='img/subscriptions.svg') }}" width="16" height="16" alt="">
-                Subscriptions
-            </h3>
-            <input type="search" id="sub-filter" placeholder="Filter subscriptions…"
-                   autocomplete="off" spellcheck="false">
-            <div class="checkbox-actions">
-                <button type="button" onclick="selectAllVisible()">Select visible</button>
-                <button type="button" onclick="deselectAll()">Clear all</button>
-            </div>
-            <div id="sub-list" class="checkbox-list">
-                <div class="loading-indicator" id="sub-loading">
-                    <div class="spinner"></div>
-                    <span>Loading subscriptions…</span>
-                </div>
-            </div>
-            <div id="sub-count" class="selection-count">0 selected</div>
-        </div>
-
-        <button type="button" id="load-btn" class="primary-btn" onclick="loadMappings()" disabled>
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="1 4 1 10 7 10"/>
-                <path d="M3.51 15a9 9 0 102.13-9.36L1 10"/>
-            </svg>
-            Load Mappings
-        </button>
-
-        <div id="error-panel" class="error-panel" style="display:none;"></div>
-        </div><!-- /.sidebar-content -->
-    </aside>
-
-    <!-- Results area -->
-    <main class="results-panel">
-        <!-- Page navigation tabs -->
-        <nav class="page-nav" id="page-nav">
-            <button type="button" class="page-nav-tab active" data-page="topology" onclick="navigateTo('topology')">
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="6" height="5" rx="1"/><rect x="16" y="3" width="6" height="5" rx="1"/><rect x="16" y="16" width="6" height="5" rx="1"/><line x1="8" y1="5.5" x2="16" y2="5.5"/><path d="M12 5.5V18.5H16"/></svg>
-                AZ Topology
-            </button>
-            <button type="button" class="page-nav-tab" data-page="planner" onclick="navigateTo('planner')">
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
-                Deployment Planner
-            </button>
-        </nav>
-
-        <!-- ====== Topology Page ====== -->
-        <div id="page-topology" class="page-content">
-            <div id="topology-empty" class="empty-state">
-                <img src="{{ url_for('static', path='img/favicon.svg') }}" width="48" height="48" alt="Main icon">
-                <p>Select a region and one or more subscriptions, then click <strong>Load Mappings</strong>.</p>
-            </div>
-
-            <div id="topology-content" style="display:none;">
-            <!-- Graph section -->
-            <section class="result-card">
-                <div class="card-header">
-                    <h2>Zone Mapping Graph</h2>
-                    <button type="button" class="export-btn" onclick="exportGraphPNG()" title="Export as PNG">
-                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
-                        </svg>
-                        PNG
-                    </button>
-                </div>
-                <div id="graph-container"></div>
-                <div id="graph-legend" class="graph-legend"></div>
-            </section>
-
-            <!-- Table section -->
-            <section class="result-card">
-                <div class="card-header">
-                    <h2>Zone Mapping Table</h2>
-                    <button type="button" class="export-btn" onclick="exportTableCSV()" title="Export as CSV">
-                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
-                        </svg>
-                        CSV
-                    </button>
-                </div>
-                <div id="table-container" class="table-container"></div>
-            </section>
-
-            <!-- Proceed to Planner -->
-            <div class="proceed-bar">
-                <button type="button" class="primary-btn proceed-btn" onclick="navigateTo('planner')">
-                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="5" y1="12" x2="19" y2="12"/>
-                        <polyline points="12 5 19 12 12 19"/>
-                    </svg>
-                    Proceed to Deployment Planner
-                </button>
-            </div>
-            </div><!-- /topology-content -->
-
-            <div id="topology-loading" class="loading-indicator" style="display:none;">
-                <div class="spinner"></div>
-                <span>Fetching zone mappings…</span>
-            </div>
-        </div><!-- /page-topology -->
-
-        <!-- ====== Planner Page ====== -->
-        <div id="page-planner" class="page-content" style="display:none;">
-            <div id="planner-empty" class="empty-state">
-                <img src="{{ url_for('static', path='img/favicon.svg') }}" width="48" height="48" alt="Main icon">
-                <p>Load zone mappings from the <strong>AZ Topology</strong> tab first, then come back here to plan deployments.</p>
-            </div>
-
-            <div id="planner-loading" class="loading-indicator" style="display:none;">
-                <div class="spinner"></div>
-                <span>Fetching zone mappings…</span>
-            </div>
-
-            <div id="planner-content" style="display:none;">
-                <div id="region-health-summary"></div>
-
-            <!-- SKU section -->
-            <section class="result-card sku-section">
-                <div class="card-header">
-                    <h2>
-                        <button type="button" class="section-toggle" onclick="toggleSkuSection()" id="sku-toggle" title="Show/hide SKU availability">
-                            <svg class="toggle-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="6 9 12 15 18 9"/>
-                            </svg>
-                        </button>
-                        SKU Availability per Physical Zone
-                    </h2>
-                    <button type="button" class="export-btn" onclick="exportSkuCSV()" title="Export as CSV">
-                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
-                        </svg>
-                        CSV
-                    </button>
-                </div>
-                <div id="sku-content" class="sku-content">
-                    <div class="sku-controls">
-                        <select id="sku-subscription-select" style="display:none;">
-                            <option value="">Select subscription…</option>
-                        </select>
-                        <input type="search" id="sku-filter" placeholder="Filter SKU names (e.g., D2s, E4)…"
-                               autocomplete="off" spellcheck="false">
-                        <label class="checkbox-item sku-price-toggle" title="Fetch retail prices from Azure Retail Prices API">
-                            <input type="checkbox" id="sku-include-prices"> Prices
-                        </label>
-                        <select id="sku-currency" class="sku-currency-select" title="Currency for prices">
-                            <option value="USD" selected>USD</option>
-                            <option value="EUR">EUR</option>
-                            <option value="GBP">GBP</option>
-                            <option value="JPY">JPY</option>
-                            <option value="AUD">AUD</option>
-                            <option value="CAD">CAD</option>
-                            <option value="CHF">CHF</option>
-                            <option value="SEK">SEK</option>
-                            <option value="BRL">BRL</option>
-                            <option value="INR">INR</option>
-                        </select>
-                        <button type="button" class="secondary-btn" onclick="loadSkus()">
-                            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="1 4 1 10 7 10"/>
-                                <path d="M3.51 15a9 9 0 102.13-9.36L1 10"/>
-                            </svg>
-                            Load SKUs
-                        </button>
-
-                    </div>
-                    <div id="sku-loading" class="loading-indicator" style="display:none;">
-                        <div class="spinner"></div>
-                        <span>Fetching SKU data…</span>
-                    </div>
-                    <div id="sku-empty" class="empty-state-small">
-                        <p>Click <strong>Load SKUs</strong> to see VM SKU availability per zone for the selected region and subscription.</p>
-                    </div>
-                    <div id="sku-table-container" class="sku-table-container" style="display:none;"></div>
-                </div>
-            </section>
-            </div><!-- /planner-content -->
-        </div><!-- /page-planner -->
-    </main>
-</div>
-
-<footer class="app-footer">
-    <div class="footer-content">
-        <a href="https://github.com/lrivallain/az-mapping" target="_blank" rel="noopener" class="footer-link">
-            <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-            </svg>
-            lrivallain/az-mapping
+<!-- ===== Navbar ===== -->
+<nav class="navbar navbar-expand-sm bg-body-tertiary border-bottom">
+    <div class="container-fluid">
+        <a class="navbar-brand d-flex align-items-center gap-2" href="#">
+            <img src="{{ url_for('static', path='img/favicon.svg') }}" width="26" height="26" alt="">
+            <span>Azure AZ Mapping</span>
         </a>
-        <span class="footer-sep">·</span>
-        <span class="footer-license">MIT License</span>
+        <div class="d-flex align-items-center gap-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">
+                <i class="bi bi-moon-fill" id="icon-dark"></i>
+                <i class="bi bi-sun-fill d-none" id="icon-light"></i>
+            </button>
+            <a href="https://github.com/lrivallain/az-mapping" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary" title="GitHub">
+                <i class="bi bi-github"></i>
+            </a>
+        </div>
     </div>
-    <p class="footer-disclaimer">Independent Azure analysis tool. Not affiliated with Microsoft. Data is based on public Azure APIs and provided for informational purposes only. Microsoft does not guarantee availability, pricing, or deployment success.</p>
+</nav>
+
+<!-- ===== Main content ===== -->
+<div class="container-fluid mt-3 flex-grow-1 overflow-auto pb-4">
+
+    <!-- Shared selectors: Tenant + Region -->
+    <div class="row mb-2 g-2 align-items-center" id="selector-bar">
+        <div class="col-auto" id="tenant-section">
+            <div class="input-group input-group-sm">
+                <span class="input-group-text"><i class="bi bi-shield-lock"></i> Tenant</span>
+                <select class="form-select form-select-sm" id="tenant-select" style="max-width:320px;">
+                    <option value="">Loading tenants…</option>
+                </select>
+            </div>
+        </div>
+        <div class="col-auto">
+            <div class="position-relative" id="region-combobox">
+                <div class="input-group input-group-sm">
+                    <span class="input-group-text"><i class="bi bi-geo-alt"></i> Region</span>
+                    <input type="search" class="form-control form-control-sm" id="region-search"
+                           placeholder="Loading regions…" autocomplete="off" spellcheck="false" disabled
+                           style="min-width:240px;">
+                </div>
+                <input type="hidden" id="region-select" value="">
+                <ul class="dropdown-menu w-100" id="region-dropdown"></ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tabs -->
+    <ul class="nav nav-tabs" id="mainTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="topology-tab" data-bs-toggle="tab" data-bs-target="#tab-topology"
+                    type="button" role="tab" aria-controls="tab-topology" aria-selected="true">
+                <i class="bi bi-diagram-3"></i> AZ Topology
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="planner-tab" data-bs-toggle="tab" data-bs-target="#tab-planner"
+                    type="button" role="tab" aria-controls="tab-planner" aria-selected="false">
+                <i class="bi bi-grid-3x3-gap"></i> Deployment Planner
+            </button>
+        </li>
+    </ul>
+
+    <div class="tab-content" id="mainTabContent">
+
+        <!-- ====== AZ Topology Tab ====== -->
+        <div class="tab-pane fade show active" id="tab-topology" role="tabpanel" aria-labelledby="topology-tab">
+            <div class="card border-top-0 rounded-top-0">
+                <div class="card-body">
+                    <div class="row g-3">
+                        <!-- Left sidebar: subscriptions -->
+                        <div class="col-md-3 col-xl-2">
+                            <div class="topo-sidebar">
+                                <label class="form-label form-label-sm mb-1">
+                                    <i class="bi bi-collection"></i> Subscriptions
+                                </label>
+                                <div class="input-group input-group-sm mb-1">
+                                    <input type="search" class="form-control" id="topo-sub-filter"
+                                           placeholder="Filter…" autocomplete="off" spellcheck="false">
+                                    <button type="button" class="btn btn-outline-secondary" onclick="topoSelectAllVisible()" title="Select visible">
+                                        <i class="bi bi-check-all"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-outline-secondary" onclick="topoDeselectAll()" title="Clear all">
+                                        <i class="bi bi-x-lg"></i>
+                                    </button>
+                                </div>
+                                <div id="topo-sub-list" class="subscription-checklist"></div>
+                                <div class="d-flex justify-content-between align-items-center mt-2">
+                                    <small class="text-body-secondary" id="topo-sub-count">0 selected</small>
+                                    <button type="button" class="btn btn-primary btn-sm" id="topo-load-btn" onclick="loadMappings()" disabled>
+                                        <i class="bi bi-arrow-repeat"></i> Load
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Right content: results -->
+                        <div class="col-md-9 col-xl-10">
+                            <!-- Error -->
+                            <div id="topo-error" class="alert alert-danger alert-sm d-none" role="alert"></div>
+
+                            <!-- Empty state -->
+                            <div id="topo-empty" class="text-center text-body-secondary py-5">
+                                <i class="bi bi-diagram-3 fs-1 d-block mb-2"></i>
+                                <p>Select subscriptions and click <strong>Load</strong>.</p>
+                            </div>
+
+                            <!-- Loading -->
+                            <div id="topo-loading" class="text-center py-5 d-none">
+                                <div class="spinner-border text-primary" role="status"></div>
+                                <p class="mt-2 text-body-secondary">Fetching zone mappings…</p>
+                            </div>
+
+                            <!-- Results -->
+                            <div id="topo-results" class="d-none">
+                                <!-- Graph -->
+                                <div class="card mb-3">
+                                    <div class="card-header d-flex justify-content-between align-items-center">
+                                        <span><i class="bi bi-diagram-3"></i> Zone Mapping Graph</span>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="exportGraphPNG()" title="Export as PNG">
+                                            <i class="bi bi-download"></i> PNG
+                                        </button>
+                                    </div>
+                                    <div class="card-body">
+                                        <div id="graph-container" class="graph-container mx-auto"></div>
+                                        <div id="graph-legend" class="d-flex flex-wrap gap-3 mt-2 justify-content-center"></div>
+                                    </div>
+                                </div>
+
+                                <!-- Table -->
+                                <div class="card">
+                                    <div class="card-header d-flex justify-content-between align-items-center">
+                                        <span><i class="bi bi-table"></i> Zone Mapping Table</span>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="exportTableCSV()" title="Export as CSV">
+                                            <i class="bi bi-download"></i> CSV
+                                        </button>
+                                    </div>
+                                    <div class="card-body">
+                                        <div id="table-container" class="table-responsive"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- ====== Deployment Planner Tab ====== -->
+        <div class="tab-pane fade" id="tab-planner" role="tabpanel" aria-labelledby="planner-tab">
+            <div class="card border-top-0 rounded-top-0">
+                <div class="card-body">
+                    <!-- Controls row -->
+                    <div class="row g-2 align-items-end mb-3">
+                        <div class="col-md-3 col-lg-3">
+                            <label for="planner-sub-search" class="form-label form-label-sm mb-1">
+                                <i class="bi bi-collection"></i> Subscription
+                            </label>
+                            <div class="position-relative" id="planner-sub-combobox">
+                                <input type="search" class="form-control form-control-sm" id="planner-sub-search"
+                                       placeholder="Loading subscriptions…" autocomplete="off" spellcheck="false" disabled>
+                                <input type="hidden" id="planner-sub-select" value="">
+                                <ul class="dropdown-menu w-100" id="planner-sub-dropdown"></ul>
+                            </div>
+                        </div>
+                        <div class="col-auto">
+                            <div class="form-check form-switch mt-1">
+                                <input class="form-check-input" type="checkbox" id="planner-include-prices">
+                                <label class="form-check-label small" for="planner-include-prices">Prices</label>
+                            </div>
+                        </div>
+                        <div class="col-auto">
+                            <select class="form-select form-select-sm" id="planner-currency" title="Currency" style="width:80px;">
+                                <option value="USD" selected>USD</option>
+                                <option value="EUR">EUR</option>
+                                <option value="GBP">GBP</option>
+                                <option value="JPY">JPY</option>
+                                <option value="AUD">AUD</option>
+                                <option value="CAD">CAD</option>
+                                <option value="CHF">CHF</option>
+                                <option value="SEK">SEK</option>
+                                <option value="BRL">BRL</option>
+                                <option value="INR">INR</option>
+                            </select>
+                        </div>
+                        <div class="col-auto">
+                            <button type="button" class="btn btn-primary btn-sm" id="planner-load-btn" onclick="loadSkus()" disabled>
+                                <i class="bi bi-arrow-repeat"></i> Load SKUs
+                            </button>
+                        </div>
+                        <div class="col d-none" id="planner-csv-btn">
+                            <div class="d-flex justify-content-end">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="exportSkuCSV()" title="Export as CSV">
+                                    <i class="bi bi-download"></i> CSV
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Error -->
+                    <div id="planner-error" class="alert alert-danger alert-sm d-none" role="alert"></div>
+
+                    <!-- Empty state -->
+                    <div id="planner-empty" class="text-center text-body-secondary py-5">
+                        <i class="bi bi-grid-3x3-gap fs-1 d-block mb-2"></i>
+                        <p>Select a subscription, then click <strong>Load SKUs</strong>.</p>
+                    </div>
+
+                    <!-- Loading -->
+                    <div id="planner-loading" class="text-center py-5 d-none">
+                        <div class="spinner-border text-primary" role="status"></div>
+                        <p class="mt-2 text-body-secondary">Fetching SKU data…</p>
+                    </div>
+
+                    <!-- SKU results -->
+                    <div id="planner-results" class="d-none">
+                        <div id="sku-table-container"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div><!-- /tab-content -->
+</div><!-- /container -->
+
+<!-- ===== Footer ===== -->
+<footer class="border-top py-2 text-center small text-body-secondary mt-auto">
+    <span>MIT License</span> ·
+    <span>Independent Azure analysis tool — not affiliated with Microsoft.</span>
 </footer>
 
-<!-- Spot Score Modal -->
-<div class="modal-overlay" id="spot-modal" style="display:none;" onclick="closeSpotModal(event)">
-    <div class="modal-dialog" onclick="event.stopPropagation()">
-        <h3>Spot Placement Score</h3>
-        <p class="modal-sku-name" id="spot-modal-sku"></p>
-        <label for="spot-modal-instances">Number of instances:</label>
-        <input type="number" id="spot-modal-instances" value="1" min="1" max="1000" class="spot-instance-input">
-        <div class="modal-actions">
-            <button type="button" class="primary-btn" onclick="confirmSpotScore()">Get Score</button>
-            <button type="button" class="secondary-btn" onclick="closeSpotModal()">Cancel</button>
+<!-- ===== Spot Score Modal ===== -->
+<div class="modal fade" id="spotModal" tabindex="-1" aria-labelledby="spotModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="spotModalLabel">Spot Placement Score</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="fw-semibold mb-2" id="spot-modal-sku"></p>
+                <label for="spot-modal-instances" class="form-label small">Number of instances:</label>
+                <input type="number" class="form-control form-control-sm mb-3" id="spot-modal-instances" value="1" min="1" max="1000">
+                <div id="spot-modal-loading" class="text-center d-none">
+                    <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                    <span class="ms-2 small">Fetching score…</span>
+                </div>
+                <div id="spot-modal-result" class="d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary btn-sm" onclick="confirmSpotScore()">Get Score</button>
+            </div>
         </div>
-        <div id="spot-modal-loading" class="loading-indicator" style="display:none;">
-            <div class="spinner"></div>
-            <span>Fetching score…</span>
-        </div>
-        <div id="spot-modal-result" style="display:none;"></div>
     </div>
 </div>
 
-<!-- SKU Pricing Detail Modal -->
-<div class="modal-overlay" id="pricing-modal" style="display:none;" onclick="closePricingModal(event)">
-    <div class="modal-dialog pricing-modal-dialog" onclick="event.stopPropagation()">
-        <div class="pricing-modal-header">
-            <h3>SKU Pricing Detail</h3>
-            <button type="button" class="modal-close-btn" onclick="closePricingModal()" title="Close">&times;</button>
+<!-- ===== Pricing Detail Modal ===== -->
+<div class="modal fade" id="pricingModal" tabindex="-1" aria-labelledby="pricingModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="pricingModalLabel">SKU Pricing Detail</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="fw-semibold" id="pricing-modal-sku"></p>
+                <div class="mb-3">
+                    <label for="pricing-modal-currency-select" class="form-label small">Currency:</label>
+                    <select class="form-select form-select-sm" id="pricing-modal-currency-select" onchange="refreshPricingModal()" style="width:100px;">
+                        <option value="USD" selected>USD</option>
+                        <option value="EUR">EUR</option>
+                        <option value="GBP">GBP</option>
+                        <option value="JPY">JPY</option>
+                        <option value="AUD">AUD</option>
+                        <option value="CAD">CAD</option>
+                        <option value="CHF">CHF</option>
+                        <option value="SEK">SEK</option>
+                        <option value="BRL">BRL</option>
+                        <option value="INR">INR</option>
+                    </select>
+                </div>
+                <div id="pricing-modal-loading" class="text-center d-none">
+                    <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                    <span class="ms-2 small">Fetching prices…</span>
+                </div>
+                <div id="pricing-modal-content" class="d-none"></div>
+            </div>
         </div>
-        <p class="modal-sku-name" id="pricing-modal-sku"></p>
-        <div class="pricing-modal-currency">
-            <label for="pricing-modal-currency-select">Currency:</label>
-            <select id="pricing-modal-currency-select" class="sku-currency-select" onchange="refreshPricingModal()">
-                <option value="USD" selected>USD</option>
-                <option value="EUR">EUR</option>
-                <option value="GBP">GBP</option>
-                <option value="JPY">JPY</option>
-                <option value="AUD">AUD</option>
-                <option value="CAD">CAD</option>
-                <option value="CHF">CHF</option>
-                <option value="SEK">SEK</option>
-                <option value="BRL">BRL</option>
-                <option value="INR">INR</option>
-            </select>
-        </div>
-        <div id="pricing-modal-loading" class="loading-indicator" style="display:none;">
-            <div class="spinner"></div>
-            <span>Fetching prices…</span>
-        </div>
-        <div id="pricing-modal-content" style="display:none;"></div>
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/simple-datatables@9/dist/umd/simple-datatables.js"></script>
 <script src="{{ url_for('static', path='js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

- Decouple Planner tab from Topology (independent zone mapping fetch)
- Rewrite frontend from custom CSS to Bootstrap 5.3.8 with dark/light theme
- Replace sidebar layout with shared selector bar and Bootstrap tabs
- Add Simple-DataTables for SKU table (sorting, per-column filtering)
- Use Bootstrap tooltips with instant display for zone icons and confidence info

## Related issue

Closes #6 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-mapping` or `uv run az-mapping`)
- [ ] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
