### PR TITLE
feat: preload tenant list at startup with TTL cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,16 @@ def _clear_usage_cache():
 
 
 @pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    """Clear the discovery cache between tests."""
+    from az_mapping.azure_api import _discovery_cache
+
+    _discovery_cache.clear()
+    yield
+    _discovery_cache.clear()
+
+
+@pytest.fixture(autouse=True)
 def _clear_spot_cache():
     """Clear the spot placement scores cache between tests."""
     from az_mapping.azure_api import _spot_cache


### PR DESCRIPTION
## Description

Add a 5-minute TTL cache for list_tenants() and preload it in a background thread during FastAPI lifespan startup, so the first browser request gets an instant tenant list.

- Loading time for tenant + (subs/regions) was ~10s before
- **Now:** 12ms for tenant + 3.5s for (subs/regions): **3.6s**

## Related issue

Closes #13

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-mapping` or `uv run az-mapping`)
- [ ] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<!-- If applicable, add screenshots showing the change. -->
