### PR TITLE
feat: Added a planner assistant, driven by AI and MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
   - Pin-to-side mode docks the chat as a resizable sidebar.
   - Tenant and region context auto-injected into tool calls; `switch_tenant`/`switch_region` tools update the UI.
   - Conversation persistence, input history (Up/Down arrows), error retry, and suggested prompts on start.
+- **Planner chat mode** – pill-style toggle in the chat panel header switches between *Assistant* (general Q&A)
+  and *Planner* (guided deployment advisor). The planner follows three independent planning paths
+  (region selection, SKU selection, zone selection) and relies on the model's built-in knowledge of
+  Azure VM families and best practices alongside live tool data.
+  - Per-mode conversation state (messages, input history) persisted independently to `localStorage`.
 - Numeric operator filters on SKU table columns (`>`, `>=`, `<`, `<=`, `=`, ranges).
 
 ## [2026.2.7] - 2026-02-20

--- a/src/az_scout/app.py
+++ b/src/az_scout/app.py
@@ -436,8 +436,10 @@ class ChatRequest(BaseModel):
     """Request body for the chat endpoint."""
 
     messages: list[ChatMessage]
+    mode: str = "discussion"
     tenant_id: str | None = None
     region: str | None = None
+    subscription_id: str | None = None
 
 
 @app.post(
@@ -462,7 +464,13 @@ async def chat(body: ChatRequest) -> StreamingResponse:
 
     messages = [{"role": m.role, "content": m.content} for m in body.messages]
     return StreamingResponse(
-        chat_stream(messages, tenant_id=body.tenant_id, region=body.region),
+        chat_stream(
+            messages,
+            tenant_id=body.tenant_id,
+            region=body.region,
+            subscription_id=body.subscription_id,
+            mode=body.mode,
+        ),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/src/az_scout/services/ai_chat.py
+++ b/src/az_scout/services/ai_chat.py
@@ -11,14 +11,16 @@ Requires environment variables:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import os
+import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from az_scout import azure_api
-from az_scout.services.capacity_confidence import compute_capacity_confidence
+from az_scout.mcp_server import mcp as _mcp_server
 
 logger = logging.getLogger(__name__)
 
@@ -74,15 +76,160 @@ automatically. Future tool calls will use the new tenant.
 - **Region context:** When the user mentions a region or asks to switch region, call \
 `switch_region` with the region **name** (e.g. `eastus`, `francecentral`). This updates \
 the region selector in the UI. You can call `list_regions` first to find valid names.
+- **Logical vs physical zones:** Azure Availability Zone numbers (1, 2, 3) are \
+**logical** — they map to different physical datacenters in each subscription. \
+Tools like `get_sku_availability` return **logical** zone numbers for a given \
+subscription. When discussing zone recommendations, **always** call \
+`get_zone_mappings` to also show the physical zone mapping and present both \
+(e.g. "logical zone 2 → physical zone 1"). This avoids confusion since the same \
+logical number points to different physical zones across subscriptions.
+"""
+
+# ---------------------------------------------------------------------------
+# Planner system prompt  (directive, guided flow)
+# ---------------------------------------------------------------------------
+
+PLANNER_SYSTEM_PROMPT = """\
+You are **Azure Scout Planner**, a deployment planning assistant embedded in the \
+Azure Scout web tool. You help users answer **one specific planning question** \
+about **VM-based workloads** — not an end-to-end deployment plan.
+
+You are **directive**: you drive the conversation, ask structured questions, and \
+make concrete recommendations based on live Azure data and documentation. Do NOT \
+wait passively — after each user answer, immediately proceed.
+
+## Scope
+
+You focus exclusively on **virtual machine** workloads (IaaS VMs, Azure Batch, \
+Spot VMs, scale sets, etc.). If the user asks about PaaS services, politely \
+redirect to the Discussion mode.
+
+## Planning paths
+
+The user will pick **one** of these goals. Focus on that goal only.
+
+### Path A – Find the best **region** for a VM workload
+Decision criteria:
+- **Capacity**: Is the desired SKU family available in the region? How many \
+  zones offer it? Any restrictions?
+- **Headroom for scale**: Are there enough zones with unrestricted capacity \
+  to handle future growth?
+- **Geo constraints**: Data residency, sovereignty, compliance requirements \
+  (e.g. EU-only, specific country).
+- **Latency**: Proximity to end users or dependent services.
+- **SKU availability**: Confirm the target SKU (or compatible alternatives) \
+  exists in the candidate regions.
+
+Steps:
+1. Ask the workload type, desired SKU family or hardware specs, and any geo / \
+   latency / compliance constraints.
+2. Call `list_regions` to enumerate AZ-enabled regions.
+3. For the top candidate regions, call `get_sku_availability` with appropriate \
+   filters — this is the **primary source** for verifying capacity, zone count, \
+   and restrictions per region.
+4. Use your knowledge of Azure VM families to recommend the right family for \
+   the workload (e.g. M-series for SAP, NC/ND-series for ML, HB-series for HPC).
+5. Present a comparison table (3–5 regions) with SKU availability, zone count, \
+   restrictions, and reasoning.
+
+### Path B – Find the right **VM SKU** in a given region
+Decision criteria:
+- **Hardware requirements**: vCPU count, memory, GPU, accelerated networking, \
+  disk throughput, temp storage — query live data first via `get_sku_availability` \
+  (returns full capabilities per SKU) and `get_sku_pricing_detail` (includes a \
+  `profile` with all ARM capabilities when a `subscription_id` is provided). \
+  Use your built-in knowledge of Azure VM families for workload-specific guidance \
+  (e.g. M-series for SAP, NC/ND-series for ML training, HB-series for HPC).
+
+**ARM SKU naming convention**: Azure ARM names follow the pattern \
+  `Standard_<Family><vCPUs><features>_v<gen>` (e.g. `Standard_FX48mds_v2`). \
+  When a user says "FX48-v2" or "D4s v5", the name filter is **fuzzy** — \
+  use whatever the user typed and it will match (e.g. `name: "FX48-v2"` \
+  matches `Standard_FX48mds_v2`). **Important**: always call `get_sku_availability` \
+  first to discover correct ARM names, then use those exact names for \
+  `get_sku_pricing_detail` and `get_spot_scores`.
+- **Capacity**: Zone availability, restrictions, and confidence score.
+- **Price**: Hourly cost (pay-as-you-go), and whether Spot or Azure Batch \
+  pricing is attractive.
+- **Spot / Batch eligibility**: Whether the SKU supports Spot VMs (check \
+  spot scores / eviction rates) or is available in Azure Batch pools.
+
+Steps:
+1. Ask what the VM will run, hardware needs (vCPU, memory, GPU, etc.), budget \
+   sensitivity, and whether Spot or Batch is acceptable. The region should \
+   already be selected or ask the user to specify one.
+2. Call `get_sku_availability` with filters (vCPU range, memory range, family) \
+   and **always set `include_prices: true`** — without this flag, NO pricing \
+   data is returned. This is the **primary source** for SKU specs, zone data, \
+   restrictions, quota, and pricing.
+3. **Sort results by PAYGO price** (ascending) and present the **cheapest 5** \
+   that meet the user's requirements. Do NOT cherry-pick or skip cheaper SKUs \
+   in favour of more "premium" ones — always include the lowest-price options. \
+   When the user asks "cheapest", you MUST scan ALL results from the tool, not \
+   just the ones you previously presented.
+4. For specific SKUs, call `get_sku_pricing_detail` with a `subscription_id` \
+   to get the full ARM profile (all capabilities) plus Spot/Reserved/Savings \
+   Plan prices. **Never call this tool with a user-friendly name like "M128" — \
+   always call `get_sku_availability` first** to discover the exact ARM names.
+5. If Spot is mentioned or relevant, **always** call `get_spot_scores` for the \
+   short-listed SKUs — never assume a SKU lacks Spot scores without checking.
+6. Present a comparison table (up to 5 SKUs) sorted by price, with specs, \
+   pricing, spot eviction rate (if applicable), confidence score, and zones.
+7. When a user mentions a SKU you haven't looked up yet (e.g. "M128 seems \
+   cheaper"), **always call `get_sku_availability`** with a name filter \
+   (e.g. `name: "M128"`) to discover and price it — never say it's unavailable \
+   without first querying live data.
+
+### Path C – Pick the best **zone** for a VM SKU
+1. The user already knows which SKU and region they want. Ask if not provided.
+2. Call `get_sku_availability` to check per-zone capacity and restrictions. \
+   The `zones` field lists **logical** zone numbers (subscription-specific). \
+   The `restrictions` field lists logical zones where deployment is restricted.
+3. **Always** call `get_zone_mappings` with the same region and subscription to \
+   translate logical zones to physical zones. Present **both** in a table so the \
+   user can see the mapping (e.g. "logical 2 → physical 1").
+4. If Spot is mentioned or relevant, **always** call `get_spot_scores` — never \
+   assume a SKU lacks Spot scores without checking.
+5. Recommend the best zone(s) based on availability, restrictions, quota, \
+   confidence score, and spot eviction rate. In the recommendation and summary, \
+   always show both logical and physical zone numbers.
+
+## Guidelines
+
+- Be concise and factual. Use Markdown tables for comparisons.
+- At each decision point, present options as `[[option text]]` on their own bullet \
+  lines. The UI renders these as clickable chips. Limit to 4–6 options.
+- Use your built-in knowledge of Azure VM families and best practices to ground \
+  recommendations (e.g. which families suit SAP, ML, HPC, web workloads).
+- Prices are per hour, Linux, from the Azure Retail Prices API.
+- Confidence scores range 0–100 (High ≥80, Medium ≥60, Low ≥40, Very Low <40).
+- **Subscription resolution:** Tools require subscription **IDs** (UUIDs), not display \
+  names. When the user provides a name, call `list_subscriptions` to resolve the ID.
+- **Tenant context:** The user's selected tenant ID is provided as context. All tool \
+  calls automatically use this tenant.
+- **Region context:** When the user picks a region, call `switch_region` to update \
+  the UI, then use that region in subsequent tool calls.
+- **Logical vs physical zones:** Zone numbers from `get_sku_availability` are \
+  **logical** (subscription-specific). **Always** call `get_zone_mappings` to \
+  translate to physical zones and present both to the user (e.g. "logical 2 → \
+  physical 1"). Never show only logical zone numbers without the physical mapping.
+- **Spot scores:** Never assume a VM SKU lacks Spot Placement Scores. The \
+  `get_spot_scores` tool works for any SKU. Always call it when discussing \
+  Spot VMs rather than guessing availability.
+- If the user deviates or asks a side question, answer it briefly, then steer back.
+- When done, present a clear summary of the recommendation.
 """
 
 
 def _build_system_prompt(
     tenant_id: str | None = None,
     region: str | None = None,
+    subscription_id: str | None = None,
+    *,
+    mode: str = "discussion",
 ) -> str:
-    """Build the system prompt, optionally including tenant and region context."""
-    prompt = SYSTEM_PROMPT
+    """Build the system prompt, optionally including tenant, region and subscription context."""
+    prompt = PLANNER_SYSTEM_PROMPT if mode == "planner" else SYSTEM_PROMPT
     if tenant_id:
         prompt += (
             f"\n\nCurrent tenant context: The user has selected tenant ID "
@@ -101,221 +248,65 @@ def _build_system_prompt(
             f"`{region}` in the UI. Tool calls that accept a `region` parameter "
             f"will automatically use this region unless you specify a different one."
         )
+    if subscription_id:
+        prompt += (
+            f"\n\nCurrent subscription context: The user has selected subscription "
+            f"ID `{subscription_id}` in the UI. Use this subscription ID for tool "
+            f"calls that require a `subscription_id` parameter, unless the user "
+            f"explicitly asks you to use a different one."
+        )
     return prompt
 
 
 # ---------------------------------------------------------------------------
-# Tool definitions (OpenAI function-calling format)
+# MCP → OpenAI tool conversion
 # ---------------------------------------------------------------------------
 
-TOOL_DEFINITIONS: list[dict[str, Any]] = [
-    {
-        "type": "function",
-        "function": {
-            "name": "list_tenants",
-            "description": (
-                "List Azure AD tenants accessible by the current credential, "
-                "with authentication status and default tenant ID."
-            ),
-            "parameters": {"type": "object", "properties": {}, "required": []},
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "list_subscriptions",
-            "description": "List enabled Azure subscriptions, sorted alphabetically.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Optional tenant ID to scope the query.",
-                    },
-                },
-                "required": [],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "list_regions",
-            "description": "List Azure regions that support Availability Zones.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "subscription_id": {
-                        "type": "string",
-                        "description": "Subscription ID. Auto-discovered if omitted.",
-                    },
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Optional tenant ID.",
-                    },
-                },
-                "required": [],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "get_zone_mappings",
-            "description": (
-                "Get logical-to-physical Availability Zone mappings for a region. "
-                "Shows how each subscription maps logical zone numbers to physical zones."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "region": {
-                        "type": "string",
-                        "description": "Azure region name (e.g. eastus).",
-                    },
-                    "subscription_ids": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "List of subscription IDs to query.",
-                    },
-                    "tenant_id": {
-                        "type": "string",
-                        "description": "Optional tenant ID.",
-                    },
-                },
-                "required": ["region", "subscription_ids"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "get_sku_availability",
-            "description": (
-                "Get VM SKU availability per zone for a region and subscription. "
-                "Returns SKUs with zone availability, restrictions, capabilities, "
-                "quotas, and optionally pricing and confidence scores. "
-                "Use filter parameters to reduce output size."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "region": {
-                        "type": "string",
-                        "description": "Azure region name (e.g. eastus).",
-                    },
-                    "subscription_id": {
-                        "type": "string",
-                        "description": "Subscription ID to query.",
-                    },
-                    "tenant_id": {"type": "string", "description": "Optional tenant ID."},
-                    "resource_type": {
-                        "type": "string",
-                        "description": "ARM resource type (default: virtualMachines).",
-                        "default": "virtualMachines",
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": (
-                            "Substring filter on SKU name (case-insensitive). "
-                            "E.g. 'D2s' matches Standard_D2s_v3."
-                        ),
-                    },
-                    "family": {
-                        "type": "string",
-                        "description": "Substring filter on SKU family (case-insensitive).",
-                    },
-                    "min_vcpus": {
-                        "type": "integer",
-                        "description": "Minimum vCPU count (inclusive).",
-                    },
-                    "max_vcpus": {
-                        "type": "integer",
-                        "description": "Maximum vCPU count (inclusive).",
-                    },
-                    "min_memory_gb": {
-                        "type": "number",
-                        "description": "Minimum memory in GB (inclusive).",
-                    },
-                    "max_memory_gb": {
-                        "type": "number",
-                        "description": "Maximum memory in GB (inclusive).",
-                    },
-                    "include_prices": {
-                        "type": "boolean",
-                        "description": "Include retail pricing (default: false).",
-                        "default": False,
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code for prices (default: USD).",
-                        "default": "USD",
-                    },
-                },
-                "required": ["region", "subscription_id"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "get_spot_scores",
-            "description": (
-                "Get Spot Placement Scores for VM sizes in a region. "
-                "Returns High / Medium / Low score per VM size."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "region": {"type": "string", "description": "Azure region name."},
-                    "subscription_id": {"type": "string", "description": "Subscription ID."},
-                    "vm_sizes": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "List of VM size names.",
-                    },
-                    "instance_count": {
-                        "type": "integer",
-                        "description": "Number of instances (default: 1).",
-                        "default": 1,
-                    },
-                    "tenant_id": {"type": "string", "description": "Optional tenant ID."},
-                },
-                "required": ["region", "subscription_id", "vm_sizes"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "get_sku_pricing_detail",
-            "description": (
-                "Get detailed Linux pricing for a single VM SKU. "
-                "Returns PAYGO, Spot, Reserved (1Y/3Y), and Savings Plan (1Y/3Y) prices per hour."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "region": {"type": "string", "description": "Azure region name."},
-                    "sku_name": {
-                        "type": "string",
-                        "description": "ARM SKU name (e.g. Standard_D2s_v5).",
-                    },
-                    "currency_code": {
-                        "type": "string",
-                        "description": "Currency code (default: USD).",
-                        "default": "USD",
-                    },
-                    "subscription_id": {
-                        "type": "string",
-                        "description": "Optional subscription ID for VM profile data.",
-                    },
-                    "tenant_id": {"type": "string", "description": "Optional tenant ID."},
-                },
-                "required": ["region", "sku_name"],
-            },
-        },
-    },
+# Lazily built registry of MCP tools keyed by name
+_mcp_tool_registry: dict[str, Any] | None = None
+
+
+def _get_mcp_tools() -> dict[str, Any]:
+    """Return a dict of MCP tool name → Tool object, built lazily."""
+    global _mcp_tool_registry  # noqa: PLW0603
+    if _mcp_tool_registry is None:
+        _mcp_tool_registry = {t.name: t for t in _mcp_server._tool_manager.list_tools()}
+    return _mcp_tool_registry
+
+
+def _mcp_schema_to_openai(params: dict[str, Any]) -> dict[str, Any]:
+    """Convert a FastMCP parameter JSON Schema to OpenAI function-calling format.
+
+    Strips ``title`` fields and converts ``anyOf`` nullable unions to simple types.
+    """
+    properties: dict[str, Any] = {}
+    for key, schema in params.get("properties", {}).items():
+        prop: dict[str, Any] = {}
+        if "anyOf" in schema:
+            # Extract the non-null type from anyOf: [{type: X}, {type: null}]
+            real_types = [t for t in schema["anyOf"] if t.get("type") != "null"]
+            if real_types:
+                prop["type"] = real_types[0]["type"]
+        else:
+            if "type" in schema:
+                prop["type"] = schema["type"]
+        if "default" in schema and schema["default"] is not None:
+            prop["default"] = schema["default"]
+        if "items" in schema:
+            prop["items"] = schema["items"]
+        if "description" in schema:
+            prop["description"] = schema["description"]
+        properties[key] = prop
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": params.get("required", []),
+    }
+
+
+# Chat-only tool definitions (these tools exist only in the chat context,
+# not in the MCP server — they control the web UI, not Azure APIs).
+_CHAT_ONLY_TOOLS: list[dict[str, Any]] = [
     {
         "type": "function",
         "function": {
@@ -360,9 +351,53 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     },
 ]
 
+
+def _build_openai_tools() -> list[dict[str, Any]]:
+    """Build OpenAI function-calling tool definitions from MCP tools + chat-only tools."""
+    tools: list[dict[str, Any]] = []
+
+    for name, mcp_tool in _get_mcp_tools().items():
+        description = mcp_tool.description
+        params = _mcp_schema_to_openai(mcp_tool.parameters)
+
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": params,
+                },
+            }
+        )
+
+    tools.extend(_CHAT_ONLY_TOOLS)
+    return tools
+
+
+TOOL_DEFINITIONS: list[dict[str, Any]] = _build_openai_tools()
+
 # ---------------------------------------------------------------------------
 # Tool execution dispatcher
 # ---------------------------------------------------------------------------
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
+
+
+def _validate_subscription_id(value: str | None, param: str = "subscription_id") -> str | None:
+    """Return an error JSON string if *value* is not a valid UUID, else None."""
+    if value and not _UUID_RE.match(value):
+        return json.dumps(
+            {
+                "error": f"'{param}' must be a subscription UUID "
+                f"(e.g. 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'), "
+                f"not a display name. You provided: '{value}'. "
+                f"Call `list_subscriptions` first to resolve the name to an ID."
+            }
+        )
+    return None
 
 
 def _get_tool_params(tool_name: str) -> set[str]:
@@ -373,137 +408,161 @@ def _get_tool_params(tool_name: str) -> set[str]:
     return set()
 
 
-def _execute_tool(name: str, arguments: dict[str, Any]) -> str:
-    """Execute a tool by name and return the JSON result string."""
+def _truncate_tool_result(result: str) -> str:
+    """Truncate a tool result string to fit within the context budget.
+
+    For JSON arrays (e.g. SKU lists), keeps only the first N items that fit
+    within ``_MAX_TOOL_RESULT_CHARS`` and appends a count of omitted items.
+    For other results, a simple character truncation is applied.
+    """
+    if len(result) <= _MAX_TOOL_RESULT_CHARS:
+        return result
+
+    # Try smart truncation for JSON arrays
     try:
-        if name == "list_tenants":
-            return json.dumps(azure_api.list_tenants(), indent=2)
+        data = json.loads(result)
+    except (json.JSONDecodeError, ValueError):
+        return result[:_MAX_TOOL_RESULT_CHARS] + "\n… (truncated)"
 
-        elif name == "list_subscriptions":
-            return json.dumps(
-                azure_api.list_subscriptions(arguments.get("tenant_id")),
-                indent=2,
+    if isinstance(data, list) and len(data) > 1:
+        # Keep items until we approach the budget
+        kept: list[Any] = []
+        current_len = 2  # for "[]"
+        for item in data:
+            item_json = json.dumps(item)
+            # +3 for ", " separator and safety margin
+            if current_len + len(item_json) + 3 > _MAX_TOOL_RESULT_CHARS - 200:
+                break
+            kept.append(item)
+            current_len += len(item_json) + 2  # ", "
+        omitted = len(data) - len(kept)
+        truncated = json.dumps(kept, indent=2)
+        if omitted > 0:
+            truncated += (
+                f"\n\n// {omitted} more items omitted "
+                f"(total: {len(data)}). Use filters to narrow results."
             )
+        return truncated
 
-        elif name == "list_regions":
-            return json.dumps(
-                azure_api.list_regions(
-                    arguments.get("subscription_id"),
-                    arguments.get("tenant_id"),
-                ),
-                indent=2,
-            )
+    # Non-array JSON or single item — just truncate
+    return result[:_MAX_TOOL_RESULT_CHARS] + "\n… (truncated)"
 
-        elif name == "get_zone_mappings":
-            return json.dumps(
-                azure_api.get_mappings(
-                    arguments["region"],
-                    arguments["subscription_ids"],
-                    arguments.get("tenant_id"),
-                ),
-                indent=2,
-            )
 
-        elif name == "get_sku_availability":
-            skus = azure_api.get_skus(
-                arguments["region"],
-                arguments["subscription_id"],
-                arguments.get("tenant_id"),
-                arguments.get("resource_type", "virtualMachines"),
-                name=arguments.get("name"),
-                family=arguments.get("family"),
-                min_vcpus=arguments.get("min_vcpus"),
-                max_vcpus=arguments.get("max_vcpus"),
-                min_memory_gb=arguments.get("min_memory_gb"),
-                max_memory_gb=arguments.get("max_memory_gb"),
-            )
-            azure_api.enrich_skus_with_quotas(
-                skus,
-                arguments["region"],
-                arguments["subscription_id"],
-                arguments.get("tenant_id"),
-            )
-            include_prices = arguments.get("include_prices", False)
-            currency = arguments.get("currency_code", "USD")
-            if include_prices:
-                azure_api.enrich_skus_with_prices(skus, arguments["region"], currency)
+def _execute_tool(name: str, arguments: dict[str, Any]) -> str:
+    """Execute a tool by name and return the JSON result string.
 
-            # Compute confidence scores
-            for sku in skus:
-                caps = sku.get("capabilities", {})
-                quota = sku.get("quota", {})
-                pricing = sku.get("pricing", {})
-                try:
-                    vcpus = int(caps.get("vCPUs", 0))
-                except (TypeError, ValueError):
-                    vcpus = None
-                remaining = quota.get("remaining")
-                sku["confidence"] = compute_capacity_confidence(
-                    vcpus=vcpus,
-                    zones_supported_count=len(sku.get("zones", [])),
-                    restrictions_present=len(sku.get("restrictions", [])) > 0,
-                    quota_remaining_vcpu=remaining,
-                    paygo_price=pricing.get("paygo") if pricing else None,
-                    spot_price=pricing.get("spot") if pricing else None,
-                )
-            return json.dumps(skus, indent=2)
-
-        elif name == "get_spot_scores":
-            return json.dumps(
-                azure_api.get_spot_placement_scores(
-                    arguments["region"],
-                    arguments["subscription_id"],
-                    arguments["vm_sizes"],
-                    arguments.get("instance_count", 1),
-                    arguments.get("tenant_id"),
-                ),
-                indent=2,
-            )
-
-        elif name == "switch_region":
-            # Validated client-side – just acknowledge
+    MCP-registered tools are called directly via their underlying function.
+    Chat-only tools (switch_region, switch_tenant) are handled locally.
+    """
+    try:
+        # Chat-only tools (not in MCP server — they control the web UI)
+        if name == "switch_region":
+            region_val = arguments.get("region")
+            if not region_val:
+                return json.dumps({"error": "Missing required parameter: region."})
             return json.dumps(
                 {
                     "status": "ok",
-                    "region": arguments["region"],
-                    "message": f"Switched active region to {arguments['region']}.",
+                    "region": region_val,
+                    "message": f"Switched active region to {region_val}.",
                 }
             )
 
-        elif name == "switch_tenant":
-            # Validated client-side – just acknowledge
+        if name == "switch_tenant":
+            tid = arguments.get("tenant_id")
+            if not tid:
+                return json.dumps({"error": "Missing required parameter: tenant_id."})
             return json.dumps(
                 {
                     "status": "ok",
-                    "tenant_id": arguments["tenant_id"],
-                    "message": f"Switched active tenant to {arguments['tenant_id']}.",
+                    "tenant_id": tid,
+                    "message": f"Switched active tenant to {tid}.",
                 }
             )
 
-        elif name == "get_sku_pricing_detail":
-            result = azure_api.get_sku_pricing_detail(
-                arguments["region"],
-                arguments["sku_name"],
-                arguments.get("currency_code", "USD"),
-            )
-            sub_id = arguments.get("subscription_id")
-            if sub_id:
-                profile = azure_api.get_sku_profile(
-                    arguments["region"],
-                    sub_id,
-                    arguments["sku_name"],
-                    arguments.get("tenant_id"),
-                )
-                if profile is not None:
-                    result["profile"] = profile
-            return json.dumps(result, indent=2)
-
-        else:
+        # MCP-registered tools
+        mcp_tools = _get_mcp_tools()
+        tool = mcp_tools.get(name)
+        if tool is None:
             return json.dumps({"error": f"Unknown tool: {name}"})
 
+        # Pre-validate subscription IDs
+        if "subscription_id" in arguments:
+            err = _validate_subscription_id(arguments["subscription_id"])
+            if err:
+                return err
+        if "subscription_ids" in arguments:
+            sub_ids = arguments["subscription_ids"]
+            if isinstance(sub_ids, str):
+                sub_ids = [sub_ids]
+                arguments["subscription_ids"] = sub_ids
+            for sid in sub_ids:
+                err = _validate_subscription_id(sid, "subscription_ids[]")
+                if err:
+                    return err
+
+        # Coerce single string to list for array parameters
+        if "vm_sizes" in arguments and isinstance(arguments["vm_sizes"], str):
+            arguments["vm_sizes"] = [arguments["vm_sizes"]]
+
+        # Call the MCP tool function directly
+        result = tool.fn(**arguments)
+
+        # Apply chat-specific post-processing
+        return _post_process_tool_result(name, arguments, result)
+
+    except TypeError as exc:
+        # Missing/invalid arguments for the MCP function
+        logger.warning("Tool %s called with bad args: %s", name, exc)
+        return json.dumps({"error": f"Invalid arguments for {name}: {exc}"})
     except Exception as exc:
         logger.exception("Tool execution failed: %s", name)
         return json.dumps({"error": str(exc)})
+
+
+def _post_process_tool_result(name: str, arguments: dict[str, Any], result: str) -> str:
+    """Apply chat-specific post-processing to an MCP tool result.
+
+    - ``get_sku_availability``: sort by PAYGO price ascending so cheapest
+      SKUs survive truncation.
+    - ``get_sku_pricing_detail``: add a hint when all prices are null to
+      guide the AI toward calling ``get_sku_availability`` first.
+    """
+    if name == "get_sku_availability" and arguments.get("include_prices"):
+        # Sort by PAYGO price ascending so cheapest SKUs survive truncation.
+        # SKUs without pricing go last.
+        try:
+            skus = json.loads(result)
+            if isinstance(skus, list):
+                skus.sort(
+                    key=lambda s: (
+                        s.get("pricing", {}).get("paygo") is None,
+                        s.get("pricing", {}).get("paygo") or float("inf"),
+                    )
+                )
+                return json.dumps(skus, indent=2)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    if name == "get_sku_pricing_detail":
+        # Add hint when all prices are null to guide the AI
+        try:
+            data = json.loads(result)
+            if isinstance(data, dict):
+                price_keys = ("paygo", "spot", "ri_1y", "ri_3y", "sp_1y", "sp_3y")
+                if all(data.get(k) is None for k in price_keys):
+                    sku_name = arguments.get("sku_name", "unknown")
+                    data["hint"] = (
+                        f"No pricing found for '{sku_name}'. This usually means the "
+                        "sku_name is not an exact ARM name. Call get_sku_availability "
+                        "with a name filter (e.g. name='M128') to discover the correct "
+                        "ARM SKU names (like Standard_M128s_v2), then retry."
+                    )
+                    return json.dumps(data, indent=2)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -513,12 +572,23 @@ def _execute_tool(name: str, arguments: dict[str, Any]) -> str:
 # Maximum tool-calling rounds to prevent infinite loops
 _MAX_TOOL_ROUNDS = 10
 
+# Retry config for Azure OpenAI 429 rate-limit errors
+_MAX_RETRIES = 3
+_DEFAULT_RETRY_WAIT = 10  # seconds when no Retry-After header
+
+# Maximum characters for a single tool result in the conversation context.
+# Large results (e.g. get_sku_availability with 300+ SKUs) are truncated to
+# keep the total prompt under the model's token limit and avoid 429 errors.
+_MAX_TOOL_RESULT_CHARS = 30_000
+
 
 async def chat_stream(
     messages: list[dict[str, Any]],
     *,
     tenant_id: str | None = None,
     region: str | None = None,
+    subscription_id: str | None = None,
+    mode: str = "discussion",
 ) -> AsyncGenerator[str, None]:
     """Stream chat completions from Azure OpenAI with tool-calling support.
 
@@ -534,7 +604,10 @@ async def chat_stream(
     import httpx
 
     full_messages: list[dict[str, Any]] = [
-        {"role": "system", "content": _build_system_prompt(tenant_id, region)},
+        {
+            "role": "system",
+            "content": _build_system_prompt(tenant_id, region, subscription_id, mode=mode),
+        },
         *messages,
     ]
 
@@ -558,18 +631,54 @@ async def chat_stream(
             }
 
             try:
-                async with client.stream(
-                    "POST",
-                    url,
-                    json=body,
-                    headers=headers,
-                ) as resp:
-                    if resp.status_code != 200:
+                # Retry loop for 429 rate-limit errors
+                resp_ctx = None
+                for _attempt in range(_MAX_RETRIES):
+                    resp_ctx = client.stream(
+                        "POST",
+                        url,
+                        json=body,
+                        headers=headers,
+                    )
+                    resp = await resp_ctx.__aenter__()
+                    if resp.status_code == 429:
                         error_body = await resp.aread()
+                        await resp_ctx.__aexit__(None, None, None)
+                        retry_after = _DEFAULT_RETRY_WAIT
+                        if resp.headers.get("retry-after"):
+                            with contextlib.suppress(TypeError, ValueError):
+                                retry_after = int(resp.headers["retry-after"])
+                        if _attempt < _MAX_RETRIES - 1:
+                            logger.warning(
+                                "Azure OpenAI 429, retrying in %ss (attempt %s/%s)",
+                                retry_after,
+                                _attempt + 1,
+                                _MAX_RETRIES,
+                            )
+                            yield _sse(
+                                {
+                                    "type": "status",
+                                    "content": (f"Rate limited — retrying in {retry_after}s…"),
+                                }
+                            )
+                            await asyncio.sleep(retry_after)
+                            continue
+                        # Last attempt still 429 — surface error
                         yield _sse({"type": "error", "content": error_body.decode()})
                         yield _sse({"type": "done"})
                         return
+                    elif resp.status_code != 200:
+                        error_body = await resp.aread()
+                        await resp_ctx.__aexit__(None, None, None)
+                        yield _sse({"type": "error", "content": error_body.decode()})
+                        yield _sse({"type": "done"})
+                        return
+                    else:
+                        break
 
+                assert resp_ctx is not None  # for type checker
+
+                try:
                     # Accumulate streamed response
                     content_parts: list[str] = []
                     tool_calls: dict[int, dict[str, str]] = {}
@@ -613,6 +722,8 @@ async def chat_stream(
                                 tool_calls[idx]["name"] = tc["function"]["name"]
                             if tc.get("function", {}).get("arguments"):
                                 tool_calls[idx]["arguments"] += tc["function"]["arguments"]
+                finally:
+                    await resp_ctx.__aexit__(None, None, None)
 
             except httpx.HTTPError as exc:
                 yield _sse({"type": "error", "content": f"HTTP error: {exc}"})
@@ -659,9 +770,18 @@ async def chat_stream(
                     args.setdefault("tenant_id", tenant_id)
                 if region and "region" in _get_tool_params(tool_name):
                     args.setdefault("region", region)
+                if subscription_id:
+                    if "subscription_id" in _get_tool_params(tool_name):
+                        args.setdefault("subscription_id", subscription_id)
+                    if "subscription_ids" in _get_tool_params(tool_name):
+                        args.setdefault("subscription_ids", [subscription_id])
+
+                # In planner mode, always include pricing data
+                if mode == "planner" and tool_name == "get_sku_availability":
+                    args.setdefault("include_prices", True)
 
                 # Emit UI actions for switch tools before executing
-                if tool_name == "switch_tenant":
+                if tool_name == "switch_tenant" and args.get("tenant_id"):
                     yield _sse(
                         {
                             "type": "ui_action",
@@ -671,7 +791,7 @@ async def chat_stream(
                     )
                     # Update tenant_id for subsequent tool calls in this stream
                     tenant_id = args["tenant_id"]
-                elif tool_name == "switch_region":
+                elif tool_name == "switch_region" and args.get("region"):
                     yield _sse(
                         {
                             "type": "ui_action",
@@ -694,11 +814,14 @@ async def chat_stream(
                     }
                 )
 
+                # Truncate large tool results to avoid blowing up the context
+                tool_content = _truncate_tool_result(result)
+
                 full_messages.append(
                     {
                         "role": "tool",
                         "tool_call_id": tc["id"],
-                        "content": result,
+                        "content": tool_content,
                     }
                 )
 

--- a/src/az_scout/static/css/style.css
+++ b/src/az_scout/static/css/style.css
@@ -641,7 +641,7 @@ select.no-arrow {
     align-items: center;
     justify-content: space-between;
     padding: 0.6rem 0.8rem;
-    min-height: 56px; /* align with navbar height */
+    min-height: 57px; /* match navbar height (56px content + 1px border-bottom) */
     border-bottom: 1px solid var(--bs-border-color);
     font-weight: 600;
     font-size: 0.9rem;
@@ -718,6 +718,27 @@ select.no-arrow {
     background: var(--bs-tertiary-bg, #f0f0f0);
     color: var(--bs-body-color);
     border-bottom-left-radius: 0.15rem;
+}
+
+/* Thinking dots indicator */
+.chat-thinking {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0;
+}
+.chat-thinking .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--bs-secondary-color, #6c757d);
+    animation: chat-bounce 1.2s ease-in-out infinite;
+}
+.chat-thinking .dot:nth-child(2) { animation-delay: 0.15s; }
+.chat-thinking .dot:nth-child(3) { animation-delay: 0.3s; }
+@keyframes chat-bounce {
+    0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+    30% { transform: translateY(-4px); opacity: 1; }
 }
 
 .chat-bubble code {
@@ -837,6 +858,39 @@ select.no-arrow {
     opacity: 0.5;
     pointer-events: none;
     border-style: dashed;
+}
+
+/* ---- Chat mode toggle (pill switch) ---- */
+.chat-mode-toggle {
+    display: flex;
+    border-radius: 999px;
+    border: 2px solid var(--bs-primary);
+    overflow: hidden;
+    flex-shrink: 0;
+}
+.chat-mode-toggle button {
+    flex: 1;
+    border: none;
+    padding: 0.22rem 0.7rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s;
+    white-space: nowrap;
+    line-height: 1.4;
+    background: transparent;
+    color: var(--bs-primary);
+}
+.chat-mode-toggle button.active {
+    background: var(--bs-primary);
+    color: #fff;
+}
+.chat-mode-toggle button:not(.active):hover {
+    background: color-mix(in srgb, var(--bs-primary) 12%, transparent);
+}
+.chat-mode-toggle button:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: -2px;
 }
 
 /* ---- Input area ---- */

--- a/src/az_scout/static/js/app.js
+++ b/src/az_scout/static/js/app.js
@@ -133,6 +133,9 @@ async function init() {
     // Restore column visibility preferences
     _restoreColumnPrefs();
 
+    // Restore chat state immediately (before any async work to avoid flash)
+    _restoreChatHistory();
+
     // Topology subscription filter
     document.getElementById("topo-sub-filter").addEventListener("input", e => renderTopoSubList(e.target.value));
 
@@ -177,11 +180,6 @@ async function init() {
 
     updateTopoLoadButton();
     updatePlannerLoadButton();
-
-    // Restore chat history if persistence is enabled
-    _restoreChatHistory();
-
-
 }
 
 // ---------------------------------------------------------------------------
@@ -2147,10 +2145,18 @@ let _chatHistoryIdx = -1;    // -1 = composing new message
 let _chatDraft = "";         // saved draft while navigating history
 let _chatPersist = false;    // whether to save chat history to localStorage
 let _chatPinned = false;     // whether chat is pinned to right side
+let _chatMode = "discussion"; // "discussion" | "planner"
 
 const _CHAT_STORAGE_KEY = "azm-chat-history";
 const _CHAT_PERSIST_KEY = "azm-chat-persist";
 const _CHAT_INPUT_HIST_KEY = "azm-chat-input-history";
+const _CHAT_MODE_KEY = "azm-chat-mode";
+
+// Per-mode conversation state: { discussion: {messages, inputHistory}, planner: {messages, inputHistory} }
+const _chatModeState = {
+    discussion: { messages: [], inputHistory: [] },
+    planner:   { messages: [], inputHistory: [] },
+};
 
 
 function toggleChatPanel() {
@@ -2164,6 +2170,72 @@ function toggleChatPanel() {
     if (panel.classList.contains("d-none") && _chatPinned) {
         _setChatPinned(false);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Chat mode switching  (Discussion ↔ Planner)
+// ---------------------------------------------------------------------------
+
+const _CHAT_WELCOME = {
+    discussion: `👋 Hi! I'm your Azure Scout assistant. Ask me about Azure regions, SKU availability, pricing, zone mappings, and more. I can query live Azure data for you.
+- [[Show me available VM sizes in this region]]
+- [[Compare zone mappings across my subscriptions]]
+- [[What are the cheapest spot VMs with 4 vCPUs?]]
+- [[List all regions with availability zones]]`,
+    planner: `🗺️ Welcome to the **VM Deployment Planner**! I can help you with one of these:
+- [[Find the best region for my VM workload]]
+- [[Find the right VM size in a specific region]]
+- [[Pick the best availability zone for a VM SKU]]`,
+};
+
+function switchChatMode(mode) {
+    if (mode === _chatMode || _chatStreaming) return;
+
+    // Save current mode's conversation state
+    _chatModeState[_chatMode].messages = [..._chatMessages];
+    _chatModeState[_chatMode].inputHistory = [..._chatInputHistory];
+
+    // Switch
+    _chatMode = mode;
+    try { localStorage.setItem(_CHAT_MODE_KEY, mode); } catch {}
+
+    // Update toggle UI
+    document.querySelectorAll("#chat-mode-toggle button").forEach(btn => {
+        btn.classList.toggle("active", btn.dataset.mode === mode);
+    });
+
+    // Restore target mode's conversation (or start fresh)
+    _chatMessages = [...(_chatModeState[mode].messages || [])];
+    _chatInputHistory = [...(_chatModeState[mode].inputHistory || [])];
+    _chatHistoryIdx = -1;
+    _chatDraft = "";
+
+    // Rebuild chat UI
+    const container = document.getElementById("chat-messages");
+    if (!container) return;
+    container.innerHTML = "";
+
+    // Show welcome message
+    const welcome = document.createElement("div");
+    welcome.className = "chat-message assistant";
+    welcome.innerHTML = `<div class="chat-bubble">${_renderMarkdown(_CHAT_WELCOME[mode])}</div>`;
+    container.appendChild(welcome);
+
+    // Replay stored messages
+    for (const msg of _chatMessages) {
+        _appendChatBubble(msg.role, msg.content);
+    }
+
+    // Update input placeholder
+    const input = document.getElementById("chat-input");
+    if (input) {
+        input.placeholder = mode === "planner"
+            ? "Describe your deployment needs…"
+            : "Ask about Azure SKUs, zones, pricing…";
+        input.focus();
+    }
+
+    _saveChatHistory();
 }
 
 function toggleChatPin() {
@@ -2226,8 +2298,12 @@ function toggleChatPersist() {
 function _saveChatHistory() {
     if (!_chatPersist) return;
     try {
-        localStorage.setItem(_CHAT_STORAGE_KEY, JSON.stringify(_chatMessages));
+        // Save per-mode state
+        _chatModeState[_chatMode].messages = [..._chatMessages];
+        _chatModeState[_chatMode].inputHistory = [..._chatInputHistory];
+        localStorage.setItem(_CHAT_STORAGE_KEY, JSON.stringify(_chatModeState));
         localStorage.setItem(_CHAT_INPUT_HIST_KEY, JSON.stringify(_chatInputHistory));
+        localStorage.setItem(_CHAT_MODE_KEY, _chatMode);
     } catch {}
 }
 
@@ -2236,32 +2312,64 @@ function _restoreChatHistory() {
         _chatPersist = localStorage.getItem(_CHAT_PERSIST_KEY) === "1";
         const btn = document.getElementById("chat-persist-btn");
         if (btn) btn.classList.toggle("active", _chatPersist);
-        if (!_chatPersist) return;
 
-        const saved = localStorage.getItem(_CHAT_STORAGE_KEY);
-        const savedInput = localStorage.getItem(_CHAT_INPUT_HIST_KEY);
-        if (!saved) return;
-
-        const msgs = JSON.parse(saved);
-        if (!Array.isArray(msgs) || !msgs.length) return;
-
-        _chatMessages = msgs;
-        if (savedInput) {
-            const inp = JSON.parse(savedInput);
-            if (Array.isArray(inp)) _chatInputHistory = inp;
+        // Restore saved mode
+        const savedMode = localStorage.getItem(_CHAT_MODE_KEY);
+        if (savedMode && (savedMode === "discussion" || savedMode === "planner")) {
+            _chatMode = savedMode;
+            document.querySelectorAll("#chat-mode-toggle button").forEach(b => {
+                b.classList.toggle("active", b.dataset.mode === _chatMode);
+            });
         }
 
-        // Rebuild the chat UI
+        let hasHistory = false;
+
+        if (_chatPersist) {
+            const saved = localStorage.getItem(_CHAT_STORAGE_KEY);
+            if (saved) {
+                const state = JSON.parse(saved);
+                // Support both old format (array) and new format (object with per-mode state)
+                if (Array.isArray(state)) {
+                    // Legacy: migrate old format into discussion mode
+                    _chatModeState.discussion.messages = state;
+                } else if (state && typeof state === "object") {
+                    // Support old "assistant" key for backward compat
+                    const disc = state.discussion || state.assistant;
+                    if (disc?.messages) _chatModeState.discussion = disc;
+                    if (state.planner?.messages) _chatModeState.planner = state.planner;
+                }
+
+                // Load current mode's state
+                _chatMessages = [...(_chatModeState[_chatMode].messages || [])];
+                _chatInputHistory = [...(_chatModeState[_chatMode].inputHistory || [])];
+                hasHistory = _chatMessages.length > 0;
+            }
+        }
+
+        // Build the chat UI in one pass (no flash)
         const container = document.getElementById("chat-messages");
         if (!container) return;
-        container.innerHTML = `<div class="chat-message assistant"><div class="chat-bubble">
-            \uD83D\uDC4B Hi! I'm your Azure Scout assistant. Ask me about Azure regions, SKU availability, pricing, zone mappings, and more. I can query live Azure data for you.
-        </div></div>
-        <div class="chat-message assistant"><div class="chat-bubble">
-            <em>Restored ${msgs.filter(m => m.role === "user").length} message(s) from previous session.</em>
-        </div></div>`;
-        for (const msg of msgs) {
-            _appendChatBubble(msg.role, msg.content);
+
+        const welcome = _renderMarkdown(_CHAT_WELCOME[_chatMode]);
+        container.innerHTML = `<div class="chat-message assistant"><div class="chat-bubble">${welcome}</div></div>`;
+
+        if (hasHistory) {
+            // Add restored-session notice then replay messages
+            const notice = document.createElement("div");
+            notice.className = "chat-message assistant";
+            notice.innerHTML = `<div class="chat-bubble"><em>Restored ${_chatMessages.filter(m => m.role === "user").length} message(s) from previous session.</em></div>`;
+            container.appendChild(notice);
+            for (const msg of _chatMessages) {
+                _appendChatBubble(msg.role, msg.content);
+            }
+        }
+
+        // Update placeholder
+        const input = document.getElementById("chat-input");
+        if (input) {
+            input.placeholder = _chatMode === "planner"
+                ? "Describe your deployment needs…"
+                : "Ask about Azure SKUs, zones, pricing…";
         }
     } catch {}
 }
@@ -2271,18 +2379,13 @@ function clearChat() {
     _chatInputHistory = [];
     _chatHistoryIdx = -1;
     _chatDraft = "";
+    _chatModeState[_chatMode].messages = [];
+    _chatModeState[_chatMode].inputHistory = [];
     _saveChatHistory();
     const container = document.getElementById("chat-messages");
     if (!container) return;
-    container.innerHTML = `<div class="chat-message assistant"><div class="chat-bubble">
-        👋 Hi! I'm your Azure Scout assistant. Ask me about Azure regions, SKU availability, pricing, zone mappings, and more. I can query live Azure data for you.
-        <div class="chat-suggestions">
-            <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">Show me available VM sizes in this region</button>
-            <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">Compare zone mappings across my subscriptions</button>
-            <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">What are the cheapest spot VMs with 4 vCPUs?</button>
-            <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">List all regions with availability zones</button>
-        </div>
-    </div></div>`;
+    const welcome = _renderMarkdown(_CHAT_WELCOME[_chatMode]);
+    container.innerHTML = `<div class="chat-message assistant"><div class="chat-bubble">${welcome}</div></div>`;
 }
 
 function handleChatKeydown(e) {
@@ -2314,8 +2417,10 @@ async function sendChatMessage() {
     _chatMessages.push({ role: "user", content: text });
     _saveChatHistory();
 
-    // Create assistant bubble for streaming
+    // Create assistant bubble with thinking indicator
     const assistantBubble = _appendChatBubble("assistant", "");
+    assistantBubble.innerHTML = '<span class="chat-thinking"><span class="dot"></span><span class="dot"></span><span class="dot"></span></span>';
+    _scrollChatBottom();
     const sendBtn = document.getElementById("chat-send-btn");
     _chatStreaming = true;
     if (sendBtn) sendBtn.disabled = true;
@@ -2328,8 +2433,10 @@ async function sendChatMessage() {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
                 messages: _chatMessages,
+                mode: _chatMode,
                 tenant_id: tenantId || undefined,
                 region: regionId || undefined,
+                subscription_id: plannerSubscriptionId || undefined,
             }),
         });
 
@@ -2364,15 +2471,21 @@ async function sendChatMessage() {
                 if (payload.type === "delta") {
                     fullContent += payload.content;
                     assistantBubble.innerHTML = _renderMarkdown(fullContent);
+                    assistantBubble.closest(".chat-message")?.classList.remove("is-thinking");
                     _scrollChatBottom();
                 } else if (payload.type === "tool_call") {
-                    _appendToolStatus(assistantBubble, payload.name, "calling");
+                    _appendToolStatus(assistantBubble, payload.name, "calling", payload.arguments);
                     _scrollChatBottom();
                 } else if (payload.type === "tool_result") {
                     _updateToolStatus(assistantBubble, payload.name, "done");
                     _scrollChatBottom();
                 } else if (payload.type === "ui_action") {
                     _handleChatUiAction(payload);
+                } else if (payload.type === "status") {
+                    // Transient status message (e.g. rate-limit retry)
+                    assistantBubble.innerHTML = `<span class="text-muted"><em>${escapeHtml(payload.content)}</em></span>`;
+                    assistantBubble.closest(".chat-message")?.classList.remove("is-thinking");
+                    _scrollChatBottom();
                 } else if (payload.type === "error") {
                     fullContent = ""; // Don't store error as assistant message
                     assistantBubble.innerHTML = `<span class="text-danger"><strong>Error:</strong> ${escapeHtml(payload.content)}</span>`
@@ -2487,7 +2600,7 @@ function _navigateChatHistory(direction, e) {
     input.setSelectionRange(input.value.length, input.value.length);
 }
 
-function _appendToolStatus(bubble, toolName, status) {
+function _appendToolStatus(bubble, toolName, status, argsJson) {
     let toolsDiv = bubble.querySelector(".chat-tool-calls");
     if (!toolsDiv) {
         toolsDiv = document.createElement("div");
@@ -2499,6 +2612,17 @@ function _appendToolStatus(bubble, toolName, status) {
     badge.dataset.tool = toolName;
     const friendlyName = toolName.replace(/_/g, " ");
     badge.innerHTML = `<i class="bi bi-gear-fill spin"></i> ${escapeHtml(friendlyName)}`;
+    // Store arguments for tooltip
+    if (argsJson) {
+        try {
+            const parsed = typeof argsJson === "string" ? JSON.parse(argsJson) : argsJson;
+            const lines = Object.entries(parsed)
+                .map(([k, v]) => `${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`)
+                .join("\n");
+            badge.title = lines;
+            badge.style.cursor = "help";
+        } catch { /* ignore parse errors */ }
+    }
     toolsDiv.appendChild(badge);
 }
 

--- a/src/az_scout/templates/index.html
+++ b/src/az_scout/templates/index.html
@@ -311,7 +311,11 @@
     <div class="chat-resize-handle" id="chat-resize-handle" title="Drag to resize"></div>
     <div class="chat-panel-header">
         <span class="d-flex align-items-center gap-2">
-            <i class="bi bi-robot"></i> Azure Scout Assistant
+            <i class="bi bi-robot"></i>
+            <div class="chat-mode-toggle" id="chat-mode-toggle">
+                <button type="button" class="active" data-mode="discussion" onclick="switchChatMode('discussion')">Discussion</button>
+                <button type="button" data-mode="planner" onclick="switchChatMode('planner')">Planner</button>
+            </div>
         </span>
         <div class="d-flex gap-1">
             <button type="button" class="btn btn-sm btn-link chat-header-btn" id="chat-pin-btn"
@@ -330,19 +334,7 @@
             </button>
         </div>
     </div>
-    <div class="chat-messages" id="chat-messages">
-        <div class="chat-message assistant">
-            <div class="chat-bubble">
-                👋 Hi! I'm your Azure Scout assistant. Ask me about Azure regions, SKU availability, pricing, zone mappings, and more. I can query live Azure data for you.
-                <div class="chat-suggestions">
-                    <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">Show me available VM sizes in this region</button>
-                    <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">Compare zone mappings across my subscriptions</button>
-                    <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">What are the cheapest spot VMs with 4 vCPUs?</button>
-                    <button class="chat-choice-chip" onclick="_onChatChoiceClick(this)">List all regions with availability zones</button>
-                </div>
-            </div>
-        </div>
-    </div>
+    <div class="chat-messages" id="chat-messages"></div>
     <div class="chat-input-area">
         <div class="input-group">
             <textarea class="form-control" id="chat-input" placeholder="Ask about Azure SKUs, zones, pricing…"

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -1,0 +1,391 @@
+"""Tests for the AI chat service – planner mode, mode switching, MCP tool conversion."""
+
+import json
+from unittest.mock import patch
+
+from az_scout.services.ai_chat import (
+    PLANNER_SYSTEM_PROMPT,
+    SYSTEM_PROMPT,
+    TOOL_DEFINITIONS,
+    _build_openai_tools,
+    _build_system_prompt,
+    _mcp_schema_to_openai,
+    _post_process_tool_result,
+    _truncate_tool_result,
+)
+
+# ---------------------------------------------------------------------------
+# is_chat_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsChatEnabled:
+    """Tests for the is_chat_enabled function."""
+
+    def test_disabled_when_env_vars_missing(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "AZURE_OPENAI_ENDPOINT": "",
+                "AZURE_OPENAI_API_KEY": "",
+                "AZURE_OPENAI_DEPLOYMENT": "",
+            },
+        ):
+            # Re-import to pick up patched env
+            from importlib import reload
+
+            from az_scout.services import ai_chat
+
+            reload(ai_chat)
+            assert ai_chat.is_chat_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# _build_system_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSystemPrompt:
+    """Tests for system prompt construction with mode parameter."""
+
+    def test_discussion_mode_uses_discussion_prompt(self):
+        prompt = _build_system_prompt(mode="discussion")
+        assert "Azure Scout Assistant" in prompt
+        assert "Deployment Planner" not in prompt
+
+    def test_planner_mode_uses_planner_prompt(self):
+        prompt = _build_system_prompt(mode="planner")
+        assert "Azure Scout Planner" in prompt
+        assert "directive" in prompt.lower()
+
+    def test_default_mode_is_discussion(self):
+        prompt = _build_system_prompt()
+        assert "Azure Scout Assistant" in prompt
+
+    def test_tenant_context_appended(self):
+        prompt = _build_system_prompt(tenant_id="tid-123", mode="discussion")
+        assert "tid-123" in prompt
+
+    def test_region_context_appended(self):
+        prompt = _build_system_prompt(region="eastus", mode="planner")
+        assert "eastus" in prompt
+
+    def test_planner_prompt_contains_planning_paths(self):
+        """The planner prompt should describe the three independent planning paths."""
+        assert "Path A" in PLANNER_SYSTEM_PROMPT
+        assert "Path B" in PLANNER_SYSTEM_PROMPT
+        assert "Path C" in PLANNER_SYSTEM_PROMPT
+        assert "region" in PLANNER_SYSTEM_PROMPT
+        assert "SKU" in PLANNER_SYSTEM_PROMPT
+        assert "zone" in PLANNER_SYSTEM_PROMPT
+        assert "virtual machine" in PLANNER_SYSTEM_PROMPT
+        assert "Spot" in PLANNER_SYSTEM_PROMPT
+
+    def test_assistant_prompt_contains_guidelines(self):
+        assert "Interactive choices" in SYSTEM_PROMPT
+        assert "Subscription resolution" in SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat  – mode parameter
+# ---------------------------------------------------------------------------
+
+
+class TestChatEndpointMode:
+    """Tests for the /api/chat endpoint with mode parameter."""
+
+    def test_chat_returns_503_when_not_configured(self, client):
+        """Chat should return 503 when Azure OpenAI is not configured."""
+        resp = client.post(
+            "/api/chat",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "mode": "discussion",
+            },
+        )
+        assert resp.status_code == 503
+        assert "not configured" in resp.json()["error"]
+
+    def test_chat_planner_mode_returns_503_when_not_configured(self, client):
+        """Planner mode should also return 503 when not configured."""
+        resp = client.post(
+            "/api/chat",
+            json={
+                "messages": [{"role": "user", "content": "help me plan"}],
+                "mode": "planner",
+            },
+        )
+        assert resp.status_code == 503
+
+    def test_chat_accepts_mode_field(self, client):
+        """The endpoint should accept the mode field without erroring (422)."""
+        resp = client.post(
+            "/api/chat",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "mode": "planner",
+                "tenant_id": "tid-1",
+                "region": "eastus",
+            },
+        )
+        # 503 because OpenAI isn't configured, but NOT 422 (validation error)
+        assert resp.status_code == 503
+
+    def test_chat_default_mode_is_discussion(self, client):
+        """When mode is omitted, it should default to discussion."""
+        resp = client.post(
+            "/api/chat",
+            json={"messages": [{"role": "user", "content": "test"}]},
+        )
+        assert resp.status_code == 503  # not 422
+
+
+# ---------------------------------------------------------------------------
+# _truncate_tool_result
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateToolResult:
+    """Tests for tool result truncation."""
+
+    def test_short_result_unchanged(self):
+        result = '{"key": "value"}'
+        assert _truncate_tool_result(result) == result
+
+    def test_large_array_truncated(self):
+        import json
+
+        items = [
+            {
+                "name": f"Standard_D{i}s_v5",
+                "vCPUs": i,
+                "zones": ["1", "2", "3"],
+                "capabilities": {"MemoryGB": str(i * 4), "PremiumIO": "True"},
+            }
+            for i in range(500)
+        ]
+        result = json.dumps(items, indent=2)
+        truncated = _truncate_tool_result(result)
+        assert len(truncated) < len(result)
+        assert "omitted" in truncated
+        assert "total: 500" in truncated
+
+    def test_large_string_truncated(self):
+        result = "x" * 50_000
+        truncated = _truncate_tool_result(result)
+        assert len(truncated) <= 30_100  # budget + "(truncated)"
+        assert "truncated" in truncated
+
+    def test_small_array_unchanged(self):
+        items = [{"name": "Standard_D2s_v5"}]
+        result = json.dumps(items, indent=2)
+        assert _truncate_tool_result(result) == result
+
+
+# ---------------------------------------------------------------------------
+# MCP → OpenAI tool conversion
+# ---------------------------------------------------------------------------
+
+
+class TestMcpToOpenaiConversion:
+    """Tests for the MCP tool → OpenAI function-calling format converter."""
+
+    def test_all_mcp_tools_present(self):
+        """All MCP tools should appear in the generated TOOL_DEFINITIONS."""
+        from az_scout.mcp_server import mcp as mcp_server
+
+        mcp_names = {t.name for t in mcp_server._tool_manager.list_tools()}
+        generated_names = {t["function"]["name"] for t in TOOL_DEFINITIONS}
+        # All MCP tools must be present (chat-only tools are extra)
+        assert mcp_names.issubset(generated_names)
+
+    def test_chat_only_tools_present(self):
+        """switch_region and switch_tenant should be in TOOL_DEFINITIONS."""
+        names = {t["function"]["name"] for t in TOOL_DEFINITIONS}
+        assert "switch_region" in names
+        assert "switch_tenant" in names
+
+    def test_total_tool_count(self):
+        """Should have 7 MCP tools + 2 chat-only = 9 total."""
+        assert len(TOOL_DEFINITIONS) == 9
+
+    def test_schema_strips_titles(self):
+        """The converter should strip Pydantic 'title' fields from parameters."""
+        schema = _mcp_schema_to_openai(
+            {
+                "properties": {
+                    "region": {"title": "Region", "type": "string"},
+                },
+                "required": ["region"],
+            }
+        )
+        assert "title" not in schema["properties"]["region"]
+        assert schema["properties"]["region"]["type"] == "string"
+
+    def test_schema_converts_nullable_anyof(self):
+        """anyOf [{type: str}, {type: null}] should become {type: str}."""
+        schema = _mcp_schema_to_openai(
+            {
+                "properties": {
+                    "tenant_id": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Tenant Id",
+                    },
+                },
+                "required": [],
+            }
+        )
+        prop = schema["properties"]["tenant_id"]
+        assert prop["type"] == "string"
+        assert "anyOf" not in prop
+        assert "default" not in prop  # None defaults are stripped
+
+    def test_schema_preserves_defaults(self):
+        """Non-null defaults should be preserved."""
+        schema = _mcp_schema_to_openai(
+            {
+                "properties": {
+                    "resource_type": {
+                        "default": "virtualMachines",
+                        "title": "Resource Type",
+                        "type": "string",
+                    },
+                    "include_prices": {
+                        "default": False,
+                        "title": "Include Prices",
+                        "type": "boolean",
+                    },
+                },
+                "required": [],
+            }
+        )
+        assert schema["properties"]["resource_type"]["default"] == "virtualMachines"
+        assert schema["properties"]["include_prices"]["default"] is False
+
+    def test_schema_preserves_array_items(self):
+        """Array parameters should keep their items schema."""
+        schema = _mcp_schema_to_openai(
+            {
+                "properties": {
+                    "vm_sizes": {
+                        "items": {"type": "string"},
+                        "title": "Vm Sizes",
+                        "type": "array",
+                    },
+                },
+                "required": ["vm_sizes"],
+            }
+        )
+        prop = schema["properties"]["vm_sizes"]
+        assert prop["type"] == "array"
+        assert prop["items"] == {"type": "string"}
+
+    def test_mcp_descriptions_used_directly(self):
+        """Tool descriptions should come from MCP docstrings (no overrides)."""
+        tools = _build_openai_tools()
+        sku_tool = next(t for t in tools if t["function"]["name"] == "get_sku_availability")
+        desc = sku_tool["function"]["description"]
+        # The MCP docstring mentions include_prices and confidence scores
+        assert "include_prices" in desc
+        assert "confidence" in desc.lower()
+
+    def test_mcp_param_descriptions_present(self):
+        """MCP parameter Field descriptions should flow into OpenAI schemas."""
+        tools = _build_openai_tools()
+        sku_tool = next(t for t in tools if t["function"]["name"] == "get_sku_availability")
+        name_desc = sku_tool["function"]["parameters"]["properties"]["name"]["description"]
+        # Should have the fuzzy matching guidance from Field(description=...)
+        assert "FX48" in name_desc or "fuzzy" in name_desc.lower()
+        # include_prices should have a description too
+        prices_desc = sku_tool["function"]["parameters"]["properties"]["include_prices"]
+        assert "description" in prices_desc
+
+    def test_every_tool_has_valid_structure(self):
+        """All tools should have the correct structure for OpenAI function calling."""
+        for tool in TOOL_DEFINITIONS:
+            assert tool["type"] == "function"
+            fn = tool["function"]
+            assert "name" in fn
+            assert "description" in fn
+            assert "parameters" in fn
+            params = fn["parameters"]
+            assert params["type"] == "object"
+            assert "properties" in params
+            assert "required" in params
+
+
+# ---------------------------------------------------------------------------
+# _post_process_tool_result
+# ---------------------------------------------------------------------------
+
+
+class TestPostProcessToolResult:
+    """Tests for chat-specific post-processing of MCP tool results."""
+
+    def test_sku_availability_sorted_by_price(self):
+        """get_sku_availability with include_prices should sort by PAYGO ascending."""
+        skus = [
+            {"name": "expensive", "pricing": {"paygo": 10.0}},
+            {"name": "cheap", "pricing": {"paygo": 1.0}},
+            {"name": "no_price", "pricing": {"paygo": None}},
+        ]
+        result = _post_process_tool_result(
+            "get_sku_availability", {"include_prices": True}, json.dumps(skus)
+        )
+        parsed = json.loads(result)
+        assert parsed[0]["name"] == "cheap"
+        assert parsed[1]["name"] == "expensive"
+        assert parsed[2]["name"] == "no_price"
+
+    def test_sku_availability_no_sort_without_prices(self):
+        """get_sku_availability without include_prices should not re-sort."""
+        skus = [{"name": "B"}, {"name": "A"}]
+        result = _post_process_tool_result("get_sku_availability", {}, json.dumps(skus))
+        parsed = json.loads(result)
+        assert parsed[0]["name"] == "B"  # preserved original order
+
+    def test_pricing_detail_hint_on_null_prices(self):
+        """get_sku_pricing_detail should add a hint when all prices are null."""
+        data = {
+            "skuName": "M128",
+            "paygo": None,
+            "spot": None,
+            "ri_1y": None,
+            "ri_3y": None,
+            "sp_1y": None,
+            "sp_3y": None,
+        }
+        result = _post_process_tool_result(
+            "get_sku_pricing_detail",
+            {"sku_name": "M128"},
+            json.dumps(data),
+        )
+        parsed = json.loads(result)
+        assert "hint" in parsed
+        assert "get_sku_availability" in parsed["hint"]
+
+    def test_pricing_detail_no_hint_with_prices(self):
+        """get_sku_pricing_detail should NOT add a hint when prices exist."""
+        data = {
+            "skuName": "Standard_D2s_v5",
+            "paygo": 0.1,
+            "spot": 0.05,
+            "ri_1y": None,
+            "ri_3y": None,
+            "sp_1y": None,
+            "sp_3y": None,
+        }
+        result = _post_process_tool_result(
+            "get_sku_pricing_detail",
+            {"sku_name": "Standard_D2s_v5"},
+            json.dumps(data),
+        )
+        parsed = json.loads(result)
+        assert "hint" not in parsed
+
+    def test_passthrough_for_other_tools(self):
+        """Other tools should return the result unchanged."""
+        original = '{"tenants": [{"id": "abc"}]}'
+        result = _post_process_tool_result("list_tenants", {}, original)
+        assert result == original

--- a/tests/test_azure_api.py
+++ b/tests/test_azure_api.py
@@ -1,0 +1,41 @@
+"""Tests for azure_api helper functions."""
+
+from az_scout.azure_api import _sku_name_matches
+
+
+class TestSkuNameMatches:
+    """Tests for the fuzzy SKU name matching logic."""
+
+    def test_exact_substring(self) -> None:
+        assert _sku_name_matches("d2s", "standard_d2s_v3")
+
+    def test_hyphen_normalised_to_underscore(self) -> None:
+        assert _sku_name_matches("d2s-v3", "standard_d2s_v3")
+
+    def test_multi_part_fuzzy(self) -> None:
+        # "FX48-v2" → parts ["fx48", "v2"] both in "standard_fx48mds_v2"
+        assert _sku_name_matches("fx48-v2", "standard_fx48mds_v2")
+
+    def test_multi_part_order_matters(self) -> None:
+        # Parts must appear in order
+        assert not _sku_name_matches("v2-fx48", "standard_fx48mds_v2")
+
+    def test_single_part_no_match(self) -> None:
+        assert not _sku_name_matches("xyz", "standard_d2s_v3")
+
+    def test_single_part_match(self) -> None:
+        assert _sku_name_matches("d2s", "standard_d2s_v5")
+
+    def test_empty_sku_name(self) -> None:
+        assert not _sku_name_matches("d2s", "")
+
+    def test_case_insensitive_assumed(self) -> None:
+        # Caller is responsible for lowering; test with already-lower inputs
+        assert _sku_name_matches("nc24", "standard_nc24ads_a100_v4")
+
+    def test_multi_part_three_segments(self) -> None:
+        assert _sku_name_matches("nc-a100-v4", "standard_nc24ads_a100_v4")
+
+    def test_no_false_positive_partial_overlap(self) -> None:
+        # "d48-v3" should not match "standard_d4s_v3" (d4 != d48)
+        assert not _sku_name_matches("d48-v3", "standard_d4s_v3")


### PR DESCRIPTION
## Description

Add a Planner chat mode (pill-style Discussion | Planner toggle) with a dedicated system prompt guiding users through three VM deployment planning paths: region selection, SKU selection, and zone selection. Each mode maintains independent conversation state in localStorage.

**Backend refactoring:** The chat layer now derives tool definitions and execution directly from the MCP server instead of maintaining duplicates.

**Other improvements:**

- Fuzzy SKU name matching (FX48-v2 → Standard_FX48mds_v2) and fuzzy pricing fallback
- 429 retry logic with Retry-After support
- Smart tool result truncation (30K chars, price-sorted so cheapest survive)
- Subscription ID validation before Azure API calls
- +432 lines of new tests (193 total, all passing)

## Related issue

Closes #22 

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<img width="715" height="826" alt="image" src="https://github.com/user-attachments/assets/227a2f13-8817-48a6-bf86-51039ffd0c9d" />
