### PR TITLE
feat: add VS Code devcontainer and tasks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# Dev container for az-scout
+# Based on the official Python devcontainer image (Debian)
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+# Install extra system tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        jq \
+        make \
+        unzip \
+        ripgrep \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (fast Python package manager)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+  "name": "az-scout",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {}
+  },
+  "forwardPorts": [5001],
+  "portsAttributes": {
+    "5001": {
+      "label": "az-scout web UI",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "uv sync --frozen",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker",
+        "ms-azuretools.vscode-azureresourcegroups",
+        "redhat.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": ".venv/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["tests"],
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,60 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Backend: install",
+      "type": "shell",
+      "command": "uv sync --frozen",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend: run",
+      "type": "shell",
+      "command": "uv run az-scout web --host 0.0.0.0 --port 5001 --reload --no-open -v",
+      "group": "build",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend: test",
+      "type": "shell",
+      "command": "uv run pytest",
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend: lint",
+      "type": "shell",
+      "command": "uv run ruff check src/ tests/",
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend: format check",
+      "type": "shell",
+      "command": "uv run ruff format --check src/ tests/",
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backend: type check",
+      "type": "shell",
+      "command": "uv run mypy src/",
+      "group": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "Dev: run all checks",
+      "dependsOn": [
+        "Backend: lint",
+        "Backend: format check",
+        "Backend: type check",
+        "Backend: test"
+      ],
+      "dependsOrder": "sequence",
+      "group": "test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -73,6 +73,42 @@ docker run --rm -p 8000:8000 \
   ghcr.io/lrivallain/az-scout:latest
 ```
 
+### Dev Container
+
+The repository includes a [Dev Container](https://containers.dev/) configuration for a one-click development environment with all tools pre-installed.
+
+#### Prerequisites
+
+- [Docker](https://www.docker.com/) running locally
+- [VS Code](https://code.visualstudio.com/) with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+
+#### Getting started
+
+1. Clone the repository and open it in VS Code.
+2. When prompted, click **"Reopen in Container"** — or run the command **Dev Containers: Reopen in Container** from the Command Palette (`Ctrl+Shift+P`).
+3. Wait for the container to build and dependencies to install (first time only).
+4. Start the server:
+
+   ```bash
+   # Via VS Code task (Terminal → Run Task → "Backend: run")
+   # Or from the terminal:
+   uv run az-scout web --host 0.0.0.0 --port 5001 --reload --no-open -v
+   ```
+
+5. Open http://localhost:5001 in your browser.
+
+#### What's included
+
+| Category | Details |
+|---|---|
+| **Python** | 3.12 + `uv` package manager |
+| **System tools** | git, curl, jq, make, unzip, ripgrep |
+| **Azure CLI** | Pre-installed via devcontainer feature |
+| **VS Code extensions** | Python, Pylance, Ruff, Docker, Azure, GitLens, Copilot |
+| **Tasks** | `Backend: run`, `Backend: test`, `Backend: lint`, `Dev: run all checks` |
+
+> **Note:** Azure authentication is **not required** to build or run tests. Use `az login` inside the container when you need to query live Azure data.
+
 ### Azure Container App
 
 It is also possible to deploy az-scout as a web app in Azure using the provided Bicep template (see [Deploy to Azure](#deploy-to-azure-container-app) section below).


### PR DESCRIPTION
## Summary

Add a Dev Container configuration for one-click development environment setup.

## Changes

- **`.devcontainer/Dockerfile`**: Based on `mcr.microsoft.com/devcontainers/python:3.12` with `uv`, `jq`, `make`, `unzip`, `ripgrep`
- **`.devcontainer/devcontainer.json`**: Azure CLI feature, port forwarding (5001), VS Code extensions (Python, Pylance, Ruff, Docker, Azure, GitLens, Copilot), editor settings
- **`.vscode/tasks.json`**: Tasks for install, run (with `--reload`), test, lint, format check, type check, and `Dev: run all checks`
- **`README.md`**: Added "Dev Container" quickstart section

## Details

- Image: `mcr.microsoft.com/devcontainers/python:3.12` (lightweight, Debian-based)
- `postCreateCommand`: `uv sync --frozen` — installs all deps automatically
- No Node.js needed (vanilla JS frontend served by FastAPI)
- Azure CLI installed but optional — tests run with mocks
- Does not break execution outside the devcontainer