### PR TITLE
feat: capacity reservation guidance in AI prompts; fix schema converter (#30, #34)

### DIFF
--- a/src/az_scout/services/ai_chat.py
+++ b/src/az_scout/services/ai_chat.py
@@ -83,6 +83,15 @@ subscription. When discussing zone recommendations, **always** call \
 `get_zone_mappings` to also show the physical zone mapping and present both \
 (e.g. "logical zone 2 → physical zone 1"). This avoids confusion since the same \
 logical number points to different physical zones across subscriptions.
+- **Capacity reservation:** When the conversation concludes on a specific VM \
+SKU recommendation, proactively suggest **Azure Capacity Reservations** as a \
+way to secure guaranteed capacity in the target region and zone. Mention that \
+capacity reservations ensure VM allocation even during high-demand periods, and \
+that they can be created for a specific SKU, region, and zone combination. Note \
+that capacity reservations are billed at the PAYG rate whether or not VMs are \
+deployed — but this cost is offset when VMs are running. Recommend capacity \
+reservations especially when: the workload is critical, the SKU shows \
+restrictions in some zones, or the confidence score is below High (< 80).
 """
 
 # ---------------------------------------------------------------------------
@@ -216,6 +225,14 @@ Steps:
 - **Spot scores:** Never assume a VM SKU lacks Spot Placement Scores. The \
   `get_spot_scores` tool works for any SKU. Always call it when discussing \
   Spot VMs rather than guessing availability.
+- **Capacity reservation:** When concluding with a SKU recommendation, \
+  proactively suggest **Azure Capacity Reservations** to secure guaranteed \
+  capacity in the target region and zone. Capacity reservations ensure VM \
+  allocation even during high-demand periods and can be created for a specific \
+  SKU, region, and zone combination. They are billed at the PAYG rate whether \
+  or not VMs are deployed (cost is offset when VMs run). Recommend them \
+  especially when: the workload is critical, the SKU shows restrictions in \
+  some zones, or the confidence score is below High (< 80).
 - If the user deviates or asks a side question, answer it briefly, then steer back.
 - When done, present a clear summary of the recommendation.
 """
@@ -287,6 +304,8 @@ def _mcp_schema_to_openai(params: dict[str, Any]) -> dict[str, Any]:
             real_types = [t for t in schema["anyOf"] if t.get("type") != "null"]
             if real_types:
                 prop["type"] = real_types[0]["type"]
+                if "items" in real_types[0]:
+                    prop["items"] = real_types[0]["items"]
         else:
             if "type" in schema:
                 prop["type"] = schema["type"]

--- a/src/az_scout/services/eviction_rate.py
+++ b/src/az_scout/services/eviction_rate.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import requests
 
@@ -191,8 +191,8 @@ def get_spot_eviction_rate(
             _eviction_cache[cache_key] = (time.monotonic(), result)
             return result
 
-        data = resp.json()
-        rows = data.get("data", {}).get("rows", [])
+        resp_data: dict[str, Any] = resp.json()
+        rows = resp_data.get("data", {}).get("rows", [])
         if not rows:
             result = EvictionRateResult(
                 evictionRate=None,


### PR DESCRIPTION
## Description

feat: capacity reservation guidance in AI prompts; fix schema converter (#30, #34)

- Add capacity reservation tip to Discussion and Planner system prompts,
  suggesting Azure Capacity Reservations when concluding on a VM SKU
  recommendation (#30).

- Propagate `items` from anyOf branches in _mcp_schema_to_openai so
  list[str]|None parameters (allow_regions, deny_regions) produce valid
  OpenAI function schemas (#34).

- Fix mypy attr-defined error in eviction_rate.py (rename shadowed
  variable, add explicit type annotation).

## Related issue

Closes #30 and #34

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
