### PR TITLE
fix: offload blocking sync calls to thread pool with asyncio.to_thread()

### DIFF
--- a/src/az_scout/app.py
+++ b/src/az_scout/app.py
@@ -4,6 +4,7 @@ Interactive web tool to visualize how Azure maps logical availability zones
 to physical zones across subscriptions in a given region.
 """
 
+import asyncio
 import logging
 import threading
 from collections.abc import AsyncGenerator
@@ -184,7 +185,7 @@ async def list_tenants() -> JSONResponse:
     tenant ID for the current auth context.
     """
     try:
-        return JSONResponse(azure_api.list_tenants())
+        return JSONResponse(await asyncio.to_thread(azure_api.list_tenants))
     except Exception as exc:
         logger.exception("Failed to list tenants")
         return JSONResponse({"error": str(exc)}, status_code=500)
@@ -198,7 +199,7 @@ async def list_subscriptions(
 ) -> JSONResponse:
     """Return all enabled Azure subscriptions, sorted alphabetically."""
     try:
-        return JSONResponse(azure_api.list_subscriptions(tenantId))
+        return JSONResponse(await asyncio.to_thread(azure_api.list_subscriptions, tenantId))
     except Exception as exc:
         logger.exception("Failed to list subscriptions")
         return JSONResponse({"error": str(exc)}, status_code=500)
@@ -213,7 +214,9 @@ async def list_regions(
 ) -> JSONResponse:
     """Return Azure regions that support Availability Zones."""
     try:
-        return JSONResponse(azure_api.list_regions(subscriptionId, tenantId))
+        return JSONResponse(
+            await asyncio.to_thread(azure_api.list_regions, subscriptionId, tenantId)
+        )
     except LookupError as exc:
         return JSONResponse({"error": str(exc)}, status_code=404)
     except Exception as exc:
@@ -230,7 +233,9 @@ async def list_locations(
 ) -> JSONResponse:
     """Return all Azure ARM locations, including those without Availability Zones."""
     try:
-        return JSONResponse(azure_api.list_locations(subscriptionId, tenantId))
+        return JSONResponse(
+            await asyncio.to_thread(azure_api.list_locations, subscriptionId, tenantId)
+        )
     except LookupError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
     except Exception as exc:
@@ -258,7 +263,7 @@ async def get_mappings(
             {"error": "Both 'region' and 'subscriptions' query parameters are required"},
             status_code=400,
         )
-    return JSONResponse(azure_api.get_mappings(region, sub_ids, tenantId))
+    return JSONResponse(await asyncio.to_thread(azure_api.get_mappings, region, sub_ids, tenantId))
 
 
 @app.get("/api/skus", tags=["SKUs"], summary="Get SKU availability per zone")
@@ -310,7 +315,8 @@ async def get_skus(
         )
 
     try:
-        skus = azure_api.get_skus(
+        skus = await asyncio.to_thread(
+            azure_api.get_skus,
             region,
             subscriptionId,
             tenantId,
@@ -322,9 +328,11 @@ async def get_skus(
             min_memory_gb=minMemoryGB,
             max_memory_gb=maxMemoryGB,
         )
-        azure_api.enrich_skus_with_quotas(skus, region, subscriptionId, tenantId)
+        await asyncio.to_thread(
+            azure_api.enrich_skus_with_quotas, skus, region, subscriptionId, tenantId
+        )
         if includePrices:
-            azure_api.enrich_skus_with_prices(skus, region, currencyCode)
+            await asyncio.to_thread(azure_api.enrich_skus_with_prices, skus, region, currencyCode)
 
         # Compute Deployment Confidence Score for each SKU (canonical module)
         for sku in skus:
@@ -382,14 +390,23 @@ async def deployment_confidence(body: DeploymentConfidenceRequest) -> JSONRespon
 
     try:
         # Fetch SKU data (zones, restrictions, capabilities, quota)
-        all_skus = azure_api.get_skus(
+        all_skus = await asyncio.to_thread(
+            azure_api.get_skus,
             body.region,
             body.subscriptionId,
             body.tenantId,
             "virtualMachines",
         )
-        azure_api.enrich_skus_with_quotas(all_skus, body.region, body.subscriptionId, body.tenantId)
-        azure_api.enrich_skus_with_prices(all_skus, body.region, body.currencyCode)
+        await asyncio.to_thread(
+            azure_api.enrich_skus_with_quotas,
+            all_skus,
+            body.region,
+            body.subscriptionId,
+            body.tenantId,
+        )
+        await asyncio.to_thread(
+            azure_api.enrich_skus_with_prices, all_skus, body.region, body.currencyCode
+        )
 
         sku_map = {s["name"]: s for s in all_skus}
 
@@ -397,7 +414,8 @@ async def deployment_confidence(body: DeploymentConfidenceRequest) -> JSONRespon
         spot_scores: dict[str, dict[str, str]] = {}
         if body.preferSpot:
             try:
-                spot_result = azure_api.get_spot_placement_scores(
+                spot_result = await asyncio.to_thread(
+                    azure_api.get_spot_placement_scores,
                     body.region,
                     body.subscriptionId,
                     body.skus,
@@ -475,7 +493,8 @@ async def get_spot_scores(body: SpotScoresRequest) -> JSONResponse:
             status_code=400,
         )
     try:
-        result = azure_api.get_spot_placement_scores(
+        result = await asyncio.to_thread(
+            azure_api.get_spot_placement_scores,
             body.region,
             body.subscriptionId,
             body.skus,
@@ -508,9 +527,13 @@ async def get_sku_pricing(
     restrictions, zones).
     """
     try:
-        result = azure_api.get_sku_pricing_detail(region, skuName, currencyCode)
+        result = await asyncio.to_thread(
+            azure_api.get_sku_pricing_detail, region, skuName, currencyCode
+        )
         if subscriptionId:
-            profile = azure_api.get_sku_profile(region, subscriptionId, skuName, tenantId)
+            profile = await asyncio.to_thread(
+                azure_api.get_sku_profile, region, subscriptionId, skuName, tenantId
+            )
             if profile is not None:
                 result["profile"] = profile
         return JSONResponse(result)
@@ -537,7 +560,7 @@ async def deployment_plan(body: DeploymentIntentRequest) -> JSONResponse:
     with business and technical views.
     """
     try:
-        result = plan_deployment(body)
+        result = await asyncio.to_thread(plan_deployment, body)
         return JSONResponse(result.model_dump())
     except Exception as exc:
         logger.exception("Failed to generate deployment plan")

--- a/src/az_scout/routes/__init__.py
+++ b/src/az_scout/routes/__init__.py
@@ -1,5 +1,6 @@
 """Plugin manager API routes – thin wrappers over :mod:`az_scout.plugin_manager`."""
 
+import asyncio
 from dataclasses import asdict
 
 from fastapi import APIRouter, Request
@@ -70,9 +71,13 @@ async def list_plugins() -> JSONResponse:
 async def validate_plugin(body: ValidateRequest) -> JSONResponse:
     """Validate a plugin from a GitHub repository or PyPI package."""
     if plugin_manager.is_pypi_source(body.repo_url):
-        result = plugin_manager.validate_pypi_plugin(body.repo_url.strip(), body.ref.strip())
+        result = await asyncio.to_thread(
+            plugin_manager.validate_pypi_plugin, body.repo_url.strip(), body.ref.strip()
+        )
     else:
-        result = plugin_manager.validate_plugin_repo(body.repo_url, body.ref.strip())
+        result = await asyncio.to_thread(
+            plugin_manager.validate_plugin_repo, body.repo_url, body.ref.strip()
+        )
     return JSONResponse(asdict(result))
 
 
@@ -81,7 +86,8 @@ async def install_plugin(body: InstallRequest, request: Request) -> JSONResponse
     """Install a plugin from a GitHub repository or PyPI."""
     actor, client_ip, user_agent = _actor(request)
     if plugin_manager.is_pypi_source(body.repo_url):
-        ok, warnings, errors = plugin_manager.install_pypi_plugin(
+        ok, warnings, errors = await asyncio.to_thread(
+            plugin_manager.install_pypi_plugin,
             body.repo_url.strip(),
             body.ref.strip(),
             actor,
@@ -89,7 +95,8 @@ async def install_plugin(body: InstallRequest, request: Request) -> JSONResponse
             user_agent,
         )
     else:
-        ok, warnings, errors = plugin_manager.install_plugin(
+        ok, warnings, errors = await asyncio.to_thread(
+            plugin_manager.install_plugin,
             body.repo_url,
             body.ref.strip(),
             actor,
@@ -111,7 +118,8 @@ async def install_plugin(body: InstallRequest, request: Request) -> JSONResponse
 async def uninstall_plugin(body: UninstallRequest, request: Request) -> JSONResponse:
     """Uninstall a plugin by its distribution name."""
     actor, client_ip, user_agent = _actor(request)
-    ok, errors = plugin_manager.uninstall_plugin(
+    ok, errors = await asyncio.to_thread(
+        plugin_manager.uninstall_plugin,
         body.distribution_name,
         actor,
         client_ip,
@@ -131,7 +139,7 @@ async def uninstall_plugin(body: UninstallRequest, request: Request) -> JSONResp
 async def check_updates(request: Request) -> JSONResponse:
     """Check all installed plugins for available updates."""
     actor, client_ip, user_agent = _actor(request)
-    results = plugin_manager.check_updates(actor, client_ip, user_agent)
+    results = await asyncio.to_thread(plugin_manager.check_updates, actor, client_ip, user_agent)
     return JSONResponse({"plugins": results})
 
 
@@ -139,7 +147,8 @@ async def check_updates(request: Request) -> JSONResponse:
 async def update_plugin(body: UpdateRequest, request: Request) -> JSONResponse:
     """Update a single plugin to the latest GitHub release/tag."""
     actor, client_ip, user_agent = _actor(request)
-    ok, errors = plugin_manager.update_plugin(
+    ok, errors = await asyncio.to_thread(
+        plugin_manager.update_plugin,
         body.distribution_name,
         actor,
         client_ip,
@@ -159,7 +168,8 @@ async def update_plugin(body: UpdateRequest, request: Request) -> JSONResponse:
 async def update_all_plugins(request: Request) -> JSONResponse:
     """Update all installed plugins that have available updates."""
     actor, client_ip, user_agent = _actor(request)
-    updated, failed, details = plugin_manager.update_all_plugins(
+    updated, failed, details = await asyncio.to_thread(
+        plugin_manager.update_all_plugins,
         actor,
         client_ip,
         user_agent,


### PR DESCRIPTION
## Problem

`async def` route handlers in FastAPI were calling synchronous `requests.get/post` functions from `azure_api` directly. Since uvicorn runs a single-threaded event loop, these blocking calls prevented the event loop from processing any other requests until completion.

**Impact:** When a plugin triggered a long-running Azure API call (e.g. fetching SKU prices across 60+ regions), all other concurrent requests — including those from other plugins or UI tabs — were forced to wait.

## Root Cause

FastAPI handles `async def` endpoints on the main event loop thread. If the handler body contains synchronous blocking I/O (like `requests.get()`), the entire event loop is blocked. No other coroutine can run until the call returns.

This is different from `def` (sync) handlers, which FastAPI automatically offloads to a thread pool.

## Solution

Wrap all blocking `azure_api.*` and `plugin_manager.*` calls with `asyncio.to_thread()`, which offloads the synchronous function to the default `ThreadPoolExecutor`. This frees the event loop to serve concurrent requests while waiting for Azure API responses.

### Why `asyncio.to_thread()` (Option 2) over alternatives?

| Option | Description | Effort | Risk |
|--------|-------------|--------|------|
| 1. Change handlers to `def` | FastAPI auto-offloads to thread pool | Low | Loses ability to do async operations in handlers |
| **2. `asyncio.to_thread()`** | **Offload sync calls explicitly** | **Low** | **None — backward compatible** |
| 3. Migrate to `httpx.AsyncClient` | Full async rewrite of `azure_api` | High | 7 files, ~20 functions, 50+ test mocks, breaking change for all plugins |

Option 2 provides ~90% of the benefit of a full async rewrite with ~10% of the effort, and is fully backward compatible with existing tests and plugins.

## Changes

### `src/az_scout/app.py`
- Added `import asyncio`
- Wrapped 12 blocking calls with `await asyncio.to_thread()`:
  - `list_tenants`, `list_subscriptions`, `list_regions`, `list_locations`
  - `get_mappings`, `get_skus`, `enrich_skus_with_quotas`, `enrich_skus_with_prices`
  - `get_spot_placement_scores` (×2)
  - `get_sku_pricing_detail` / `get_sku_profile`
  - `plan_deployment`

### `src/az_scout/routes/__init__.py`
- Added `import asyncio`  
- Wrapped 7 blocking `plugin_manager.*` calls with `await asyncio.to_thread()`:
  - `validate_pypi_plugin`, `validate_plugin_repo`
  - `install_pypi_plugin`, `install_plugin`, `uninstall_plugin`
  - `check_updates`, `update_plugin`, `update_all_plugins`

## Testing

- All 328 existing tests pass (18 deselected)
- No new dependencies added (`asyncio` is stdlib)
- ruff lint + format: pass
- mypy strict: pass

## Plugin impact

- **No breaking changes** for plugins
- Plugin authors using `async def` handlers with sync blocking calls should apply the same pattern
- The `az-scout-plugin-regions-cheapest` plugin has been updated separately
- The `az-scout-plugin-bdd-sku` plugin already uses `aiosqlite` (truly async) — no changes needed
