### PR TITLE
fix: unify logging format across core, plugins and third-party loggers

### DIFF
--- a/docs/plugin-scaffold/src/az_scout_example/__init__.py
+++ b/docs/plugin-scaffold/src/az_scout_example/__init__.py
@@ -10,8 +10,10 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
-from az_scout.plugin_api import ChatMode, TabDefinition
+from az_scout.plugin_api import ChatMode, TabDefinition, get_plugin_logger
 from fastapi import APIRouter
+
+logger = get_plugin_logger("example")
 
 _STATIC_DIR = Path(__file__).parent / "static"
 

--- a/docs/plugin-scaffold/src/az_scout_example/_log.py
+++ b/docs/plugin-scaffold/src/az_scout_example/_log.py
@@ -1,0 +1,3 @@
+from az_scout.plugin_api import get_plugin_logger
+
+logger = get_plugin_logger("example")

--- a/src/az_scout/app.py
+++ b/src/az_scout/app.py
@@ -141,21 +141,110 @@ def _ensure_fresh_session_manager() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _setup_logging(level: int = logging.WARNING) -> None:
-    """Configure the root ``az_scout`` logger with uvicorn-style colours."""
+class _CategoryFilter(logging.Filter):
+    """Inject a ``category`` field into every log record.
+
+    * Loggers under ``az_scout.*``       → ``core``
+    * Loggers under ``az_scout_<plugin>.*`` → ``plugin:<plugin>``
+    * Loggers under ``uvicorn.*``         → ``server``
+    * Loggers under ``httpx.*``           → ``http``
+    * Everything else                     → ``ext``
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        name = record.name
+        if name.startswith("az_scout_"):
+            # e.g. "az_scout_batch_sku.routes" → plugin name "batch_sku"
+            suffix = name[len("az_scout_") :]
+            plugin_name = suffix.split(".")[0]
+            record.category = f"plugin:{plugin_name}"  # type: ignore[attr-defined]
+        elif name.startswith("az_scout"):
+            record.category = "core"  # type: ignore[attr-defined]
+        elif name.startswith("uvicorn"):
+            record.category = "server"  # type: ignore[attr-defined]
+        elif name.startswith("httpx"):
+            record.category = "http"  # type: ignore[attr-defined]
+        elif name.startswith("mcp"):
+            record.category = "mcp"  # type: ignore[attr-defined]
+        else:
+            record.category = "ext"  # type: ignore[attr-defined]
+        return True
+
+
+# Shared handler & filter – reused by setup_plugin_logger()
+_log_handler: logging.Handler | None = None
+_log_filter: _CategoryFilter = _CategoryFilter()
+
+
+def _setup_logging(level: int | None = None) -> None:
+    """Configure the root ``az_scout`` logger with uvicorn-style colours.
+
+    *level* overrides the default.  When *level* is ``None`` the function
+    reads the ``AZ_SCOUT_LOG_LEVEL`` environment variable (``DEBUG``,
+    ``INFO``, ``WARNING``, …) so that uvicorn reload workers inherit the
+    log level set by the CLI.
+    """
+    global _log_handler  # noqa: PLW0603
+
+    import os
+
     from uvicorn.logging import DefaultFormatter
+
+    if level is None:
+        level = getattr(logging, os.environ.get("AZ_SCOUT_LOG_LEVEL", "WARNING"))
 
     handler = logging.StreamHandler()
     handler.setFormatter(
-        DefaultFormatter(fmt="%(levelprefix)s %(name)s - %(message)s", use_colors=True)
+        DefaultFormatter(
+            fmt="%(levelprefix)s [%(category)s] %(name)s - %(message)s",
+            use_colors=True,
+        )
     )
+    handler.addFilter(_log_filter)
+    _log_handler = handler
+
     app_logger = logging.getLogger("az_scout")
     app_logger.handlers = [handler]
     app_logger.setLevel(level)
     app_logger.propagate = False
 
+    # Unify uvicorn, httpx and mcp loggers under the same format
+    for third_party in ("uvicorn", "uvicorn.error", "uvicorn.access", "httpx", "mcp"):
+        tp_logger = logging.getLogger(third_party)
+        tp_logger.handlers = [handler]
+        tp_logger.propagate = False
+    # uvicorn.access stays at INFO (request lines); uvicorn.error follows app level
+    logging.getLogger("uvicorn").setLevel(level)
+    logging.getLogger("uvicorn.error").setLevel(level)
+    logging.getLogger("uvicorn.access").setLevel(logging.INFO)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("mcp").setLevel(logging.INFO)
+
     # Silence noisy third-party loggers
     logging.getLogger("azure").setLevel(logging.WARNING)
+
+    # Remove any stray handlers on the root logger (e.g. rich, basicConfig)
+    # so that plugin loggers with propagate=False don't get duplicated.
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.WARNING)
+
+
+def setup_plugin_logger(plugin_name: str) -> None:
+    """Configure the ``az_scout_<plugin_name>`` logger to share the core format.
+
+    Called automatically during plugin registration.  Plugin authors do not
+    need to call this themselves — use :func:`az_scout.plugin_api.get_plugin_logger`
+    to obtain a correctly-namespaced logger.
+    """
+    if _log_handler is None:
+        return  # logging not yet initialised
+    module_name = f"az_scout_{plugin_name.replace('-', '_')}"
+    plugin_logger = logging.getLogger(module_name)
+    if _log_handler not in plugin_logger.handlers:
+        plugin_logger.handlers = [_log_handler]
+    plugin_logger.setLevel(logging.getLogger("az_scout").level)
+    plugin_logger.propagate = False
 
 
 _setup_logging()

--- a/src/az_scout/cli.py
+++ b/src/az_scout/cli.py
@@ -54,12 +54,15 @@ def web(
 ) -> None:
     """Run the web UI (default)."""
     import logging
+    import os
 
     import uvicorn
 
     from az_scout.app import _PKG_DIR, _setup_logging, app
 
-    log_level = "info" if verbose else "warning"
+    log_level = "debug" if verbose else "warning"
+    env_level = "DEBUG" if verbose else "WARNING"
+    os.environ["AZ_SCOUT_LOG_LEVEL"] = env_level
     _setup_logging(level=logging.DEBUG if verbose else logging.WARNING)
 
     url = f"http://{host}:{port}"
@@ -94,12 +97,20 @@ def web(
             host=host,
             port=port,
             log_level=log_level,
+            log_config=None,  # use our unified _setup_logging() config
             reload=True,
             reload_dirs=[str(_PKG_DIR)],
             **proxy_kwargs,  # type: ignore[arg-type]
         )
     else:
-        uvicorn.run(app, host=host, port=port, log_level=log_level, **proxy_kwargs)  # type: ignore[arg-type]
+        uvicorn.run(
+            app,
+            host=host,
+            port=port,
+            log_level=log_level,
+            log_config=None,  # use our unified _setup_logging() config
+            **proxy_kwargs,  # type: ignore[arg-type]
+        )
 
 
 @cli.command()
@@ -125,13 +136,14 @@ def web(
 def mcp(http: bool, port: int, verbose: bool) -> None:
     """Run the MCP server."""
     import logging
+    import os
 
+    from az_scout.app import _setup_logging
     from az_scout.mcp_server import mcp as mcp_server
 
-    if verbose:
-        logging.basicConfig(level=logging.INFO)
-    else:
-        logging.basicConfig(level=logging.WARNING)
+    env_level = "DEBUG" if verbose else "WARNING"
+    os.environ["AZ_SCOUT_LOG_LEVEL"] = env_level
+    _setup_logging(level=logging.DEBUG if verbose else logging.WARNING)
 
     if http:
         mcp_server.settings.port = port

--- a/src/az_scout/plugin_api.py
+++ b/src/az_scout/plugin_api.py
@@ -10,12 +10,29 @@ Example ``pyproject.toml`` entry::
     my_plugin = "az_scout_myplugin:plugin"
 """
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from fastapi import APIRouter
+
+
+def get_plugin_logger(plugin_name: str) -> logging.Logger:
+    """Return a logger for a plugin, using the ``az_scout_<name>`` namespace.
+
+    This ensures plugin logs share the same coloured format and category
+    labelling (``plugin:<name>``) as the core application.
+
+    Usage in a plugin module::
+
+        from az_scout.plugin_api import get_plugin_logger
+        logger = get_plugin_logger("batch-sku")
+        logger.info("Loading data")  # → INFO [plugin:batch_sku] az_scout_batch_sku - Loading data
+    """
+    module_name = f"az_scout_{plugin_name.replace('-', '_')}"
+    return logging.getLogger(module_name)
 
 
 @dataclass

--- a/src/az_scout/plugins.py
+++ b/src/az_scout/plugins.py
@@ -128,6 +128,11 @@ def _register_one(app: FastAPI, mcp_server: Any, plugin: AzScoutPlugin) -> None:
     """Wire a single plugin into the application."""
     name = plugin.name
 
+    # Configure the plugin's logger to use the same format as core
+    from az_scout.app import setup_plugin_logger
+
+    setup_plugin_logger(name)
+
     # API routes
     try:
         router = plugin.get_router()


### PR DESCRIPTION
## Description

Unify all log output under a single coloured format with a `[category]` tag that identifies the source:

- `[core]` — az-scout core modules
- `[plugin:<name>]` — plugin modules (e.g. `[plugin:batch_sku]`)
- `[server]` — uvicorn
- `[mcp]` — MCP server
- `[http]` — httpx
- `[ext]` — other third-party libraries

Example output:

```
INFO [core] az_scout.app - Starting server...
DEBUG [plugin:batch_sku] az_scout_batch_sku.routes - Loading data
INFO [server] uvicorn.access - 127.0.0.1 - "GET /api/regions" 200
INFO [mcp] mcp.server.streamable_http_manager - Session manager started
```

### Changes

- **`app.py`**: Added `_CategoryFilter` that injects `%(category)s` into log records. `_setup_logging()` now reads `AZ_SCOUT_LOG_LEVEL` env var so reload workers inherit the correct level. Configures uvicorn, httpx, and mcp loggers with the same handler. Clears root logger handlers to prevent `rich`/`basicConfig` duplicates. Added `setup_plugin_logger()` helper.
- **`cli.py`**: Sets `AZ_SCOUT_LOG_LEVEL` env var before starting uvicorn. Passes `log_config=None` to prevent uvicorn overriding our config. MCP command now uses `_setup_logging()` instead of `basicConfig()`. Verbose mode passes `log_level="debug"` (was `"info"`).
- **`plugin_api.py`**: Added `get_plugin_logger(plugin_name)` convenience function for plugin authors.
- **`plugins.py`**: Calls `setup_plugin_logger()` during plugin registration.
- **Plugin scaffold**: Updated to use `get_plugin_logger()` with `_log.py` pattern.

## Related issue

<!-- Link to the issue this PR addresses, e.g. "Closes #42" -->

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<!-- N/A -->
