### PR TITLE
feat: Plugin Manager update support

### DIFF
--- a/src/az_scout/static/html/plugins.html
+++ b/src/az_scout/static/html/plugins.html
@@ -54,7 +54,19 @@
     <!-- Installed (UI) -->
     <div>
         <div class="card">
-            <div class="card-header"><i class="bi bi-box-seam me-1"></i>Installed (UI)</div>
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <span><i class="bi bi-box-seam me-1"></i>Installed (UI)</span>
+                <div class="d-flex gap-1">
+                    <button class="btn btn-outline-info btn-sm py-0 px-2" id="pm-check-updates-btn"
+                            onclick="pmCheckUpdates()" title="Check for updates">
+                        <i class="bi bi-arrow-repeat me-1"></i>Check updates
+                    </button>
+                    <button class="btn btn-primary btn-sm py-0 px-2 d-none" id="pm-update-all-btn"
+                            onclick="pmUpdateAll()" title="Update all plugins">
+                        <i class="bi bi-cloud-download me-1"></i>Update all
+                    </button>
+                </div>
+            </div>
             <div class="card-body p-0">
                 <div id="pm-installed-empty" class="text-center text-body-secondary py-3">
                     No plugins installed via UI
@@ -66,9 +78,10 @@
                             <tr>
                                 <th>Distribution</th>
                                 <th>Repo</th>
-                                <th>Ref</th>
-                                <th>SHA</th>
                                 <th>Installed</th>
+                                <th>Latest</th>
+                                <th>Status</th>
+                                <th>Installed at</th>
                                 <th></th>
                             </tr>
                         </thead>


### PR DESCRIPTION
## Summary

Add update support to the Plugin Manager: check for latest versions, update single plugin, and update all plugins.

### Changes

**Backend (`plugin_manager.py`)**
- Extend `InstalledPluginRecord` with update tracking fields (`last_checked_at`, `latest_ref`, `latest_sha`, `update_available`) — backward-compatible
- Add `fetch_latest_ref()` for GitHub latest version detection (releases API → tags fallback)
- Add `check_updates()`, `update_plugin()`, `update_all_plugins()` business logic
- Audit logging for `check_updates`, `update`, `update_all` actions

**API (`routes/__init__.py`)**
- `GET /api/plugins/updates` — check all plugins for available updates
- `POST /api/plugins/update` — update a single plugin by distribution name
- `POST /api/plugins/update-all` — update all plugins with available updates

**UI (`plugins.html` + `plugins.js`)**
- Check updates button + Update all button in plugin manager header
- New table columns: Installed version, Latest version, Status badge
- Per-plugin Update button when update is available

**Tests (`test_plugin_manager.py`)**
- 17 new tests (40 total for plugin manager)
- Covers: fetch_latest_ref, backward compatibility, check_updates, update_plugin, update_all_plugins, API routes

### Quality
- ruff lint ✅
- ruff format ✅  
- mypy strict (41 files) ✅
- pytest (331 tests) ✅