### PR TITLE
fix: match font-weight in text measurement for subscription labels (#29)

### DIFF
--- a/src/az_scout/static/js/app.js
+++ b/src/az_scout/static/js/app.js
@@ -556,8 +556,8 @@ function renderGraph(data) {
 
     // Measure text widths
     const measurer = d3.select(container).append("svg").attr("class", "measurer").style("position", "absolute").style("visibility", "hidden");
-    const measureText = (txt, fontSize) => {
-        const t = measurer.append("text").attr("font-size", fontSize).attr("font-weight", 500)
+    const measureText = (txt, fontSize, fontWeight = 500) => {
+        const t = measurer.append("text").attr("font-size", fontSize).attr("font-weight", fontWeight)
             .attr("font-family", "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif").text(txt);
         const w = t.node().getComputedTextLength();
         t.remove();
@@ -568,7 +568,7 @@ function renderGraph(data) {
     const subLabels = validData.map(d => truncate(getSubName(d.subscriptionId), 22));
     const maxLZText = Math.max(100, ...lzLabels.map(l => measureText(l, 13)));
     const maxPZText = Math.max(100, ...pzLabels.map(l => measureText(l, 13)));
-    const maxSubText = Math.max(100, ...subLabels.map(l => measureText(l, 12)));
+    const maxSubText = Math.max(100, ...subLabels.map(l => measureText(l, 12, 600)));
     measurer.remove();
 
     const nodePadX = 24;


### PR DESCRIPTION
## Description

measureText() hardcoded font-weight 500 but .group-label-left renders at 600, causing subscription names to overflow their graph boxes.

## Related issue

Closes #29 

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<img width="783" height="291" alt="image" src="https://github.com/user-attachments/assets/1a4325cc-e202-4f8a-9deb-322dbfb2f32d" />
