### PR TITLE
feat(plugins): support PyPI as plugin source with auto‑resolve to latest

### DIFF
--- a/src/az_scout/plugin_manager.py
+++ b/src/az_scout/plugin_manager.py
@@ -1,10 +1,15 @@
 """Plugin manager – validate, install, and uninstall az-scout plugins.
 
-Only public GitHub repositories are supported.  Installation pins to a
-resolved commit SHA so that builds are reproducible.  Plugins are installed
-into a flat ``plugin-packages`` directory via ``pip install --target``,
-avoiding the need for a virtual environment (which is problematic on
-filesystems that do not support symlinks, such as Azure Files / SMB).
+Plugins can be installed from two sources:
+
+* **GitHub** – public repositories, pinned to a resolved commit SHA for
+  reproducible builds.
+* **PyPI** – standard Python packages, pinned to a specific version.
+
+Plugins are installed into a flat ``plugin-packages`` directory via
+``pip install --target``, avoiding the need for a virtual environment
+(which is problematic on filesystems that do not support symlinks, such
+as Azure Files / SMB).
 
 Business logic lives here; FastAPI route handlers are thin wrappers.
 """
@@ -38,6 +43,10 @@ _GITHUB_URL_RE = re.compile(
     r"^https://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)/?$"
 )
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+_PYPI_API_BASE = "https://pypi.org/pypi"
+# PEP 508 / PEP 625 compatible name pattern
+_PYPI_PACKAGE_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$")
 
 
 def _default_data_dir() -> Path:
@@ -82,8 +91,10 @@ class PluginValidationResult:
     repo: str
     repo_url: str
     ref: str
+    source: str = "github"  # "github" or "pypi"
     resolved_sha: str | None = None
     distribution_name: str | None = None
+    version: str | None = None  # resolved PyPI version
     entry_points: dict[str, str] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
@@ -98,6 +109,7 @@ class InstalledPluginRecord:
     entry_points: dict[str, str]
     installed_at: str  # ISO-8601
     actor: str
+    source: str = "github"  # "github" or "pypi"
     # Update-related fields (optional for backward compatibility)
     last_checked_at: str | None = None
     latest_ref: str | None = None
@@ -124,6 +136,11 @@ def parse_github_repo_url(repo_url: str) -> GitHubRepo | None:
 def is_commit_sha(ref: str) -> bool:
     """Return ``True`` if *ref* looks like a 40-hex-char commit SHA."""
     return bool(_SHA_RE.match(ref))
+
+
+def is_pypi_source(source: str) -> bool:
+    """Return ``True`` when *source* is a PyPI package name (not a URL)."""
+    return not source.startswith("http") and bool(_PYPI_PACKAGE_RE.match(source.strip()))
 
 
 # ---------------------------------------------------------------------------
@@ -191,9 +208,10 @@ def parse_pyproject_toml(toml_text: str) -> dict[str, Any]:
     return tomllib.loads(toml_text)
 
 
-def validate_plugin_repo(repo_url: str, ref: str) -> PluginValidationResult:
+def validate_plugin_repo(repo_url: str, ref: str = "") -> PluginValidationResult:
     """Validate that a GitHub repository is a conforming az-scout plugin.
 
+    When *ref* is empty the latest release or tag is resolved automatically.
     This fetches and inspects ``pyproject.toml`` without executing any code.
     """
     gh = parse_github_repo_url(repo_url)
@@ -206,6 +224,20 @@ def validate_plugin_repo(repo_url: str, ref: str) -> PluginValidationResult:
             ref=ref,
             errors=["Invalid GitHub URL. Expected https://github.com/<owner>/<repo>"],
         )
+
+    # Auto-resolve to latest when no ref is provided
+    if not ref:
+        try:
+            ref, _ = fetch_latest_ref(gh.owner, gh.repo)
+        except Exception as exc:
+            return PluginValidationResult(
+                ok=False,
+                owner=gh.owner,
+                repo=gh.repo,
+                repo_url=repo_url,
+                ref="",
+                errors=[f"Cannot determine latest version: {exc}"],
+            )
 
     result = PluginValidationResult(
         ok=False,
@@ -354,6 +386,7 @@ def _record_from_dict(data: dict[str, Any]) -> InstalledPluginRecord:
         "entry_points",
         "installed_at",
         "actor",
+        "source",
         "last_checked_at",
         "latest_ref",
         "latest_sha",
@@ -429,7 +462,9 @@ def install_plugin(
         )
         return False, validation.warnings, validation.errors
 
-    sha = validation.resolved_sha or ref
+    # Use the ref resolved by validation (may differ from input when auto-resolved)
+    resolved_ref = validation.ref
+    sha = validation.resolved_sha or resolved_ref
     clean_url = repo_url.rstrip("/")
     if not clean_url.endswith(".git"):
         clean_url += ".git"
@@ -445,7 +480,7 @@ def install_plugin(
             client_ip,
             user_agent,
             repo_url=repo_url,
-            ref=ref,
+            ref=resolved_ref,
             resolved_sha=sha,
             distribution_name=validation.distribution_name,
             success=False,
@@ -462,7 +497,7 @@ def install_plugin(
         InstalledPluginRecord(
             distribution_name=dist_name,
             repo_url=repo_url,
-            ref=ref,
+            ref=resolved_ref,
             resolved_sha=sha,
             entry_points=validation.entry_points,
             installed_at=datetime.now(UTC).isoformat(),
@@ -477,7 +512,7 @@ def install_plugin(
         client_ip,
         user_agent,
         repo_url=repo_url,
-        ref=ref,
+        ref=resolved_ref,
         resolved_sha=sha,
         distribution_name=dist_name,
         success=True,
@@ -528,6 +563,206 @@ def fetch_latest_ref(owner: str, repo: str) -> tuple[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# PyPI helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_pypi_metadata(
+    package_name: str,
+    version: str = "",
+) -> dict[str, Any]:
+    """Fetch package metadata from the PyPI JSON API.
+
+    When *version* is given, fetches that specific release.
+    Otherwise fetches the latest release.
+
+    Raises ``requests.HTTPError`` on network / 404 errors.
+    """
+    if version:
+        url = f"{_PYPI_API_BASE}/{package_name}/{version}/json"
+    else:
+        url = f"{_PYPI_API_BASE}/{package_name}/json"
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    data: dict[str, Any] = resp.json()
+    return data
+
+
+def validate_pypi_plugin(
+    package_name: str,
+    version: str = "",
+) -> PluginValidationResult:
+    """Validate that a PyPI package is a conforming az-scout plugin.
+
+    Checks:
+    - Package exists on PyPI
+    - Version exists (if specified)
+    - Naming convention ``az-scout-*`` (warning if not followed)
+    - ``az-scout`` listed as a dependency (warning if absent)
+    """
+    result = PluginValidationResult(
+        ok=False,
+        owner="",
+        repo="",
+        repo_url="",
+        ref=version,
+        source="pypi",
+        distribution_name=package_name,
+    )
+
+    # Validate package name format
+    if not _PYPI_PACKAGE_RE.match(package_name):
+        result.errors.append(
+            f"Invalid package name '{package_name}'. "
+            "Must contain only letters, digits, '.', '-', or '_'."
+        )
+        return result
+
+    # Fetch metadata from PyPI
+    try:
+        data = fetch_pypi_metadata(package_name, version)
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            if version:
+                result.errors.append(
+                    f"Version '{version}' of package '{package_name}' not found on PyPI"
+                )
+            else:
+                result.errors.append(f"Package '{package_name}' not found on PyPI")
+        else:
+            result.errors.append(f"PyPI API error: {exc}")
+        return result
+    except Exception as exc:
+        result.errors.append(f"Cannot reach PyPI: {exc}")
+        return result
+
+    info: dict[str, Any] = data.get("info", {})
+    resolved_version: str = info.get("version", version)
+    result.ref = resolved_version
+    result.version = resolved_version
+
+    # Naming convention warning
+    normalized_name = package_name.lower().replace("_", "-").replace(".", "-")
+    if not normalized_name.startswith("az-scout-"):
+        result.warnings.append(
+            f"Package '{package_name}' does not follow the 'az-scout-*' naming convention"
+        )
+
+    # Check dependencies for az-scout
+    requires_dist: list[str] = info.get("requires_dist") or []
+    dep_names = [re.split(r"[<>=!~\[;@ ]", d)[0].strip().lower() for d in requires_dist]
+    if "az-scout" not in dep_names:
+        result.warnings.append(
+            "Package dependencies do not include 'az-scout' — plugin may fail at runtime"
+        )
+
+    # Check project URLs for homepage
+    project_urls: dict[str, str] = info.get("project_urls") or {}
+    if project_urls:
+        homepage = project_urls.get("Homepage", "")
+        if homepage:
+            result.repo_url = homepage
+
+    if not result.errors:
+        result.ok = True
+
+    return result
+
+
+def install_pypi_plugin(
+    package_name: str,
+    version: str,
+    actor: str,
+    client_ip: str,
+    user_agent: str,
+) -> tuple[bool, list[str], list[str]]:
+    """Validate and install a plugin from PyPI.
+
+    Returns ``(ok, warnings, errors)``.
+    """
+    validation = validate_pypi_plugin(package_name, version)
+    if not validation.ok:
+        _audit_event(
+            "install",
+            actor,
+            client_ip,
+            user_agent,
+            distribution_name=package_name,
+            ref=version,
+            success=False,
+            detail="; ".join(validation.errors),
+        )
+        return False, validation.warnings, validation.errors
+
+    resolved_version = validation.version or validation.ref or version
+    pip_spec = f"{package_name}=={resolved_version}" if resolved_version else package_name
+
+    pip_result = run_pip(["pip", "install", pip_spec])
+    if pip_result.returncode != 0:
+        err_msg = f"pip install failed: {pip_result.stderr.strip()}"
+        validation.errors.append(err_msg)
+        _audit_event(
+            "install",
+            actor,
+            client_ip,
+            user_agent,
+            distribution_name=package_name,
+            ref=resolved_version,
+            success=False,
+            detail=err_msg,
+        )
+        return False, validation.warnings, validation.errors
+
+    # Update installed.json
+    records = load_installed()
+    # Remove previous entry for the same distribution (upgrade scenario)
+    records = [r for r in records if r.distribution_name != package_name]
+    records.append(
+        InstalledPluginRecord(
+            distribution_name=package_name,
+            repo_url=validation.repo_url,
+            ref=resolved_version,
+            resolved_sha="",
+            entry_points=validation.entry_points,
+            installed_at=datetime.now(UTC).isoformat(),
+            actor=actor,
+            source="pypi",
+        )
+    )
+    save_installed(records)
+
+    _audit_event(
+        "install",
+        actor,
+        client_ip,
+        user_agent,
+        distribution_name=package_name,
+        ref=resolved_version,
+        success=True,
+        detail="installed from PyPI",
+    )
+
+    return True, validation.warnings, []
+
+
+def fetch_pypi_latest_version(package_name: str) -> str:
+    """Return the latest version string for a PyPI package.
+
+    Raises ``ValueError`` when the package is not found.
+    """
+    try:
+        data = fetch_pypi_metadata(package_name)
+    except requests.HTTPError:
+        msg = f"Package '{package_name}' not found on PyPI"
+        raise ValueError(msg)  # noqa: B904
+    version: str = data.get("info", {}).get("version", "")
+    if not version:
+        msg = f"Cannot determine latest version for '{package_name}'"
+        raise ValueError(msg)
+    return version
+
+
+# ---------------------------------------------------------------------------
 # Check for updates
 # ---------------------------------------------------------------------------
 
@@ -548,6 +783,7 @@ def check_updates(
     for record in records:
         info: dict[str, Any] = {
             "distribution_name": record.distribution_name,
+            "source": record.source,
             "repo_url": record.repo_url,
             "installed_ref": record.ref,
             "resolved_sha": record.resolved_sha,
@@ -557,26 +793,40 @@ def check_updates(
             "error": None,
         }
 
-        gh = parse_github_repo_url(record.repo_url)
-        if gh is None:
-            info["error"] = "Invalid GitHub URL"
-            results.append(info)
-            continue
+        if record.source == "pypi":
+            try:
+                latest_version = fetch_pypi_latest_version(record.distribution_name)
+                info["latest_ref"] = latest_version
+                info["update_available"] = latest_version != record.ref
 
-        try:
-            latest_ref, latest_sha = fetch_latest_ref(gh.owner, gh.repo)
-            info["latest_ref"] = latest_ref
-            info["latest_sha"] = latest_sha
-            info["update_available"] = latest_sha != record.resolved_sha
+                record.last_checked_at = now
+                record.latest_ref = latest_version
+                record.latest_sha = None
+                record.update_available = latest_version != record.ref
+            except Exception as exc:
+                info["error"] = str(exc)
+                record.last_checked_at = now
+        else:
+            gh = parse_github_repo_url(record.repo_url)
+            if gh is None:
+                info["error"] = "Invalid GitHub URL"
+                results.append(info)
+                continue
 
-            # Update the record in-place for persistence
-            record.last_checked_at = now
-            record.latest_ref = latest_ref
-            record.latest_sha = latest_sha
-            record.update_available = latest_sha != record.resolved_sha
-        except Exception as exc:
-            info["error"] = str(exc)
-            record.last_checked_at = now
+            try:
+                latest_ref, latest_sha = fetch_latest_ref(gh.owner, gh.repo)
+                info["latest_ref"] = latest_ref
+                info["latest_sha"] = latest_sha
+                info["update_available"] = latest_sha != record.resolved_sha
+
+                # Update the record in-place for persistence
+                record.last_checked_at = now
+                record.latest_ref = latest_ref
+                record.latest_sha = latest_sha
+                record.update_available = latest_sha != record.resolved_sha
+            except Exception as exc:
+                info["error"] = str(exc)
+                record.last_checked_at = now
 
         results.append(info)
 
@@ -606,7 +856,9 @@ def update_plugin(
     client_ip: str,
     user_agent: str,
 ) -> tuple[bool, list[str]]:
-    """Update a single plugin to the latest GitHub release/tag.
+    """Update a single plugin to the latest version.
+
+    Supports both GitHub-sourced and PyPI-sourced plugins.
 
     Returns ``(ok, errors)``.
     """
@@ -626,6 +878,23 @@ def update_plugin(
             detail=errors[0],
         )
         return False, errors
+
+    if record.source == "pypi":
+        return _update_pypi_plugin(record, records, actor, client_ip, user_agent)
+
+    return _update_github_plugin(record, records, actor, client_ip, user_agent)
+
+
+def _update_github_plugin(
+    record: InstalledPluginRecord,
+    records: list[InstalledPluginRecord],
+    actor: str,
+    client_ip: str,
+    user_agent: str,
+) -> tuple[bool, list[str]]:
+    """Update a GitHub-sourced plugin to the latest release/tag."""
+    errors: list[str] = []
+    distribution_name = record.distribution_name
 
     gh = parse_github_repo_url(record.repo_url)
     if gh is None:
@@ -691,6 +960,7 @@ def update_plugin(
 
     # Update the record
     now = datetime.now(UTC).isoformat()
+    old_ref = record.ref
     record.ref = latest_ref
     record.resolved_sha = latest_sha
     record.installed_at = now
@@ -711,7 +981,81 @@ def update_plugin(
         resolved_sha=latest_sha,
         distribution_name=distribution_name,
         success=True,
-        detail=f"Updated from {record.ref} to {latest_ref}",
+        detail=f"Updated from {old_ref} to {latest_ref}",
+    )
+
+    return True, []
+
+
+def _update_pypi_plugin(
+    record: InstalledPluginRecord,
+    records: list[InstalledPluginRecord],
+    actor: str,
+    client_ip: str,
+    user_agent: str,
+) -> tuple[bool, list[str]]:
+    """Update a PyPI-sourced plugin to the latest version."""
+    errors: list[str] = []
+    distribution_name = record.distribution_name
+
+    try:
+        latest_version = fetch_pypi_latest_version(distribution_name)
+    except Exception as exc:
+        errors.append(f"Cannot determine latest version: {exc}")
+        _audit_event(
+            "update",
+            actor,
+            client_ip,
+            user_agent,
+            distribution_name=distribution_name,
+            ref=record.ref,
+            success=False,
+            detail=errors[0],
+        )
+        return False, errors
+
+    if latest_version == record.ref:
+        errors.append("Already up to date")
+        return False, errors
+
+    pip_spec = f"{distribution_name}=={latest_version}"
+    result = run_pip(["pip", "install", "--upgrade", pip_spec])
+    if result.returncode != 0:
+        err_msg = f"pip install --upgrade failed: {result.stderr.strip()}"
+        errors.append(err_msg)
+        _audit_event(
+            "update",
+            actor,
+            client_ip,
+            user_agent,
+            distribution_name=distribution_name,
+            ref=record.ref,
+            success=False,
+            detail=err_msg,
+        )
+        return False, errors
+
+    old_ref = record.ref
+    now = datetime.now(UTC).isoformat()
+    record.ref = latest_version
+    record.resolved_sha = ""
+    record.installed_at = now
+    record.actor = actor
+    record.last_checked_at = now
+    record.latest_ref = latest_version
+    record.latest_sha = None
+    record.update_available = False
+    save_installed(records)
+
+    _audit_event(
+        "update",
+        actor,
+        client_ip,
+        user_agent,
+        distribution_name=distribution_name,
+        ref=latest_version,
+        success=True,
+        detail=f"Updated from {old_ref} to {latest_version} (PyPI)",
     )
 
     return True, []
@@ -732,41 +1076,69 @@ def update_all_plugins(
     details: list[dict[str, Any]] = []
 
     for record in records:
-        gh = parse_github_repo_url(record.repo_url)
-        if gh is None:
-            details.append(
-                {
-                    "distribution_name": record.distribution_name,
-                    "ok": False,
-                    "error": "Invalid GitHub URL",
-                }
-            )
-            failed += 1
-            continue
+        # Determine if update is needed based on source
+        if record.source == "pypi":
+            try:
+                latest_version = fetch_pypi_latest_version(record.distribution_name)
+            except Exception as exc:
+                details.append(
+                    {
+                        "distribution_name": record.distribution_name,
+                        "ok": False,
+                        "error": str(exc),
+                    }
+                )
+                failed += 1
+                continue
 
-        try:
-            latest_ref, latest_sha = fetch_latest_ref(gh.owner, gh.repo)
-        except Exception as exc:
-            details.append(
-                {
-                    "distribution_name": record.distribution_name,
-                    "ok": False,
-                    "error": str(exc),
-                }
-            )
-            failed += 1
-            continue
+            if latest_version == record.ref:
+                details.append(
+                    {
+                        "distribution_name": record.distribution_name,
+                        "ok": True,
+                        "skipped": True,
+                        "reason": "Already up to date",
+                    }
+                )
+                continue
+            latest_ref_display = latest_version
+        else:
+            gh = parse_github_repo_url(record.repo_url)
+            if gh is None:
+                details.append(
+                    {
+                        "distribution_name": record.distribution_name,
+                        "ok": False,
+                        "error": "Invalid GitHub URL",
+                    }
+                )
+                failed += 1
+                continue
 
-        if latest_sha == record.resolved_sha:
-            details.append(
-                {
-                    "distribution_name": record.distribution_name,
-                    "ok": True,
-                    "skipped": True,
-                    "reason": "Already up to date",
-                }
-            )
-            continue
+            try:
+                latest_ref, latest_sha = fetch_latest_ref(gh.owner, gh.repo)
+            except Exception as exc:
+                details.append(
+                    {
+                        "distribution_name": record.distribution_name,
+                        "ok": False,
+                        "error": str(exc),
+                    }
+                )
+                failed += 1
+                continue
+
+            if latest_sha == record.resolved_sha:
+                details.append(
+                    {
+                        "distribution_name": record.distribution_name,
+                        "ok": True,
+                        "skipped": True,
+                        "reason": "Already up to date",
+                    }
+                )
+                continue
+            latest_ref_display = latest_ref
 
         ok, errors = update_plugin(
             record.distribution_name,
@@ -780,7 +1152,7 @@ def update_all_plugins(
                 {
                     "distribution_name": record.distribution_name,
                     "ok": True,
-                    "updated_to": latest_ref,
+                    "updated_to": latest_ref_display,
                 }
             )
         else:
@@ -916,18 +1288,30 @@ def reconcile_installed_plugins() -> list[dict[str, str | bool]]:
             )
             continue
 
-        # Need to reinstall from pinned SHA
-        clean_url = record.repo_url.rstrip("/")
-        if not clean_url.endswith(".git"):
-            clean_url += ".git"
-        git_url = f"git+{clean_url}@{record.resolved_sha}"
-        logger.info(
-            "Reconciling plugin '%s' — reinstalling from %s",
-            record.distribution_name,
-            git_url,
-        )
-
-        result = run_pip(["pip", "install", git_url])
+        # Need to reinstall from pinned source
+        if record.source == "pypi":
+            pip_spec = (
+                f"{record.distribution_name}=={record.ref}"
+                if record.ref
+                else record.distribution_name
+            )
+            logger.info(
+                "Reconciling plugin '%s' — reinstalling from PyPI (%s)",
+                record.distribution_name,
+                pip_spec,
+            )
+            result = run_pip(["pip", "install", pip_spec])
+        else:
+            clean_url = record.repo_url.rstrip("/")
+            if not clean_url.endswith(".git"):
+                clean_url += ".git"
+            git_url = f"git+{clean_url}@{record.resolved_sha}"
+            logger.info(
+                "Reconciling plugin '%s' — reinstalling from %s",
+                record.distribution_name,
+                git_url,
+            )
+            result = run_pip(["pip", "install", git_url])
         if result.returncode == 0:
             results.append(
                 {

--- a/src/az_scout/routes/__init__.py
+++ b/src/az_scout/routes/__init__.py
@@ -18,13 +18,13 @@ router = APIRouter(prefix="/api/plugins", tags=["Plugin Manager"])
 
 
 class ValidateRequest(BaseModel):
-    repo_url: str
-    ref: str
+    repo_url: str  # GitHub URL or PyPI package name
+    ref: str = ""  # Version/ref — optional for PyPI (auto-resolves to latest)
 
 
 class InstallRequest(BaseModel):
-    repo_url: str
-    ref: str
+    repo_url: str  # GitHub URL or PyPI package name
+    ref: str = ""  # Version/ref — optional for PyPI (auto-resolves to latest)
 
 
 class UninstallRequest(BaseModel):
@@ -66,24 +66,36 @@ async def list_plugins() -> JSONResponse:
     )
 
 
-@router.post("/validate", summary="Validate a plugin repository")
+@router.post("/validate", summary="Validate a plugin source")
 async def validate_plugin(body: ValidateRequest) -> JSONResponse:
-    """Fetch and validate ``pyproject.toml`` from a GitHub repository."""
-    result = plugin_manager.validate_plugin_repo(body.repo_url, body.ref)
+    """Validate a plugin from a GitHub repository or PyPI package."""
+    if plugin_manager.is_pypi_source(body.repo_url):
+        result = plugin_manager.validate_pypi_plugin(body.repo_url.strip(), body.ref.strip())
+    else:
+        result = plugin_manager.validate_plugin_repo(body.repo_url, body.ref.strip())
     return JSONResponse(asdict(result))
 
 
 @router.post("/install", summary="Install a plugin")
 async def install_plugin(body: InstallRequest, request: Request) -> JSONResponse:
-    """Install a plugin from a GitHub repository at a pinned SHA."""
+    """Install a plugin from a GitHub repository or PyPI."""
     actor, client_ip, user_agent = _actor(request)
-    ok, warnings, errors = plugin_manager.install_plugin(
-        body.repo_url,
-        body.ref,
-        actor,
-        client_ip,
-        user_agent,
-    )
+    if plugin_manager.is_pypi_source(body.repo_url):
+        ok, warnings, errors = plugin_manager.install_pypi_plugin(
+            body.repo_url.strip(),
+            body.ref.strip(),
+            actor,
+            client_ip,
+            user_agent,
+        )
+    else:
+        ok, warnings, errors = plugin_manager.install_plugin(
+            body.repo_url,
+            body.ref.strip(),
+            actor,
+            client_ip,
+            user_agent,
+        )
     if ok:
         reload_plugins(request.app, request.app.state.mcp_server)
     return JSONResponse(

--- a/src/az_scout/static/html/plugins.html
+++ b/src/az_scout/static/html/plugins.html
@@ -6,15 +6,15 @@
             <div class="card-header"><i class="bi bi-plus-circle me-1"></i>Add Plugin</div>
             <div class="card-body">
                 <div class="mb-2">
-                    <label for="pm-repo-url" class="form-label form-label-sm">Repository URL</label>
-                    <input type="url" class="form-control form-control-sm" id="pm-repo-url"
-                           placeholder="https://github.com/owner/repo">
-                    <div class="form-text">Only public github.com repositories</div>
+                    <label for="pm-repo-url" class="form-label form-label-sm">Plugin source</label>
+                    <input type="text" class="form-control form-control-sm" id="pm-repo-url"
+                           placeholder="PyPI package name or https://github.com/owner/repo">
+                    <div class="form-text">PyPI package name (e.g. <code>az-scout-example</code>) or public GitHub URL</div>
                 </div>
                 <div class="mb-3">
-                    <label for="pm-ref" class="form-label form-label-sm">Ref (tag or commit SHA)</label>
+                    <label for="pm-ref" class="form-label form-label-sm">Version / Ref <span class="text-body-secondary">(optional – defaults to latest)</span></label>
                     <input type="text" class="form-control form-control-sm" id="pm-ref"
-                           placeholder="v0.1.0 or 40-char SHA">
+                           placeholder="latest">
                 </div>
                 <div class="d-flex gap-2">
                     <button class="btn btn-outline-primary btn-sm" id="pm-validate-btn" onclick="pmValidate()">
@@ -71,11 +71,10 @@
                         <thead>
                             <tr>
                                 <th>Distribution</th>
-                                <th>Repo</th>
+                                <th>Source</th>
                                 <th>Installed</th>
                                 <th>Latest</th>
                                 <th>Status</th>
-                                <th>Installed at</th>
                                 <th></th>
                             </tr>
                         </thead>

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -11,6 +11,11 @@
     let initialized = false;
     let updateInfo = {};  // distribution_name → update status from /api/plugins/updates
 
+    /** Return true when the source string looks like a PyPI package name (not a URL). */
+    function isPypiSource(source) {
+        return source && !source.startsWith("http");
+    }
+
     const offcanvasEl = document.getElementById("pluginOffcanvas");
     if (!offcanvasEl) return;
 
@@ -74,14 +79,28 @@
         let anyUpdate = false;
         for (const r of list) {
             const tr = document.createElement("tr");
-            const shaShort = (r.resolved_sha || "").substring(0, 8);
-            const repoLink = r.repo_url
-                ? `<a href="${escHtml(r.repo_url)}" target="_blank" rel="noopener">${escHtml(r.repo_url)}</a>`
-                : "";
+            const pypi = r.source === "pypi";
             const installed = r.installed_at ? new Date(r.installed_at).toLocaleString() : "";
 
+            // Source column: PyPI link or GitHub repo link
+            let sourceLink;
+            if (pypi) {
+                const pypiUrl = `https://pypi.org/project/${encodeURIComponent(r.distribution_name)}/`;
+                sourceLink = `<a href="${escHtml(pypiUrl)}" target="_blank" rel="noopener"><i class="bi bi-box-seam me-1"></i>PyPI</a>`;
+            } else {
+                sourceLink = r.repo_url
+                    ? `<a href="${escHtml(r.repo_url)}" target="_blank" rel="noopener"><i class="bi bi-github me-1"></i>GitHub</a>`
+                    : "";
+            }
+
             // Installed version column
-            const installedVer = `${escHtml(r.ref)} <code title="${escHtml(r.resolved_sha)}">${escHtml(shaShort)}</code>`;
+            let installedVer;
+            if (pypi) {
+                installedVer = escHtml(r.ref);
+            } else {
+                const shaShort = (r.resolved_sha || "").substring(0, 8);
+                installedVer = `${escHtml(r.ref)} <code title="${escHtml(r.resolved_sha)}">${escHtml(shaShort)}</code>`;
+            }
 
             // Latest version column
             const info = updateInfo[r.distribution_name];
@@ -94,8 +113,12 @@
                     latestVer = '<span class="text-danger" title="' + escHtml(info.error) + '">Error</span>';
                     statusBadge = '<span class="badge bg-warning text-dark">Unknown</span>';
                 } else if (info.latest_ref) {
-                    const latestShaShort = (info.latest_sha || "").substring(0, 8);
-                    latestVer = `${escHtml(info.latest_ref)} <code title="${escHtml(info.latest_sha)}">${escHtml(latestShaShort)}</code>`;
+                    if (pypi) {
+                        latestVer = escHtml(info.latest_ref);
+                    } else {
+                        const latestShaShort = (info.latest_sha || "").substring(0, 8);
+                        latestVer = `${escHtml(info.latest_ref)} <code title="${escHtml(info.latest_sha)}">${escHtml(latestShaShort)}</code>`;
+                    }
                     if (info.update_available) {
                         statusBadge = '<span class="badge bg-info text-dark">Update available</span>';
                         updateBtn = ` <button class="btn btn-outline-info btn-sm py-0 px-1"
@@ -110,8 +133,12 @@
                 }
             } else if (r.update_available === true && r.latest_ref) {
                 // Use persisted data from installed.json
-                const latestShaShort = (r.latest_sha || "").substring(0, 8);
-                latestVer = `${escHtml(r.latest_ref)} <code title="${escHtml(r.latest_sha)}">${escHtml(latestShaShort)}</code>`;
+                if (pypi) {
+                    latestVer = escHtml(r.latest_ref);
+                } else {
+                    const latestShaShort = (r.latest_sha || "").substring(0, 8);
+                    latestVer = `${escHtml(r.latest_ref)} <code title="${escHtml(r.latest_sha)}">${escHtml(latestShaShort)}</code>`;
+                }
                 statusBadge = '<span class="badge bg-info text-dark">Update available</span>';
                 updateBtn = ` <button class="btn btn-outline-info btn-sm py-0 px-1"
                                       title="Update"
@@ -120,20 +147,23 @@
                               </button>`;
                 anyUpdate = true;
             } else if (r.update_available === false) {
-                const latestShaShort = (r.latest_sha || "").substring(0, 8);
                 if (r.latest_ref) {
-                    latestVer = `${escHtml(r.latest_ref)} <code title="${escHtml(r.latest_sha)}">${escHtml(latestShaShort)}</code>`;
+                    if (pypi) {
+                        latestVer = escHtml(r.latest_ref);
+                    } else {
+                        const latestShaShort = (r.latest_sha || "").substring(0, 8);
+                        latestVer = `${escHtml(r.latest_ref)} <code title="${escHtml(r.latest_sha)}">${escHtml(latestShaShort)}</code>`;
+                    }
                 }
                 statusBadge = '<span class="badge bg-success">Up to date</span>';
             }
 
             tr.innerHTML = `
                 <td><code>${escHtml(r.distribution_name)}</code></td>
-                <td>${repoLink}</td>
+                <td>${sourceLink}</td>
                 <td>${installedVer}</td>
                 <td>${latestVer}</td>
                 <td>${statusBadge}</td>
-                <td>${escHtml(installed)}</td>
                 <td class="text-nowrap">
                     ${updateBtn}
                     <button class="btn btn-outline-danger btn-sm py-0 px-1"
@@ -182,7 +212,7 @@
     window.pmValidate = async function () {
         const repoUrl = (document.getElementById("pm-repo-url").value || "").trim();
         const ref = (document.getElementById("pm-ref").value || "").trim();
-        if (!repoUrl || !ref) return;
+        if (!repoUrl) return;
 
         showSpinner("Validating…");
         hideResult();
@@ -206,7 +236,7 @@
     window.pmInstall = async function () {
         const repoUrl = (document.getElementById("pm-repo-url").value || "").trim();
         const ref = (document.getElementById("pm-ref").value || "").trim();
-        if (!repoUrl || !ref) return;
+        if (!repoUrl) return;
 
         showSpinner("Installing…");
         disableInstall();
@@ -341,7 +371,9 @@
 
         const lines = [];
         if (data.distribution_name) lines.push("<strong>Distribution:</strong> " + escHtml(data.distribution_name));
+        if (data.version) lines.push("<strong>Version:</strong> " + escHtml(data.version));
         if (data.resolved_sha) lines.push("<strong>SHA:</strong> <code>" + escHtml(data.resolved_sha) + "</code>");
+        if (data.source) lines.push("<strong>Source:</strong> " + escHtml(data.source === "pypi" ? "PyPI" : "GitHub"));
         if (data.entry_points && Object.keys(data.entry_points).length) {
             lines.push("<strong>Entry points:</strong> " +
                 Object.entries(data.entry_points).map(([k, v]) => escHtml(k) + " → " + escHtml(v)).join(", "));

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from az_scout import plugin_manager
 from az_scout.plugin_manager import (
@@ -16,12 +17,17 @@ from az_scout.plugin_manager import (
     PluginValidationResult,
     _default_data_dir,
     fetch_latest_ref,
+    fetch_pypi_latest_version,
+    fetch_pypi_metadata,
+    install_pypi_plugin,
     is_commit_sha,
+    is_pypi_source,
     load_installed,
     parse_github_repo_url,
     reconcile_installed_plugins,
     save_installed,
     validate_plugin_repo,
+    validate_pypi_plugin,
 )
 
 # ---------------------------------------------------------------------------
@@ -1102,3 +1108,628 @@ class TestReconcileInstalledPlugins:
         # Second plugin succeeded
         assert results[1]["reinstalled"] is True
         assert results[1]["error"] == ""
+
+
+# ---------------------------------------------------------------------------
+# PyPI source detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsPypiSource:
+    def test_pypi_package_name(self) -> None:
+        assert is_pypi_source("az-scout-example") is True
+
+    def test_pypi_package_with_dots(self) -> None:
+        assert is_pypi_source("az.scout.example") is True
+
+    def test_pypi_package_with_underscores(self) -> None:
+        assert is_pypi_source("az_scout_example") is True
+
+    def test_github_url(self) -> None:
+        assert is_pypi_source("https://github.com/owner/repo") is False
+
+    def test_http_url(self) -> None:
+        assert is_pypi_source("http://example.com/pkg") is False
+
+    def test_empty_string(self) -> None:
+        assert is_pypi_source("") is False
+
+    def test_single_char(self) -> None:
+        assert is_pypi_source("a") is True
+
+    def test_invalid_chars(self) -> None:
+        assert is_pypi_source("pkg name!") is False
+
+
+# ---------------------------------------------------------------------------
+# PyPI metadata / validation tests
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_PYPI_RESPONSE: dict = {
+    "info": {
+        "name": "az-scout-example",
+        "version": "0.2.0",
+        "requires_dist": ["az-scout>=2025.1", "fastapi>=0.100"],
+        "project_urls": {"Homepage": "https://github.com/owner/az-scout-example"},
+    },
+    "releases": {
+        "0.1.0": [],
+        "0.2.0": [],
+    },
+}
+
+
+class TestFetchPypiMetadata:
+    def test_latest(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_PYPI_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp) as mock_get:
+            data = fetch_pypi_metadata("az-scout-example")
+
+        assert data == SAMPLE_PYPI_RESPONSE
+        mock_get.assert_called_once()
+        assert "/az-scout-example/json" in mock_get.call_args[0][0]
+
+    def test_specific_version(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_PYPI_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp) as mock_get:
+            fetch_pypi_metadata("az-scout-example", "0.1.0")
+
+        assert "/az-scout-example/0.1.0/json" in mock_get.call_args[0][0]
+
+
+class TestValidatePypiPlugin:
+    def test_valid_package(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_PYPI_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            result = validate_pypi_plugin("az-scout-example")
+
+        assert result.ok
+        assert result.source == "pypi"
+        assert result.distribution_name == "az-scout-example"
+        assert result.version == "0.2.0"
+        assert result.ref == "0.2.0"
+        assert result.repo_url == "https://github.com/owner/az-scout-example"
+        assert len(result.warnings) == 0
+
+    def test_valid_with_version(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "info": {
+                "name": "az-scout-example",
+                "version": "0.1.0",
+                "requires_dist": ["az-scout"],
+                "project_urls": {},
+            },
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            result = validate_pypi_plugin("az-scout-example", "0.1.0")
+
+        assert result.ok
+        assert result.version == "0.1.0"
+
+    def test_package_not_found(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        http_err = requests.HTTPError(response=mock_resp)
+        mock_resp.raise_for_status.side_effect = http_err
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            result = validate_pypi_plugin("nonexistent-pkg")
+
+        assert not result.ok
+        assert any("not found on PyPI" in e for e in result.errors)
+
+    def test_version_not_found(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        http_err = requests.HTTPError(response=mock_resp)
+        mock_resp.raise_for_status.side_effect = http_err
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            result = validate_pypi_plugin("az-scout-example", "99.99.99")
+
+        assert not result.ok
+        assert any("99.99.99" in e for e in result.errors)
+
+    def test_naming_warning(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "info": {
+                "name": "some-random-pkg",
+                "version": "1.0.0",
+                "requires_dist": ["az-scout"],
+                "project_urls": {},
+            },
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            result = validate_pypi_plugin("some-random-pkg")
+
+        assert result.ok
+        assert any("naming convention" in w for w in result.warnings)
+
+    def test_missing_dependency_warning(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "info": {
+                "name": "az-scout-example",
+                "version": "1.0.0",
+                "requires_dist": ["requests"],
+                "project_urls": {},
+            },
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            result = validate_pypi_plugin("az-scout-example")
+
+        assert result.ok
+        assert any("az-scout" in w for w in result.warnings)
+
+    def test_invalid_name(self) -> None:
+        result = validate_pypi_plugin("invalid name!")
+        assert not result.ok
+        assert any("Invalid package name" in e for e in result.errors)
+
+
+class TestFetchPypiLatestVersion:
+    def test_success(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_PYPI_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        with patch("az_scout.plugin_manager.requests.get", return_value=mock_resp):
+            version = fetch_pypi_latest_version("az-scout-example")
+
+        assert version == "0.2.0"
+
+    def test_not_found(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        http_err = requests.HTTPError(response=mock_resp)
+        mock_resp.raise_for_status.side_effect = http_err
+        with (
+            patch("az_scout.plugin_manager.requests.get", return_value=mock_resp),
+            pytest.raises(ValueError, match="not found"),
+        ):
+            fetch_pypi_latest_version("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# PyPI install tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPypiPlugin:
+    def test_success(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        installed_file.write_text("[]", encoding="utf-8")
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_PYPI_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_pip = MagicMock()
+        mock_pip.returncode = 0
+        mock_pip.stderr = ""
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch("az_scout.plugin_manager.requests.get", return_value=mock_resp),
+            patch("az_scout.plugin_manager.run_pip", return_value=mock_pip),
+        ):
+            ok, warnings, errors = install_pypi_plugin(
+                "az-scout-example", "", "actor", "127.0.0.1", "test-agent"
+            )
+
+        assert ok is True
+        assert errors == []
+
+        loaded = json.loads(installed_file.read_text(encoding="utf-8"))
+        assert len(loaded) == 1
+        assert loaded[0]["distribution_name"] == "az-scout-example"
+        assert loaded[0]["source"] == "pypi"
+        assert loaded[0]["ref"] == "0.2.0"
+        assert loaded[0]["resolved_sha"] == ""
+
+    def test_validation_failure(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        installed_file.write_text("[]", encoding="utf-8")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        http_err = requests.HTTPError(response=mock_resp)
+        mock_resp.raise_for_status.side_effect = http_err
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch("az_scout.plugin_manager.requests.get", return_value=mock_resp),
+        ):
+            ok, warnings, errors = install_pypi_plugin(
+                "nonexistent", "", "actor", "127.0.0.1", "test-agent"
+            )
+
+        assert ok is False
+        assert len(errors) > 0
+
+    def test_pip_failure(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        installed_file.write_text("[]", encoding="utf-8")
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_PYPI_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_pip = MagicMock()
+        mock_pip.returncode = 1
+        mock_pip.stderr = "pip error"
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch("az_scout.plugin_manager.requests.get", return_value=mock_resp),
+            patch("az_scout.plugin_manager.run_pip", return_value=mock_pip),
+        ):
+            ok, warnings, errors = install_pypi_plugin(
+                "az-scout-example", "", "actor", "127.0.0.1", "test-agent"
+            )
+
+        assert ok is False
+        assert any("pip" in e.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# PyPI check updates
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUpdatesPypi:
+    def test_update_available(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "",
+                "ref": "0.1.0",
+                "resolved_sha": "",
+                "entry_points": {},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+                "source": "pypi",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch(
+                "az_scout.plugin_manager.fetch_pypi_latest_version",
+                return_value="0.2.0",
+            ),
+        ):
+            results = plugin_manager.check_updates("actor", "127.0.0.1", "test-agent")
+
+        assert len(results) == 1
+        assert results[0]["update_available"] is True
+        assert results[0]["latest_ref"] == "0.2.0"
+        assert results[0]["source"] == "pypi"
+
+    def test_up_to_date(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "",
+                "ref": "0.2.0",
+                "resolved_sha": "",
+                "entry_points": {},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+                "source": "pypi",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch(
+                "az_scout.plugin_manager.fetch_pypi_latest_version",
+                return_value="0.2.0",
+            ),
+        ):
+            results = plugin_manager.check_updates("actor", "127.0.0.1", "test-agent")
+
+        assert len(results) == 1
+        assert results[0]["update_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# PyPI update tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePypiPlugin:
+    def test_update_success(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "",
+                "ref": "0.1.0",
+                "resolved_sha": "",
+                "entry_points": {},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+                "source": "pypi",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        mock_pip = MagicMock()
+        mock_pip.returncode = 0
+        mock_pip.stderr = ""
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch(
+                "az_scout.plugin_manager.fetch_pypi_latest_version",
+                return_value="0.2.0",
+            ),
+            patch("az_scout.plugin_manager.run_pip", return_value=mock_pip),
+        ):
+            ok, errors = plugin_manager.update_plugin(
+                "az-scout-example", "actor", "127.0.0.1", "test-agent"
+            )
+
+        assert ok is True
+        assert errors == []
+
+        loaded = json.loads(installed_file.read_text(encoding="utf-8"))
+        assert loaded[0]["ref"] == "0.2.0"
+        assert loaded[0]["source"] == "pypi"
+
+    def test_already_up_to_date(self, tmp_path: Path) -> None:
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "",
+                "ref": "0.2.0",
+                "resolved_sha": "",
+                "entry_points": {},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+                "source": "pypi",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch(
+                "az_scout.plugin_manager.fetch_pypi_latest_version",
+                return_value="0.2.0",
+            ),
+        ):
+            ok, errors = plugin_manager.update_plugin(
+                "az-scout-example", "actor", "127.0.0.1", "test-agent"
+            )
+
+        assert ok is False
+        assert any("up to date" in e.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# PyPI reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestReconcilePypiPlugin:
+    def test_pypi_plugin_reinstalled(self, tmp_path: Path) -> None:
+        """A PyPI plugin missing from packages is reinstalled with pinned version."""
+        installed_file = tmp_path / "installed.json"
+        audit_file = tmp_path / "audit.jsonl"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "",
+                "ref": "0.2.0",
+                "resolved_sha": "",
+                "entry_points": {},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+                "source": "pypi",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        mock_pip = MagicMock()
+        mock_pip.returncode = 0
+        mock_pip.stderr = ""
+
+        with (
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+            patch.object(plugin_manager, "_DATA_DIR", tmp_path),
+            patch.object(plugin_manager, "_AUDIT_FILE", audit_file),
+            patch("az_scout.plugin_manager._is_plugin_installed", return_value=False),
+            patch("az_scout.plugin_manager.run_pip", return_value=mock_pip) as mock_run,
+        ):
+            results = reconcile_installed_plugins()
+
+        assert len(results) == 1
+        assert results[0]["reinstalled"] is True
+        args = mock_run.call_args[0][0]
+        assert "install" in args
+        # Should use pip_spec like "az-scout-example==0.2.0"
+        assert "az-scout-example==0.2.0" in args[-1]
+
+
+# ---------------------------------------------------------------------------
+# PyPI route tests
+# ---------------------------------------------------------------------------
+
+
+class TestPypiRoutes:
+    def test_validate_pypi(self, client) -> None:  # type: ignore[no-untyped-def]
+        result = PluginValidationResult(
+            ok=True,
+            owner="",
+            repo="",
+            repo_url="",
+            ref="0.2.0",
+            source="pypi",
+            distribution_name="az-scout-example",
+            version="0.2.0",
+        )
+        with patch(
+            "az_scout.routes.plugin_manager.validate_pypi_plugin",
+            return_value=result,
+        ):
+            resp = client.post(
+                "/api/plugins/validate",
+                json={"repo_url": "az-scout-example"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["source"] == "pypi"
+        assert data["version"] == "0.2.0"
+
+    def test_validate_github_without_ref_auto_resolves(self, client) -> None:  # type: ignore[no-untyped-def]
+        """GitHub sources without ref auto-resolve to latest."""
+        result = PluginValidationResult(
+            ok=True,
+            owner="owner",
+            repo="repo",
+            repo_url="https://github.com/owner/repo",
+            ref="v2.0.0",
+            resolved_sha=SAMPLE_SHA,
+            distribution_name="az-scout-example",
+            entry_points={"example": "mod:obj"},
+        )
+        with patch(
+            "az_scout.routes.plugin_manager.validate_plugin_repo",
+            return_value=result,
+        ):
+            resp = client.post(
+                "/api/plugins/validate",
+                json={"repo_url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["ref"] == "v2.0.0"
+
+    def test_install_pypi(self, client) -> None:  # type: ignore[no-untyped-def]
+        with (
+            patch(
+                "az_scout.routes.plugin_manager.install_pypi_plugin",
+                return_value=(True, [], []),
+            ),
+            patch("az_scout.routes.reload_plugins"),
+        ):
+            resp = client.post(
+                "/api/plugins/install",
+                json={"repo_url": "az-scout-example"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+    def test_install_github_without_ref_auto_resolves(self, client) -> None:  # type: ignore[no-untyped-def]
+        """GitHub installs without ref auto-resolve to latest."""
+        with (
+            patch(
+                "az_scout.routes.plugin_manager.install_plugin",
+                return_value=(True, [], []),
+            ),
+            patch("az_scout.routes.reload_plugins"),
+        ):
+            resp = client.post(
+                "/api/plugins/install",
+                json={"repo_url": "https://github.com/owner/repo"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility – source field
+# ---------------------------------------------------------------------------
+
+
+class TestSourceBackwardCompat:
+    def test_load_without_source_defaults_to_github(self, tmp_path: Path) -> None:
+        """Old installed.json without 'source' field should default to github."""
+        installed_file = tmp_path / "installed.json"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "https://github.com/owner/repo",
+                "ref": "v1.0.0",
+                "resolved_sha": SAMPLE_SHA,
+                "entry_points": {"example": "mod:obj"},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with patch.object(plugin_manager, "_INSTALLED_FILE", installed_file):
+            loaded = load_installed()
+
+        assert len(loaded) == 1
+        assert loaded[0].source == "github"
+
+    def test_load_with_pypi_source(self, tmp_path: Path) -> None:
+        """installed.json with source=pypi should load correctly."""
+        installed_file = tmp_path / "installed.json"
+        data = [
+            {
+                "distribution_name": "az-scout-example",
+                "repo_url": "",
+                "ref": "0.2.0",
+                "resolved_sha": "",
+                "entry_points": {},
+                "installed_at": "2026-02-28T00:00:00+00:00",
+                "actor": "tester",
+                "source": "pypi",
+            }
+        ]
+        installed_file.write_text(json.dumps(data), encoding="utf-8")
+
+        with patch.object(plugin_manager, "_INSTALLED_FILE", installed_file):
+            loaded = load_installed()
+
+        assert len(loaded) == 1
+        assert loaded[0].source == "pypi"
+        assert loaded[0].ref == "0.2.0"


### PR DESCRIPTION
## Description

Add PyPI as an alternative plugin installation source alongside GitHub. The plugin manager auto-detects the source type based on the input: URLs → GitHub, bare package names → PyPI. Both sources now default to the latest version when no ref/version is specified.

**Backend:** new PyPI validation/install/update/reconcile functions, `source` field on `InstalledPluginRecord` (backward-compatible default `"github"`), refactored `update_plugin()` into source-specific dispatchers, `validate_plugin_repo()` auto-resolves to latest release/tag when ref is empty.

**Frontend:** relabeled inputs ("Plugin source", "Version / Ref – optional"), PyPI/GitHub icons in the installed table, version-only display for PyPI records (no SHA).

## Related issue

Closes #61

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [ ] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<!-- If applicable, add screenshots showing the change. -->