### PR TITLE
chore: add data/plugins/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ wheels/
 .vscode/
 !.vscode/tasks.json
 .env
+data/plugins/
 
 # Tool caches
 .mypy_cache/


### PR DESCRIPTION
Add `data/plugins/` to .gitignore to prevent committing plugin runtime data.