### PR TITLE
feat: in-process hot-reload for plugins (closes #60)

### DIFF
--- a/src/az_scout/app.py
+++ b/src/az_scout/app.py
@@ -50,10 +50,12 @@ _PKG_DIR = Path(__file__).resolve().parent
 @asynccontextmanager
 async def _lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Warm the tenant cache, reconcile & register plugins, and start the MCP session manager."""
+    # Store MCP server ref so route handlers can call reload_plugins()
+    _app.state.mcp_server = _mcp_server
     t = threading.Thread(target=azure_api.preload_discovery, daemon=True)
     t.start()
     # Reconcile plugins: reinstall any that are in installed.json but missing
-    # from the venv (e.g. after a container scale-to-zero restart).
+    # from the packages dir (e.g. after a container restart).
     reconcile_installed_plugins()
     # Discover and register plugins (routes, static, MCP tools, chat modes)
     register_plugins(_app, _mcp_server)

--- a/src/az_scout/plugins.py
+++ b/src/az_scout/plugins.py
@@ -5,10 +5,16 @@ installed packages that expose an ``az_scout.plugins`` entry point.
 Then :func:`register_plugins` wires up routes, static files, MCP tools,
 and chat modes contributed by each plugin.
 
+After install/uninstall/update, :func:`reload_plugins` performs an
+in-process hot-reload: it tears down old routes, static mounts, MCP tools,
+and chat modes, flushes the Python module cache for plugin packages, then
+re-discovers and re-registers everything.
+
 Plugins may be installed in the main environment or in the dedicated
 ``plugin-packages`` directory managed by the Plugin Manager UI.
 """
 
+import importlib
 import importlib.metadata
 import logging
 import sys
@@ -26,6 +32,8 @@ logger = logging.getLogger(__name__)
 _loaded_plugins: list[AzScoutPlugin] = []
 _plugin_dist_names: dict[str, str] = {}  # plugin.name → pip distribution name
 _plugin_chat_modes: dict[str, ChatMode] = {}
+_plugin_mcp_tool_names: dict[str, list[str]] = {}  # plugin.name → list of MCP tool names
+_plugin_route_prefixes: set[str] = set()  # tracked prefixes for route cleanup
 
 
 def _ensure_plugin_packages_on_path() -> None:
@@ -124,7 +132,9 @@ def _register_one(app: FastAPI, mcp_server: Any, plugin: AzScoutPlugin) -> None:
     try:
         router = plugin.get_router()
         if router is not None:
-            app.include_router(router, prefix=f"/plugins/{name}", tags=[f"Plugin: {name}"])
+            prefix = f"/plugins/{name}"
+            app.include_router(router, prefix=prefix, tags=[f"Plugin: {name}"])
+            _plugin_route_prefixes.add(prefix)
             logger.info("Registered API routes for plugin '%s'", name)
     except Exception:
         logger.exception("Failed to register routes for plugin '%s'", name)
@@ -133,8 +143,9 @@ def _register_one(app: FastAPI, mcp_server: Any, plugin: AzScoutPlugin) -> None:
     try:
         static_dir = plugin.get_static_dir()
         if static_dir is not None:
+            mount_path = f"/plugins/{name}/static"
             app.mount(
-                f"/plugins/{name}/static",
+                mount_path,
                 StaticFiles(directory=str(static_dir)),
                 name=f"plugin-{name}-static",
             )
@@ -146,8 +157,11 @@ def _register_one(app: FastAPI, mcp_server: Any, plugin: AzScoutPlugin) -> None:
     try:
         tools = plugin.get_mcp_tools()
         if tools:
+            tool_names: list[str] = []
             for fn in tools:
                 mcp_server.tool()(fn)
+                tool_names.append(fn.__name__)
+            _plugin_mcp_tool_names[name] = tool_names
             logger.info("Registered %d MCP tool(s) for plugin '%s'", len(tools), name)
     except Exception:
         logger.exception("Failed to register MCP tools for plugin '%s'", name)
@@ -171,6 +185,77 @@ def get_loaded_plugins() -> list[AzScoutPlugin]:
 def get_plugin_chat_modes() -> dict[str, ChatMode]:
     """Return all chat modes contributed by plugins, keyed by mode ID."""
     return dict(_plugin_chat_modes)
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload helpers
+# ---------------------------------------------------------------------------
+
+
+def _unregister_all(app: FastAPI, mcp_server: Any) -> None:
+    """Remove all plugin routes, static mounts, MCP tools, and chat modes."""
+    # Remove FastAPI routes whose path starts with a known plugin prefix
+    prefixes_to_remove = set(_plugin_route_prefixes)
+    # Also remove static mounts at /plugins/*/static
+    for plugin in _loaded_plugins:
+        prefixes_to_remove.add(f"/plugins/{plugin.name}/static")
+
+    if prefixes_to_remove:
+        app.routes[:] = [
+            r
+            for r in app.routes
+            if not any(getattr(r, "path", "").startswith(p) for p in prefixes_to_remove)
+        ]
+        logger.debug("Removed plugin routes for prefixes: %s", prefixes_to_remove)
+
+    # Remove MCP tools
+    for tool_names in _plugin_mcp_tool_names.values():
+        for name in tool_names:
+            try:
+                mcp_server.remove_tool(name)
+                logger.debug("Removed MCP tool '%s'", name)
+            except Exception:
+                logger.debug("MCP tool '%s' already absent", name)
+
+    # Clear registries
+    _loaded_plugins.clear()
+    _plugin_dist_names.clear()
+    _plugin_chat_modes.clear()
+    _plugin_mcp_tool_names.clear()
+    _plugin_route_prefixes.clear()
+
+
+def _flush_plugin_modules() -> None:
+    """Remove plugin-related modules from ``sys.modules`` so reimport picks up new code."""
+    if not _PACKAGES_DIR.exists():
+        return
+    pkg_str = str(_PACKAGES_DIR)
+    stale = [
+        name
+        for name, mod in sys.modules.items()
+        if mod is not None
+        and hasattr(mod, "__file__")
+        and mod.__file__ is not None
+        and mod.__file__.startswith(pkg_str)
+    ]
+    for name in stale:
+        del sys.modules[name]
+    if stale:
+        logger.info("Flushed %d plugin module(s) from sys.modules", len(stale))
+    # Also invalidate importlib caches so fresh distributions are found
+    importlib.invalidate_caches()
+
+
+def reload_plugins(app: FastAPI, mcp_server: Any) -> list[AzScoutPlugin]:
+    """Hot-reload all plugins: tear down, flush caches, re-discover, re-register.
+
+    Call this after plugin install/uninstall/update to pick up changes
+    without restarting the process.
+    """
+    logger.info("Hot-reloading plugins …")
+    _unregister_all(app, mcp_server)
+    _flush_plugin_modules()
+    return register_plugins(app, mcp_server)
 
 
 def _get_plugin_homepage(plugin_name: str) -> str:

--- a/src/az_scout/routes/__init__.py
+++ b/src/az_scout/routes/__init__.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from az_scout import plugin_manager
-from az_scout.plugins import get_loaded_plugins
+from az_scout.plugins import get_loaded_plugins, reload_plugins
 
 router = APIRouter(prefix="/api/plugins", tags=["Plugin Manager"])
 
@@ -84,10 +84,11 @@ async def install_plugin(body: InstallRequest, request: Request) -> JSONResponse
         client_ip,
         user_agent,
     )
+    if ok:
+        reload_plugins(request.app, request.app.state.mcp_server)
     return JSONResponse(
         {
             "ok": ok,
-            "restart_required": ok,
             "warnings": warnings,
             "errors": errors,
         },
@@ -104,10 +105,11 @@ async def uninstall_plugin(body: UninstallRequest, request: Request) -> JSONResp
         client_ip,
         user_agent,
     )
+    if ok:
+        reload_plugins(request.app, request.app.state.mcp_server)
     return JSONResponse(
         {
             "ok": ok,
-            "restart_required": ok,
             "errors": errors,
         },
     )
@@ -131,10 +133,11 @@ async def update_plugin(body: UpdateRequest, request: Request) -> JSONResponse:
         client_ip,
         user_agent,
     )
+    if ok:
+        reload_plugins(request.app, request.app.state.mcp_server)
     return JSONResponse(
         {
             "ok": ok,
-            "restart_required": ok,
             "errors": errors,
         },
     )
@@ -149,10 +152,11 @@ async def update_all_plugins(request: Request) -> JSONResponse:
         client_ip,
         user_agent,
     )
+    if updated > 0:
+        reload_plugins(request.app, request.app.state.mcp_server)
     return JSONResponse(
         {
             "ok": failed == 0,
-            "restart_required": updated > 0,
             "updated": updated,
             "failed": failed,
             "details": details,

--- a/src/az_scout/static/html/plugins.html
+++ b/src/az_scout/static/html/plugins.html
@@ -43,12 +43,6 @@
                 </div>
             </div>
         </div>
-
-        <!-- Restart banner -->
-        <div id="pm-restart-banner" class="alert alert-warning d-none" role="alert">
-            <i class="bi bi-exclamation-triangle me-1"></i>
-            <strong>Restart required</strong> — the application must be restarted for plugin changes to take effect.
-        </div>
     </div>
 
     <!-- Installed (UI) -->

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -214,9 +214,8 @@
         try {
             const data = await apiPost("/api/plugins/install", { repo_url: repoUrl, ref: ref });
             if (data.ok) {
-                showRestart();
-                loadPlugins();
-                hideResult();
+                window.location.reload();
+                return;
             } else {
                 showResultError((data.errors || []).join("; "));
             }
@@ -235,8 +234,8 @@
         try {
             const data = await apiPost("/api/plugins/uninstall", { distribution_name: distName });
             if (data.ok) {
-                showRestart();
-                loadPlugins();
+                window.location.reload();
+                return;
             } else {
                 alert("Uninstall failed: " + (data.errors || []).join("; "));
             }
@@ -270,10 +269,8 @@
         try {
             const data = await apiPost("/api/plugins/update", { distribution_name: distName });
             if (data.ok) {
-                showRestart();
-                // Refresh update info
-                delete updateInfo[distName];
-                loadPlugins();
+                window.location.reload();
+                return;
             } else {
                 alert("Update failed: " + (data.errors || []).join("; "));
             }
@@ -292,13 +289,15 @@
         showSpinner("Updating all plugins…");
         try {
             const data = await apiPost("/api/plugins/update-all", {});
-            if (data.restart_required) {
-                showRestart();
+            if (data.updated > 0) {
+                window.location.reload();
+                return;
             }
             updateInfo = {};
             loadPlugins();
-            const msg = "Updated: " + data.updated + ", Failed: " + data.failed;
-            alert(msg);
+            if (data.failed > 0) {
+                alert("Some plugins failed to update: " + data.failed);
+            }
         } catch (e) {
             alert("Update all error: " + e.message);
         } finally {
@@ -391,11 +390,6 @@
     function disableInstall() {
         const btn = document.getElementById("pm-install-btn");
         if (btn) btn.disabled = true;
-    }
-
-    function showRestart() {
-        const el = document.getElementById("pm-restart-banner");
-        if (el) el.classList.remove("d-none");
     }
 
     function escHtml(s) {

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -305,9 +305,12 @@ class TestPluginRoutes:
         assert len(data["errors"]) > 0
 
     def test_install_success(self, client) -> None:  # type: ignore[no-untyped-def]
-        with patch(
-            "az_scout.routes.plugin_manager.install_plugin",
-            return_value=(True, [], []),
+        with (
+            patch(
+                "az_scout.routes.plugin_manager.install_plugin",
+                return_value=(True, [], []),
+            ),
+            patch("az_scout.routes.reload_plugins"),
         ):
             resp = client.post(
                 "/api/plugins/install",
@@ -317,7 +320,6 @@ class TestPluginRoutes:
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is True
-        assert data["restart_required"] is True
 
     def test_install_failure(self, client) -> None:  # type: ignore[no-untyped-def]
         with patch(
@@ -335,9 +337,12 @@ class TestPluginRoutes:
         assert "install failed" in data["errors"]
 
     def test_uninstall_success(self, client) -> None:  # type: ignore[no-untyped-def]
-        with patch(
-            "az_scout.routes.plugin_manager.uninstall_plugin",
-            return_value=(True, []),
+        with (
+            patch(
+                "az_scout.routes.plugin_manager.uninstall_plugin",
+                return_value=(True, []),
+            ),
+            patch("az_scout.routes.reload_plugins"),
         ):
             resp = client.post(
                 "/api/plugins/uninstall",
@@ -347,7 +352,6 @@ class TestPluginRoutes:
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is True
-        assert data["restart_required"] is True
 
     def test_uninstall_failure(self, client) -> None:  # type: ignore[no-untyped-def]
         with patch(
@@ -821,9 +825,12 @@ class TestUpdateRoutes:
         assert data["plugins"][0]["update_available"] is True
 
     def test_update_single_success(self, client) -> None:  # type: ignore[no-untyped-def]
-        with patch(
-            "az_scout.routes.plugin_manager.update_plugin",
-            return_value=(True, []),
+        with (
+            patch(
+                "az_scout.routes.plugin_manager.update_plugin",
+                return_value=(True, []),
+            ),
+            patch("az_scout.routes.reload_plugins"),
         ):
             resp = client.post(
                 "/api/plugins/update",
@@ -833,7 +840,6 @@ class TestUpdateRoutes:
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is True
-        assert data["restart_required"] is True
 
     def test_update_single_failure(self, client) -> None:  # type: ignore[no-untyped-def]
         with patch(
@@ -850,16 +856,19 @@ class TestUpdateRoutes:
         assert data["ok"] is False
 
     def test_update_all(self, client) -> None:  # type: ignore[no-untyped-def]
-        with patch(
-            "az_scout.routes.plugin_manager.update_all_plugins",
-            return_value=(
-                2,
-                0,
-                [
-                    {"distribution_name": "a", "ok": True},
-                    {"distribution_name": "b", "ok": True},
-                ],
+        with (
+            patch(
+                "az_scout.routes.plugin_manager.update_all_plugins",
+                return_value=(
+                    2,
+                    0,
+                    [
+                        {"distribution_name": "a", "ok": True},
+                        {"distribution_name": "b", "ok": True},
+                    ],
+                ),
             ),
+            patch("az_scout.routes.reload_plugins"),
         ):
             resp = client.post("/api/plugins/update-all")
 
@@ -867,7 +876,6 @@ class TestUpdateRoutes:
         data = resp.json()
         assert data["ok"] is True
         assert data["updated"] == 2
-        assert data["restart_required"] is True
 
     def test_update_all_with_failures(self, client) -> None:  # type: ignore[no-untyped-def]
         with patch(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,6 @@
 """Tests for the plugin discovery and registration system."""
 
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -11,10 +12,14 @@ from az_scout.plugin_api import AzScoutPlugin, ChatMode, TabDefinition
 from az_scout.plugins import (
     _loaded_plugins,
     _plugin_chat_modes,
+    _plugin_mcp_tool_names,
+    _plugin_route_prefixes,
+    _unregister_all,
     discover_plugins,
     get_plugin_chat_modes,
     get_plugin_metadata,
     register_plugins,
+    reload_plugins,
 )
 
 
@@ -119,9 +124,13 @@ def _clear_plugin_registries():
     """Reset module-level plugin registries between tests."""
     _loaded_plugins.clear()
     _plugin_chat_modes.clear()
+    _plugin_mcp_tool_names.clear()
+    _plugin_route_prefixes.clear()
     yield
     _loaded_plugins.clear()
     _plugin_chat_modes.clear()
+    _plugin_mcp_tool_names.clear()
+    _plugin_route_prefixes.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +350,247 @@ class TestPluginChatModeIntegration:
 
         prompt = _build_system_prompt(mode="discussion")
         assert prompt.startswith(SYSTEM_PROMPT[:50])
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload: _unregister_all
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisterAll:
+    """Tests for _unregister_all() — cleans up routes, MCP tools, and chat modes."""
+
+    def test_removes_plugin_routes(self):
+        """After unregister, plugin route prefixes are removed from app.routes."""
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            register_plugins(app, mock_mcp)
+
+        # Plugin route should be present
+        paths = [getattr(r, "path", "") for r in app.routes]
+        assert any(p.startswith("/plugins/test-full") for p in paths)
+
+        _unregister_all(app, mock_mcp)
+
+        # Plugin routes should be gone
+        paths_after = [getattr(r, "path", "") for r in app.routes]
+        assert not any(p.startswith("/plugins/test-full") for p in paths_after)
+
+    def test_removes_mcp_tools(self):
+        """MCP server.remove_tool() is called for each registered tool."""
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            register_plugins(app, mock_mcp)
+
+        _unregister_all(app, mock_mcp)
+
+        mock_mcp.remove_tool.assert_called_once_with("my_tool")
+
+    def test_clears_chat_modes(self):
+        """Plugin chat modes are cleared after unregister."""
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            register_plugins(app, mock_mcp)
+
+        assert "test-mode" in _plugin_chat_modes
+
+        _unregister_all(app, mock_mcp)
+
+        assert len(_plugin_chat_modes) == 0
+        assert len(_loaded_plugins) == 0
+
+    def test_clears_tracking_registries(self):
+        """All internal tracking registries are cleared after unregister."""
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            register_plugins(app, mock_mcp)
+
+        assert len(_plugin_mcp_tool_names) == 1
+        assert len(_plugin_route_prefixes) >= 1
+
+        _unregister_all(app, mock_mcp)
+
+        assert len(_plugin_mcp_tool_names) == 0
+        assert len(_plugin_route_prefixes) == 0
+
+    def test_tolerates_missing_mcp_tool(self):
+        """If remove_tool raises, _unregister_all does not crash."""
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        mock_mcp = MagicMock()
+        mock_mcp.remove_tool.side_effect = Exception("not found")
+
+        from az_scout.app import app
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            register_plugins(app, mock_mcp)
+
+        # Should not raise
+        _unregister_all(app, mock_mcp)
+
+        assert len(_loaded_plugins) == 0
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload: _flush_plugin_modules
+# ---------------------------------------------------------------------------
+
+
+class TestFlushPluginModules:
+    """Tests for _flush_plugin_modules() — removes stale modules from sys.modules."""
+
+    def test_removes_modules_under_packages_dir(self):
+        """Modules with __file__ under _PACKAGES_DIR are flushed."""
+        from az_scout.plugin_manager import _PACKAGES_DIR
+        from az_scout.plugins import _flush_plugin_modules
+
+        fake_mod = MagicMock()
+        fake_mod.__file__ = str(_PACKAGES_DIR / "az_scout_myplugin" / "__init__.py")
+        sys.modules["az_scout_myplugin"] = fake_mod
+
+        _PACKAGES_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            _flush_plugin_modules()
+        finally:
+            sys.modules.pop("az_scout_myplugin", None)
+
+        assert "az_scout_myplugin" not in sys.modules
+
+    def test_keeps_non_plugin_modules(self):
+        """Modules outside _PACKAGES_DIR are not removed."""
+        from az_scout.plugin_manager import _PACKAGES_DIR
+        from az_scout.plugins import _flush_plugin_modules
+
+        original_count = len(sys.modules)
+
+        _PACKAGES_DIR.mkdir(parents=True, exist_ok=True)
+        _flush_plugin_modules()
+
+        # Core modules should still be present
+        assert "sys" in sys.modules
+        assert "os" in sys.modules
+        assert len(sys.modules) == original_count
+
+    def test_noop_when_packages_dir_missing(self):
+        """No crash when _PACKAGES_DIR doesn't exist."""
+        from az_scout.plugin_manager import _PACKAGES_DIR
+        from az_scout.plugins import _flush_plugin_modules
+
+        # Ensure dir does not exist
+        if _PACKAGES_DIR.exists():
+            import shutil
+
+            shutil.rmtree(_PACKAGES_DIR)
+
+        _flush_plugin_modules()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload: reload_plugins
+# ---------------------------------------------------------------------------
+
+
+class TestReloadPlugins:
+    """Tests for reload_plugins() — the main hot-reload entry point."""
+
+    def test_reload_replaces_plugins(self):
+        """After reload, the loaded plugins reflect the current entry points."""
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            register_plugins(app, mock_mcp)
+
+        assert len(_loaded_plugins) == 1
+
+        # Reload with no plugins
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[]):
+            reload_plugins(app, mock_mcp)
+
+        assert len(_loaded_plugins) == 0
+        assert len(_plugin_chat_modes) == 0
+
+    def test_reload_picks_up_new_plugin(self):
+        """A newly installed plugin is discovered after reload."""
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        # Start with no plugins
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[]):
+            register_plugins(app, mock_mcp)
+
+        assert len(_loaded_plugins) == 0
+
+        # Install a plugin, then reload
+        full = FullPlugin()
+        mock_ep = MagicMock()
+        mock_ep.name = "test-full"
+        mock_ep.load.return_value = full
+
+        with patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[mock_ep]):
+            result = reload_plugins(app, mock_mcp)
+
+        assert len(result) == 1
+        assert result[0].name == "test-full"
+        assert "test-mode" in _plugin_chat_modes
+
+    def test_reload_calls_unregister_and_flush(self):
+        """reload_plugins delegates to _unregister_all and _flush_plugin_modules."""
+        mock_mcp = MagicMock()
+
+        from az_scout.app import app
+
+        with (
+            patch("az_scout.plugins._unregister_all") as mock_unreg,
+            patch("az_scout.plugins._flush_plugin_modules") as mock_flush,
+            patch("az_scout.plugins.importlib.metadata.entry_points", return_value=[]),
+        ):
+            reload_plugins(app, mock_mcp)
+
+        mock_unreg.assert_called_once_with(app, mock_mcp)
+        mock_flush.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Implements in-process plugin hot-reload so that install, uninstall, and update operations take effect immediately without restarting the application.

After a successful mutation, the backend tears down old routes, static mounts, MCP tools, and chat modes, flushes stale plugin modules from `sys.modules`, then re-discovers and re-registers everything. The frontend simply reloads the page to pick up the changes.

### Key changes

- **`plugins.py`**: New `reload_plugins()` orchestrating `_unregister_all()` → `_flush_plugin_modules()` → `register_plugins()`. Added tracking registries (`_plugin_mcp_tool_names`, `_plugin_route_prefixes`) for clean teardown.
- **`routes/__init__.py`**: All mutation endpoints call `reload_plugins()` on success. Removed `restart_required` from responses.
- **`app.py`**: Store `_mcp_server` on `app.state` so route handlers can pass it to `reload_plugins()`.
- **`plugins.js` + `plugins.html`**: Replaced restart banner with `window.location.reload()`.
- **Tests**: 10 new tests for `_unregister_all`, `_flush_plugin_modules`, `reload_plugins`. Updated 5 existing route tests.

## Related issue

Closes #60

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<!-- N/A – no visual change beyond removing the restart banner. -->
