### PR TITLE
feat(plugins): add recommended plugins catalog to Plugin Manager (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## [Unreleased]
 
+
+#### Added
+
+- **Plugin catalog (recommendations)** – the Plugin Manager now shows a curated list of
+  recommended plugins loaded from `recommended_plugins.json`, with quick-install buttons and
+  installed status badges. New `GET /api/plugins/recommended` endpoint and
+  `load_recommended_plugins()` helper in `plugin_manager`.
+
 ### Changed
 
 - **Deployment Confidence Scoring** – reworked scoring signals for better accuracy (#36):

--- a/README.md
+++ b/README.md
@@ -48,33 +48,42 @@ uvx az-scout
 Your browser opens automatically at `http://127.0.0.1:5001`.
 
 
-## Known plugins
+## Plugins
 
 az-scout can be extended with pip-installable plugins discovered automatically at startup. See [docs/PLUGINS.md](docs/PLUGINS.md) for the plugin development guide and the [scaffold](docs/plugin-scaffold/) for a ready-to-use template.
 
+### Known plugins
+
 | Plugin | Description |
 |---|---|
-| [az-scout-plugin-strategy-advisor](https://github.com/lrivallain/az-scout-plugin-strategy-advisor) | Multi-region capacity strategy recommendation engine — evaluates regions, quotas, spot scores, pricing, and latency to recommend deployment strategies |
 | [az-scout-plugin-batch-sku](https://github.com/lrivallain/az-scout-plugin-batch-sku) | Azure Batch SKU availability — discover and compare Batch-supported VM SKUs per region |
 | [az-scout-plugin-latency-stats](https://github.com/lrivallain/az-scout-plugin-latency-stats) | Inter-region latency statistics — D3.js graph visualisation of pairwise RTT between Azure regions |
+| [az-scout-plugin-strategy-advisor](https://github.com/lrivallain/az-scout-plugin-strategy-advisor) | (WIP) Multi-region capacity strategy recommendation engine — evaluates regions, quotas, spot scores, pricing, and latency to recommend deployment strategies |
 
-Install a plugin:
+### Install a plugin
+
+#### Recommended: install plugin with package manager
+
+Use the built-in plugin manager to install plugins from PyPI (with package names like `az-scout-plugin-xyz`) or from GitHub URLs.
+
+A curated list of recommended plugins is available in the Plugin Manager UI, with **one-click install**.
+
+#### Alternative: install plugin with `pip` or `uv`
 
 ```bash
 uv pip install <plugin-package-name>
 ```
 
-
 ## Installation options
 
-### Recommended: install with `uv`
+### Recommended: install az-scout with `uv`
 
 ```bash
 uv install az-scout
 uvx az-scout
 ```
 
-### Alternative: install with `pip`
+### Alternative: install az-scout with `pip`
 
 ```bash
 pip install az-scout

--- a/src/az_scout/plugin_manager.py
+++ b/src/az_scout/plugin_manager.py
@@ -1353,6 +1353,58 @@ def reconcile_installed_plugins() -> list[dict[str, str | bool]]:
     return results
 
 
+# ---------------------------------------------------------------------------
+# Recommended plugins
+# ---------------------------------------------------------------------------
+
+_RECOMMENDED_FILE = Path(__file__).parent / "recommended_plugins.json"
+
+
+@dataclass
+class RecommendedPlugin:
+    """A plugin recommended for installation."""
+
+    name: str
+    description: str
+    source: str  # "pypi" or "github"
+    url: str = ""  # GitHub URL (required when source is "github")
+    version: str = ""  # Optional pinned version
+
+
+def load_recommended_plugins() -> list[dict[str, Any]]:
+    """Load the recommended plugins list and annotate with install status.
+
+    Each entry is a dict with the fields from :class:`RecommendedPlugin` plus
+    an ``installed`` boolean indicating whether the plugin is already present.
+    """
+    if not _RECOMMENDED_FILE.exists():
+        return []
+    try:
+        raw: list[dict[str, Any]] = json.loads(_RECOMMENDED_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        logger.exception("Failed to read %s", _RECOMMENDED_FILE)
+        return []
+
+    installed_names = {r.distribution_name for r in load_installed()}
+
+    results: list[dict[str, Any]] = []
+    for entry in raw:
+        rec = RecommendedPlugin(
+            name=entry.get("name", ""),
+            description=entry.get("description", ""),
+            source=entry.get("source", "pypi"),
+            url=entry.get("url", ""),
+            version=entry.get("version", ""),
+        )
+        results.append(
+            {
+                **asdict(rec),
+                "installed": rec.name in installed_names,
+            }
+        )
+    return results
+
+
 def _audit_event(
     action: str,
     actor: str,

--- a/src/az_scout/recommended_plugins.json
+++ b/src/az_scout/recommended_plugins.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "az-scout-plugin-batch-sku",
+    "description": "Batch SKU availability checker across multiple regions.",
+    "source": "pypi"
+  },
+  {
+    "name": "az-scout-plugin-regions-cheapest",
+    "description": "Find the cheapest Azure regions for a given VM SKU.",
+    "source": "github",
+    "url": "https://github.com/rsabile/az-scout-plugin-regions-cheapest"
+  },
+  {
+    "name": "az-scout-plugin-latency-stats",
+    "description": "Provides insights and recommendations for Azure subscriptions.",
+    "source": "pypi"
+  }
+]

--- a/src/az_scout/routes/__init__.py
+++ b/src/az_scout/routes/__init__.py
@@ -164,6 +164,13 @@ async def update_plugin(body: UpdateRequest, request: Request) -> JSONResponse:
     )
 
 
+@router.get("/recommended", summary="List recommended plugins")
+async def list_recommended() -> JSONResponse:
+    """Return the curated list of recommended plugins with install status."""
+    plugins = plugin_manager.load_recommended_plugins()
+    return JSONResponse({"plugins": plugins})
+
+
 @router.post("/update-all", summary="Update all plugins")
 async def update_all_plugins(request: Request) -> JSONResponse:
     """Update all installed plugins that have available updates."""

--- a/src/az_scout/static/html/plugins.html
+++ b/src/az_scout/static/html/plugins.html
@@ -108,4 +108,31 @@
             </div>
         </div>
     </div>
+
+    <!-- Recommended plugins -->
+    <div>
+        <div class="card">
+            <div class="card-header"><i class="bi bi-star me-1"></i>Plugin catalog (recommendations)</div>
+            <div class="card-body p-0">
+                <div id="pm-recommended-empty" class="text-center text-body-secondary py-3">
+                    No recommended plugins
+                </div>
+                <div id="pm-recommended-table-wrap" class="d-none">
+                    <div class="table-responsive">
+                    <table class="table table-sm table-hover mb-0" style="font-size:0.82rem;">
+                        <thead>
+                            <tr>
+                                <th>Plugin</th>
+                                <th>Description</th>
+                                <th>Source</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody id="pm-recommended-tbody"></tbody>
+                    </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -50,6 +50,7 @@
             .then(html => {
                 container.innerHTML = html;
                 loadPlugins();
+                loadRecommended();
             });
     }
 
@@ -330,6 +331,81 @@
             }
         } catch (e) {
             alert("Update all error: " + e.message);
+        } finally {
+            hideSpinner();
+        }
+    };
+
+    // ---- Recommended plugins ----
+
+    function loadRecommended() {
+        apiFetch("/api/plugins/recommended").then(data => {
+            renderRecommended(data.plugins || []);
+        }).catch(() => {});
+    }
+
+    function renderRecommended(list) {
+        const empty = document.getElementById("pm-recommended-empty");
+        const wrap = document.getElementById("pm-recommended-table-wrap");
+        const tbody = document.getElementById("pm-recommended-tbody");
+        if (!empty || !wrap || !tbody) return;
+
+        if (list.length === 0) {
+            empty.classList.remove("d-none");
+            wrap.classList.add("d-none");
+            return;
+        }
+        empty.classList.add("d-none");
+        wrap.classList.remove("d-none");
+        tbody.innerHTML = "";
+
+        for (const p of list) {
+            const tr = document.createElement("tr");
+            const pypi = p.source === "pypi";
+            let sourceLink;
+            if (pypi) {
+                const pypiUrl = `https://pypi.org/project/${encodeURIComponent(p.name)}/`;
+                sourceLink = `<a href="${escHtml(pypiUrl)}" target="_blank" rel="noopener"><i class="bi bi-box-seam me-1"></i>PyPI</a>`;
+            } else {
+                sourceLink = p.url
+                    ? `<a href="${escHtml(p.url)}" target="_blank" rel="noopener"><i class="bi bi-github me-1"></i>GitHub</a>`
+                    : escHtml(p.source);
+            }
+
+            let actionCell;
+            if (p.installed) {
+                actionCell = '<span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Installed</span>';
+            } else {
+                const installSource = pypi ? escAttr(p.name) : escAttr(p.url);
+                const installVersion = escAttr(p.version || "");
+                actionCell = `<button class="btn btn-outline-success btn-sm py-0 px-2"
+                                      title="Quick install"
+                                      onclick="pmQuickInstall('${installSource}', '${installVersion}')">
+                                  <i class="bi bi-download me-1"></i>Install
+                              </button>`;
+            }
+
+            tr.innerHTML = `
+                <td><code>${escHtml(p.name)}</code></td>
+                <td>${escHtml(p.description)}</td>
+                <td>${sourceLink}</td>
+                <td class="text-nowrap">${actionCell}</td>`;
+            tbody.appendChild(tr);
+        }
+    }
+
+    window.pmQuickInstall = async function (source, version) {
+        showSpinner("Installing…");
+        try {
+            const data = await apiPost("/api/plugins/install", { repo_url: source, ref: version });
+            if (data.ok) {
+                window.location.reload();
+                return;
+            } else {
+                showResultError((data.errors || []).join("; "));
+            }
+        } catch (e) {
+            showResultError(e.message);
         } finally {
             hideSpinner();
         }

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1733,3 +1733,148 @@ class TestSourceBackwardCompat:
         assert len(loaded) == 1
         assert loaded[0].source == "pypi"
         assert loaded[0].ref == "0.2.0"
+
+
+# ---------------------------------------------------------------------------
+# Recommended plugins
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRecommendedPlugins:
+    def test_load_with_no_installed(self, tmp_path: Path) -> None:
+        """Recommended plugins should all show installed=False when nothing is installed."""
+        rec_file = tmp_path / "recommended_plugins.json"
+        rec_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "az-scout-plugin-foo",
+                        "description": "Foo plugin",
+                        "source": "pypi",
+                    },
+                    {
+                        "name": "az-scout-plugin-bar",
+                        "description": "Bar plugin",
+                        "source": "github",
+                        "url": "https://github.com/owner/bar",
+                    },
+                ]
+            ),
+            encoding="utf-8",
+        )
+        installed_file = tmp_path / "installed.json"
+        installed_file.write_text("[]", encoding="utf-8")
+
+        with (
+            patch.object(plugin_manager, "_RECOMMENDED_FILE", rec_file),
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+        ):
+            result = plugin_manager.load_recommended_plugins()
+
+        assert len(result) == 2
+        assert result[0]["name"] == "az-scout-plugin-foo"
+        assert result[0]["installed"] is False
+        assert result[1]["name"] == "az-scout-plugin-bar"
+        assert result[1]["source"] == "github"
+        assert result[1]["installed"] is False
+
+    def test_installed_plugin_marked(self, tmp_path: Path) -> None:
+        """Plugins that are already installed should be marked installed=True."""
+        rec_file = tmp_path / "recommended_plugins.json"
+        rec_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "az-scout-plugin-foo",
+                        "description": "Foo",
+                        "source": "pypi",
+                    },
+                ]
+            ),
+            encoding="utf-8",
+        )
+        installed_file = tmp_path / "installed.json"
+        installed_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "distribution_name": "az-scout-plugin-foo",
+                        "repo_url": "",
+                        "ref": "1.0.0",
+                        "resolved_sha": "",
+                        "entry_points": {},
+                        "installed_at": "2026-01-01T00:00:00+00:00",
+                        "actor": "tester",
+                        "source": "pypi",
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch.object(plugin_manager, "_RECOMMENDED_FILE", rec_file),
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+        ):
+            result = plugin_manager.load_recommended_plugins()
+
+        assert len(result) == 1
+        assert result[0]["installed"] is True
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """When the recommended file does not exist, return an empty list."""
+        missing = tmp_path / "does_not_exist.json"
+        with patch.object(plugin_manager, "_RECOMMENDED_FILE", missing):
+            result = plugin_manager.load_recommended_plugins()
+        assert result == []
+
+    def test_optional_version_field(self, tmp_path: Path) -> None:
+        """Entries with a version field should be propagated."""
+        rec_file = tmp_path / "recommended_plugins.json"
+        rec_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "az-scout-plugin-pinned",
+                        "description": "Pinned plugin",
+                        "source": "pypi",
+                        "version": "2.0.0",
+                    },
+                ]
+            ),
+            encoding="utf-8",
+        )
+        installed_file = tmp_path / "installed.json"
+        installed_file.write_text("[]", encoding="utf-8")
+
+        with (
+            patch.object(plugin_manager, "_RECOMMENDED_FILE", rec_file),
+            patch.object(plugin_manager, "_INSTALLED_FILE", installed_file),
+        ):
+            result = plugin_manager.load_recommended_plugins()
+
+        assert result[0]["version"] == "2.0.0"
+
+
+class TestRecommendedRoute:
+    def test_list_recommended(self, client) -> None:  # type: ignore[no-untyped-def]
+        """GET /api/plugins/recommended should return the recommended list."""
+        mock_data = [
+            {
+                "name": "az-scout-plugin-foo",
+                "description": "Foo",
+                "source": "pypi",
+                "url": "",
+                "version": "",
+                "installed": False,
+            }
+        ]
+        with patch.object(plugin_manager, "load_recommended_plugins", return_value=mock_data):
+            resp = client.get("/api/plugins/recommended")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "plugins" in data
+        assert len(data["plugins"]) == 1
+        assert data["plugins"][0]["name"] == "az-scout-plugin-foo"
+        assert data["plugins"][0]["installed"] is False


### PR DESCRIPTION
## Description

Add a curated plugin catalog to the Plugin Manager panel. A new
`recommended_plugins.json` config file lists recommended plugins with
metadata (name, description, source, version). The Plugin Manager UI
displays these in a "Plugin catalog (recommendations)" card with
quick-install buttons and installed-status badges.

**Backend:**
- New `RecommendedPlugin` dataclass and `load_recommended_plugins()` in
  `plugin_manager.py` — reads the config, cross-references installed
  plugins, and returns entries with an `installed` boolean.
- New `GET /api/plugins/recommended` route.

**Frontend:**
- New catalog card in `plugins.html` with a table (plugin, description,
  source link, install/installed badge).
- `loadRecommended()`, `renderRecommended()`, and `pmQuickInstall()` in
  `plugins.js`.

**Tests:** 5 new tests covering config loading, installed-status
marking, missing file fallback, optional version field, and the API
route.

## Related issue

Closes #78

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

## Screenshots

<img width="687" height="237" alt="image" src="https://github.com/user-attachments/assets/9286c780-5ebf-4c30-aa97-e6a6f039f890" />