### PR TITLE
feat(azure_api): public ARM helpers with retry + migrate internal modules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,9 @@ src/az_scout/
 ├── plugins.py          # Plugin discovery, registration, hot-reload
 ├── azure_api/          # Shared Azure ARM logic (auth, pagination, data functions)
 │   ├── __init__.py     # Public API surface (PLUGIN_API_VERSION, __all__)
+│   ├── _arm.py         # arm_get/arm_post/arm_paginate + get_headers (public)
+│   ├── _auth.py        # DefaultAzureCredential, _get_headers (internal)
+│   ├── _pagination.py  # Legacy _paginate (internal, use arm_paginate instead)
 │   ├── discovery.py    # Tenants, subscriptions, regions
 │   ├── skus.py         # SKU catalogue + zone mappings
 │   ├── pricing.py      # Retail prices API
@@ -64,9 +67,11 @@ tests/
 ## Azure API patterns
 
 - Auth uses `DefaultAzureCredential` with optional `tenant_id` parameter.
-- All ARM calls go through `requests.get()` with `Authorization: Bearer <token>` header.
+- All ARM calls should use the public helpers: `arm_get()`, `arm_post()`, `arm_paginate()`.
+- These helpers provide automatic Bearer-token auth, 429/5xx retry with backoff, and structured error handling (`ArmAuthorizationError`, `ArmNotFoundError`, `ArmRequestError`).
+- For raw token access (non-ARM endpoints), use `get_headers(tenant_id)`.
 - API base URL: `https://management.azure.com`.
-- Handle pagination (`nextLink`) for list endpoints.
+- Handle pagination (`nextLink`) via `arm_paginate()` for list endpoints.
 - Per-subscription errors should be included in the response (not fail the whole request).
 
 ## MCP tools reference

--- a/.github/prompts/add-plugin-to-catalog.prompt.md
+++ b/.github/prompts/add-plugin-to-catalog.prompt.md
@@ -1,0 +1,86 @@
+---
+description: Add a new plugin to the known-plugins list and recommended catalog.
+
+tools:
+  - run_in_terminal
+  - mcp_github_get_file_contents
+---
+
+Add a new external plugin to the az-scout plugin catalog.
+The user will provide the plugin name, GitHub URL, and optionally its PyPI status.
+
+## 1. Gather plugin information
+
+Collect:
+
+- **Plugin name** (package name, e.g. `az-scout-plugin-foo`)
+- **GitHub URL** (e.g. `https://github.com/owner/az-scout-plugin-foo`)
+- **Short description** (one line)
+- **Source:** `pypi` if published on PyPI, otherwise `github`
+- **PyPI URL** (if applicable): check with `https://pypi.org/project/<name>/`
+
+If only a GitHub URL is provided, use `mcp_github_get_file_contents` to read the plugin's
+`pyproject.toml` and `README.md` to extract the package name and description.
+
+Verify the plugin is a valid az-scout plugin by checking that its `pyproject.toml` declares
+an `az_scout.plugins` entry point.
+
+## 2. Update known-plugins table
+
+Edit `docs/_includes/known-plugins.md` — this file is included by:
+
+- `docs/plugins/index.md`
+- `docs/plugins/catalog.md`
+- `docs/features.md`
+- `docs/index.md`
+
+Add a new row in the table, maintaining alphabetical order by plugin name:
+
+```markdown
+| [az-scout-plugin-foo](https://github.com/owner/az-scout-plugin-foo) | Short description |
+```
+
+## 3. Update recommended plugins JSON
+
+Edit `src/az_scout/recommended_plugins.json` — this powers the Plugin Manager UI's
+"Recommended" section.
+
+Add a new entry to the JSON array:
+
+For PyPI-published plugins:
+```json
+{
+  "name": "az-scout-plugin-foo",
+  "description": "Short description.",
+  "source": "pypi"
+}
+```
+
+For GitHub-only plugins (not on PyPI):
+```json
+{
+  "name": "az-scout-plugin-foo",
+  "description": "Short description.",
+  "source": "github",
+  "url": "https://github.com/owner/az-scout-plugin-foo"
+}
+```
+
+## 5. Verify
+
+Run a quick check to ensure no JSON syntax errors:
+
+```bash
+python3 -c "import json; json.load(open('src/az_scout/recommended_plugins.json'))"
+```
+
+And verify the markdown table renders correctly by inspecting `docs/_includes/known-plugins.md`.
+
+## 6. Summary
+
+Report what was updated:
+
+- `docs/_includes/known-plugins.md` — new table row
+- `src/az_scout/recommended_plugins.json` — new catalog entry
+
+Update `CHANGELOG.md` under `## Unreleased` with the new plugin addition.

--- a/.github/prompts/review-plugin.prompt.md
+++ b/.github/prompts/review-plugin.prompt.md
@@ -1,0 +1,124 @@
+---
+description: Review an external az-scout plugin for convention compliance, correctness, and best practices.
+
+tools:
+  - un_in_termina
+  - mcp_github_get_file_contents
+---
+
+Review an external az-scout plugin for compliance with project conventions.
+The user will provide the plugin path (local) or GitHub repository URL.
+
+## 1. Gather plugin sources
+
+If a **local path** is provided, read files directly from that directory.
+If a **GitHub URL** is provided, use `mcp_github_get_file_contents` to fetch key files.
+
+Collect these files (all are expected to exist):
+
+- `pyproject.toml`
+- `src/<module>/__init__.py` (plugin class)
+- `src/<module>/routes.py` (if API routes are provided)
+- `src/<module>/tools.py` (if MCP tools are provided)
+- Any JS/CSS/HTML files under `static/`
+
+## 2. Naming conventions
+
+Verify:
+
+| Item | Expected pattern | Example |
+|------|-----------------|---------|
+| Package name | `az-scout-{slug}` | `az-scout-batch-sku` |
+| Module name | `az_scout_{slug}` | `az_scout_batch_sku` |
+| Entry point key | `{slug}` (under `az_scout.plugins` group) | `batch_sku` |
+| Plugin `name` attribute | `"{slug}"` (kebab-case) | `"batch-sku"` |
+| `TabDefinition.id` | matches slug | `"batch-sku"` |
+
+Flag any mismatch.
+
+## 3. Packaging and build
+
+Check `pyproject.toml` for:
+
+- [ ] Build backend is `hatchling` (with `hatch-vcs` if using dynamic version)
+- [ ] `requires-python = ">=3.11"`
+- [ ] `az-scout` and `fastapi` are listed in `dependencies`
+- [ ] Entry point is correctly declared under `[project.entry-points."az_scout.plugins"]`
+- [ ] `[tool.hatch.build.targets.wheel]` specifies `packages = ["src/<module>"]`
+- [ ] If using `hatch-vcs`: has `raw-options.fallback_version` for editable-install safety
+- [ ] Ruff config: `line-length = 100`, `target-version = "py311"`, rules include `E, F, I, W, UP, B, SIM`
+- [ ] Mypy config: `python_version = "3.11"`, `strict = true`
+
+## 4. Plugin protocol compliance
+
+Check the plugin class in `__init__.py`:
+
+- [ ] Has `name: str` and `version: str` attributes
+- [ ] `get_router()` returns `APIRouter | None` (lazy import of router module)
+- [ ] `get_mcp_tools()` returns `list[Callable] | None` (lazy import of tool functions)
+- [ ] `get_static_dir()` returns `Path | None` (uses `_STATIC_DIR = Path(__file__).parent / "static"`)
+- [ ] `get_tabs()` returns `list[TabDefinition] | None`
+- [ ] `get_chat_modes()` returns `list[ChatMode] | None`
+- [ ] Optional: `get_system_prompt_addendum()` returns `str | None`
+- [ ] Module-level `plugin = PluginClass()` instance exists
+- [ ] All methods use **lazy imports** (no heavy imports at module top-level)
+- [ ] No global mutable state
+
+## 5. Type annotations
+
+- [ ] All functions have type annotations (parameters and return types)
+- [ ] `from __future__ import annotations` is NOT required (Python 3.11+) but acceptable
+- [ ] MCP tool docstrings are present (they become tool descriptions for LLMs)
+
+## 6. Frontend conventions (if UI tab exists)
+
+- [ ] JS uses `const`/`let` (never `var`), `camelCase` naming
+- [ ] Tab container targets `#plugin-tab-{slug}`
+- [ ] Uses `azscout:*` events for context changes (not MutationObserver or direct DOM watchers)
+- [ ] HTML loaded as fragments from `static/html/` (not inline strings in JS)
+- [ ] CSS uses custom properties from core `:root`, supports dark/light themes
+- [ ] Static assets reference paths under `/plugins/{slug}/static/`
+
+## 7. Isolation rules
+
+- [ ] Plugin does not mutate global application state
+- [ ] Plugin does not override built-in routes
+- [ ] Plugin does not import heavy modules at import time
+- [ ] Plugin does not assume plugin registration ordering
+- [ ] Plugin respects the core app's authentication model (uses `tenantQS`, etc.)
+
+## 8. Run lint checks (local path only)
+
+If the plugin is available locally, run:
+
+```bash
+cd <plugin-path>
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+uv run pytest
+```
+
+Report any failures.
+
+## 9. Report findings
+
+Produce a structured review summary:
+
+```markdown
+## Plugin Review: <plugin-name>
+
+### ✅ Passes
+- …
+
+### ⚠️ Warnings (non-blocking)
+- …
+
+### ❌ Issues (must fix)
+- …
+
+### Recommendations
+- …
+```
+
+If a GitHub issue or PR is associated, post the review there. Otherwise, present it to the user.

--- a/.github/prompts/ship-code-change.prompt.md
+++ b/.github/prompts/ship-code-change.prompt.md
@@ -1,0 +1,77 @@
+---
+description: Prepare a code change for shipping — run quality checks, update changelog and docs, commit, and open a PR.
+
+tools:
+  - run_in_terminal
+  - get_changed_files
+  - get_errors
+  - create_and_run_task
+  - mcp_github_create_branch
+  - mcp_github_push_files
+  - mcp_github_create_pull_request
+---
+
+Prepare the current working-tree changes for shipping by executing each step below.
+Stop and report clearly if any step fails.
+
+## 1. Gather context
+
+- Use `get_changed_files` to list all staged & unstaged changes.
+- Read `CHANGELOG.md` and `.github/pull_request_template.md` for current format.
+- Identify any related GitHub issue numbers from branch names, commit messages, or file content.
+
+## 2. Quality checks
+
+Run the project's quality gate (lint, format, type-check, tests) via the workspace task:
+
+```
+run_task: "Dev: run all checks"
+```
+
+Alternatively run each step with `run_in_terminal`:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+uv run pytest
+```
+
+If any check fails, fix the issue in the source files and re-run until all pass.
+
+## 3. Changelog
+
+- Update `CHANGELOG.md` under the `## Unreleased` section.
+- Follow the existing format: group entries under `### Added`, `### Changed`, `### Fixed`, or `### Removed`.
+- Each entry should start with a bold feature/area label and a concise description.
+
+## 4. Documentation
+
+- If the change affects public APIs, CLI commands, plugin contracts, or user-facing features, update the relevant files in `docs/`, `README.md`, or scaffold docs under `docs/plugin-scaffold/`.
+- If a new MCP tool was added, update the tool table in `README.md` and `docs/ai/mcp.md`.
+
+## 5. Commit
+
+Compose a commit message following conventional-commit style:
+
+```
+<type>(<scope>): <concise summary>
+
+- bullet list of notable changes
+- reference issues with #<number>
+```
+
+Where `<type>` is one of: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
+
+Create a feature branch (`git checkout -b <branch-name>`) if not already on one, stage all relevant files, and commit.
+
+## 6. Push and open PR
+
+- Push the branch to `origin`.
+- Use `mcp_github_create_pull_request` to open a PR against `main`.
+- Fill the PR body using the template from `.github/pull_request_template.md`:
+  - **Description:** summarize what the PR does.
+  - **Related issue:** link issues with `Closes #<number>` when applicable.
+  - **Type of change:** check the matching boxes.
+  - **Checklist:** mark items that have been verified.
+- If breaking changes are included, highlight them in both the commit message and the PR description.

--- a/.github/prompts/tag-release.prompt.md
+++ b/.github/prompts/tag-release.prompt.md
@@ -1,0 +1,110 @@
+---
+description: Tag a new CalVer release on the main branch — finalize changelog, commit, tag, push, and verify.
+
+tools:
+  - run_in_terminal
+  - get_changed_files
+---
+
+Tag a new release by executing each step below **on the `main` branch**.
+Stop and report clearly if any step fails.
+
+## 1. Verify branch
+
+Confirm the current branch is `main` and the working tree is clean:
+
+```bash
+git branch --show-current   # must be "main"
+git status --short           # must be empty
+```
+
+If not on `main`, abort with a clear message — releases are only tagged from `main`.
+If the working tree is dirty, list the uncommitted changes and ask for confirmation before proceeding.
+
+## 2. Determine the new version
+
+This project uses [CalVer](https://calver.org/) with the format `YYYY.MM.MICRO`:
+
+- `YYYY` — current four-digit year (e.g. `2026`)
+- `MM` — current month as a single or double digit (e.g. `3` for March)
+- `MICRO` — patch counter, incremented from the last tag in the same `YYYY.MM` series
+
+Steps:
+
+1. Get the current year and month.
+2. List existing tags matching `vYYYY.MM.*` for the current year/month:
+   ```bash
+   git tag -l "v$(date +%Y).$(date +%-m).*" --sort=-v:refname | head -5
+   ```
+3. If tags exist for this month, increment `MICRO` by 1.
+   If no tags exist for this month, start at `0`.
+4. The new version is `YYYY.MM.MICRO` and the tag is `vYYYY.MM.MICRO`.
+
+Present the computed version and ask for confirmation before proceeding.
+
+## 3. Quality checks
+
+Run the full quality gate to ensure the codebase is release-ready:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+uv run pytest
+```
+
+All four commands must pass. If any fails, stop and report the failure — do not tag a broken release.
+
+## 4. Finalize the changelog
+
+Edit `CHANGELOG.md`:
+
+1. Read the current `## Unreleased` section.
+2. If it is empty or contains only a placeholder (e.g. "To complete."), stop and ask the user to provide changelog entries before proceeding.
+3. Insert a new version heading between `## Unreleased` and the previous release:
+   ```markdown
+   ## Unreleased
+
+   ## [YYYY.MM.MICRO] - YYYY-MM-DD
+
+   ### Added
+   - …
+   ```
+4. Move all entries from `## Unreleased` into the new version section.
+5. Leave `## Unreleased` empty (no placeholder text).
+
+## 5. Commit the changelog
+
+```bash
+git add CHANGELOG.md
+git commit -m "release: vYYYY.MM.MICRO"
+```
+
+## 6. Create the tag
+
+```bash
+git tag vYYYY.MM.MICRO
+```
+
+## 7. Push
+
+Push the commit and the tag together:
+
+```bash
+git push origin main --tags
+```
+
+## 8. Post-tag verification
+
+Confirm the tag was pushed and the CI workflow was triggered:
+
+```bash
+git ls-remote --tags origin | grep "vYYYY.MM.MICRO"
+```
+
+Report the final version, tag name, and remind that the **Publish** workflow will:
+
+1. Run CI (lint + tests across Python 3.11–3.13).
+2. Validate the tag follows CalVer and the built package version matches.
+3. Create a GitHub Release with auto-generated release notes.
+4. Publish to PyPI via trusted publishing (OIDC).

--- a/.github/prompts/triage-issue.prompt.md
+++ b/.github/prompts/triage-issue.prompt.md
@@ -1,0 +1,91 @@
+---
+description: Triage a GitHub issue — investigate the codebase, assess impact, propose a plan, and post findings as a comment on the issue.
+
+tools:
+  - run_in_terminal
+  - mcp_github_issue_read
+  - mcp_github_add_issue_comment
+---
+
+Triage a GitHub issue by executing each step below.
+The issue URL or number will be provided by the user.
+
+## 1. Read the issue
+
+Use `mcp_github_issue_read` to fetch the issue title, body, labels, and existing comments.
+Note the issue number for later.
+
+## 2. Classify the issue
+
+Determine the type:
+
+| Type | Indicators |
+|------|-----------|
+| **Bug** | Error trace, unexpected behavior, regression |
+| **Feature request** | "It would be nice", "add support for", enhancement |
+| **Question / support** | "How do I", "is it possible", clarification |
+| **Documentation** | Typo, missing docs, unclear instructions |
+
+## 3. Search the codebase
+
+Based on the issue content, search for related code:
+
+- Search for keywords, function names, error messages, or file paths mentioned in the issue.
+- Identify the affected module(s): `azure_api/`, `routes/`, `services/`, `internal_plugins/`, `static/js/`, `scoring/`, `plugin_api`, etc.
+- Read relevant source files to understand current behavior.
+- If a stack trace is provided, locate the exact file and line.
+
+## 4. Assess reproducibility and impact
+
+- **Reproducibility:** Can the issue be reproduced from the description? Is it environment-specific?
+- **Scope:** Which components are affected? Is it isolated or cross-cutting?
+- **Severity:** Does it block core functionality, affect plugins, or is it cosmetic?
+- **Complexity:** Estimate effort — trivial (< 1h), moderate (1–4h), or significant (> 4h).
+
+## 5. Propose an implementation plan
+
+For bugs:
+- Identify the root cause and the fix location.
+- Note if tests need updating or if new tests are needed.
+
+For features:
+- Outline the approach (which files to modify, new modules if any).
+- Note if it requires changes in `azure_api/`, plugin API, frontend, or docs.
+- Flag any breaking changes.
+
+## 6. Post the triage comment
+
+Use `mcp_github_add_issue_comment` to post a structured comment on the issue:
+
+```markdown
+## Triage Summary
+
+**Type:** Bug / Feature / Docs / Question
+**Severity:** Low / Medium / High / Critical
+**Complexity:** Trivial / Moderate / Significant
+**Affected area(s):** `module/path`
+
+### Analysis
+
+<!-- What was found in the codebase — root cause for bugs, feasibility for features -->
+
+### Relevant code
+
+- `src/az_scout/path/to/file.py` (lines X–Y) — brief description
+- …
+
+### Proposed approach
+
+1. Step one
+2. Step two
+3. …
+
+### Checklist before implementation
+
+- [ ] Tests to add/update
+- [ ] Documentation to update
+- [ ] Breaking change? (yes/no)
+- [ ] Plugin API impact? (yes/no)
+```
+
+Do NOT modify any source files — this prompt is investigation-only. Report findings back to the issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
-To complete.
+### Added
+
+- **Public ARM helpers** – new `arm_get()`, `arm_post()`, and `arm_paginate()` functions in `azure_api` provide authenticated ARM calls with built-in 429/5xx retry, exponential backoff, `Retry-After` header support, and structured error handling (`ArmAuthorizationError`, `ArmNotFoundError`, `ArmRequestError`). These are the recommended way for plugins and core modules to interact with Azure Resource Manager (#97).
+- **`get_headers()` public alias** – promoted from internal `_get_headers()` for plugins that need raw Bearer-token headers for non-ARM endpoints (#95).
+- **`PLUGIN_API_VERSION` bumped to `1.1`** – additive change, backward compatible.
+- **Copilot prompts** – added `triage-issue`, `review-plugin`, `add-plugin-to-catalog`, and `tag-release` reusable prompt files for coding agents.
+
+### Changed
+
+- **Internal modules migrated to ARM helpers** – `discovery.py`, `skus.py`, `quotas.py`, and `spot.py` now use `arm_get`/`arm_post`/`arm_paginate` instead of raw `requests.get`/`requests.post` + manual retry loops. This eliminates duplicated retry/backoff/error handling code across 4 modules.
 
 ## [2026.3.3] - 2026-03-06
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -203,6 +203,53 @@ The docstring is the tool description shown to LLMs — keep it concise.
 
 ---
 
+## Azure ARM helpers for plugins
+
+Plugins that need to make authenticated ARM API calls should use the public
+helpers from `az_scout.azure_api` (available since `PLUGIN_API_VERSION = "1.1"`):
+
+```python
+from az_scout.azure_api import (
+    AZURE_MGMT_URL,
+    arm_get,          # GET with auth + retry + error handling
+    arm_post,         # POST with auth + retry + error handling
+    arm_paginate,     # GET + follow nextLink pages
+    get_headers,      # raw Bearer-token headers (escape hatch)
+    ArmAuthorizationError,  # raised on HTTP 403
+    ArmNotFoundError,       # raised on HTTP 404
+    ArmRequestError,        # raised after all retries exhausted
+)
+```
+
+### `arm_get(url, *, params=None, tenant_id=None, timeout=30, max_retries=3)`
+
+GET an ARM endpoint. Returns the parsed JSON response as a `dict`.
+
+### `arm_post(url, *, json, tenant_id=None, timeout=30, max_retries=3)`
+
+POST to an ARM endpoint. Returns the parsed JSON response as a `dict`.
+
+### `arm_paginate(url, *, params=None, tenant_id=None, timeout=30, max_retries=3)`
+
+GET all pages from an ARM list endpoint. Follows `nextLink` automatically.
+Returns the merged `value` items as a `list[dict]`.
+
+### `get_headers(tenant_id=None)`
+
+Returns raw `{"Authorization": "Bearer …"}` headers. Use this only for
+non-ARM endpoints or custom HTTP libraries — prefer `arm_get`/`arm_post`
+for standard ARM calls.
+
+All three helpers handle:
+
+- **Authentication** — Bearer token via `DefaultAzureCredential`
+- **429 rate limiting** — retries with `Retry-After` header support
+- **5xx server errors** — retries with exponential backoff
+- **Timeouts** — retries on `ReadTimeout`
+- **403/404** — raises typed exceptions (`ArmAuthorizationError`, `ArmNotFoundError`)
+
+---
+
 ## Plugin `pyproject.toml` template
 
 ```toml

--- a/src/az_scout/azure_api/__init__.py
+++ b/src/az_scout/azure_api/__init__.py
@@ -26,6 +26,17 @@ import time as time  # noqa: F401  # re-export for mock patching
 
 import requests as requests  # noqa: F401  # re-export for mock patching
 
+# -- ARM helpers (public API for plugins) ------------------------------------
+from az_scout.azure_api._arm import (  # noqa: F401
+    ArmAuthorizationError,
+    ArmNotFoundError,
+    ArmRequestError,
+    arm_get,
+    arm_paginate,
+    arm_post,
+    get_headers,
+)
+
 # -- Auth & constants -------------------------------------------------------
 from az_scout.azure_api._auth import (  # noqa: F401
     AZURE_API_VERSION,
@@ -97,7 +108,7 @@ from az_scout.azure_api.spot import (  # noqa: F401
 # ---------------------------------------------------------------------------
 # API version – bump major for breaking changes, minor for additions.
 # ---------------------------------------------------------------------------
-PLUGIN_API_VERSION = "1.0"
+PLUGIN_API_VERSION = "1.1"
 """Semantic version of the plugin-facing API surface (``__all__``)."""
 
 # ---------------------------------------------------------------------------
@@ -113,6 +124,14 @@ __all__ = [
     "RETAIL_PRICES_API_VERSION",
     "RETAIL_PRICES_URL",
     "SPOT_API_VERSION",
+    # ARM helpers (authentication, retry, pagination)
+    "get_headers",
+    "arm_get",
+    "arm_post",
+    "arm_paginate",
+    "ArmRequestError",
+    "ArmAuthorizationError",
+    "ArmNotFoundError",
     # Discovery
     "list_tenants",
     "list_subscriptions",

--- a/src/az_scout/azure_api/_arm.py
+++ b/src/az_scout/azure_api/_arm.py
@@ -1,0 +1,336 @@
+"""High-level ARM HTTP helpers with authentication, retry, and pagination.
+
+These functions form the **recommended** way for both core modules and
+plugins to interact with Azure Resource Manager endpoints.
+
+All three helpers (``arm_get``, ``arm_post``, ``arm_paginate``) are part
+of the stable public plugin API (see ``__all__`` in ``__init__.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+# Import requests through a module-level reference that test fixtures
+# can patch via ``az_scout.azure_api._arm.requests``.
+import requests
+
+from az_scout.azure_api._auth import _get_headers
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+DEFAULT_TIMEOUT = 30
+DEFAULT_MAX_RETRIES = 3
+_INITIAL_BACKOFF = 1.0  # seconds
+_MAX_BACKOFF = 16.0  # seconds
+
+
+class ArmRequestError(Exception):
+    """Raised when an ARM request fails after all retries."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        url: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.url = url
+
+
+class ArmAuthorizationError(ArmRequestError):
+    """Raised on HTTP 403 — the caller lacks permissions."""
+
+
+class ArmNotFoundError(ArmRequestError):
+    """Raised on HTTP 404 — the resource does not exist."""
+
+
+def _compute_backoff(attempt: int, retry_after: str | None = None) -> float:
+    """Compute wait time from ``Retry-After`` header or exponential backoff."""
+    if retry_after:
+        try:
+            wait = float(retry_after)
+            return float(min(wait, _MAX_BACKOFF))
+        except ValueError:
+            pass
+    return float(min(_INITIAL_BACKOFF * (2**attempt), _MAX_BACKOFF))
+
+
+def _should_retry(status_code: int) -> bool:
+    """Return True for status codes that warrant a retry."""
+    try:
+        code = int(status_code)
+    except (TypeError, ValueError):
+        return False
+    return code == 429 or code >= 500
+
+
+def _arm_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    params: dict[str, str] | None = None,
+    json_body: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Execute an ARM HTTP request with retry and structured error handling."""
+    last_exc: Exception | None = None
+
+    for attempt in range(max_retries):
+        try:
+            if method == "POST":
+                resp = requests.post(
+                    url,
+                    headers=headers,
+                    json=json_body,
+                    timeout=timeout,
+                )
+            else:
+                resp = requests.get(
+                    url,
+                    headers=headers,
+                    params=params,
+                    timeout=timeout,
+                )
+
+            if resp.status_code == 403:
+                raise ArmAuthorizationError(
+                    f"Authorization failed: {resp.text[:200]}",
+                    status_code=403,
+                    url=url,
+                )
+
+            if resp.status_code == 404:
+                raise ArmNotFoundError(
+                    f"Resource not found: {url}",
+                    status_code=404,
+                    url=url,
+                )
+
+            if _should_retry(resp.status_code) and attempt < max_retries - 1:
+                wait = _compute_backoff(attempt, resp.headers.get("Retry-After"))
+                logger.warning(
+                    "ARM %s %s returned %d, retrying in %.1fs (attempt %d/%d)",
+                    method,
+                    url[:120],
+                    resp.status_code,
+                    wait,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(wait)
+                continue
+
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+            return data
+
+        except (ArmAuthorizationError, ArmNotFoundError):
+            raise
+        except requests.exceptions.ReadTimeout:
+            last_exc = requests.exceptions.ReadTimeout()
+            if attempt < max_retries - 1:
+                wait = _compute_backoff(attempt)
+                logger.warning(
+                    "ARM %s %s timed out, retrying in %.1fs (attempt %d/%d)",
+                    method,
+                    url[:120],
+                    wait,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(wait)
+                continue
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            if attempt < max_retries - 1:
+                wait = _compute_backoff(attempt)
+                logger.warning(
+                    "ARM %s %s failed (%s), retrying in %.1fs (attempt %d/%d)",
+                    method,
+                    url[:120],
+                    exc,
+                    wait,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(wait)
+                continue
+
+    raise ArmRequestError(
+        f"ARM {method} {url[:120]} failed after {max_retries} attempts: {last_exc}",
+        url=url,
+    )
+
+
+def arm_get(
+    url: str,
+    *,
+    params: dict[str, str] | None = None,
+    tenant_id: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """GET an ARM endpoint with authentication, retry on 429/5xx, and error handling.
+
+    Parameters
+    ----------
+    url:
+        Full ARM URL (e.g. ``https://management.azure.com/subscriptions/…``).
+    params:
+        Optional query parameters (merged with the URL).
+    tenant_id:
+        Scope the Bearer token to a specific Azure AD tenant.
+    timeout:
+        HTTP request timeout in seconds (default 30).
+    max_retries:
+        Maximum number of attempts (default 3).
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed JSON response body.
+
+    Raises
+    ------
+    ArmAuthorizationError
+        On HTTP 403.
+    ArmNotFoundError
+        On HTTP 404.
+    ArmRequestError
+        On other failures after all retries are exhausted.
+    """
+    headers = _get_headers(tenant_id)
+    logger.debug("ARM GET %s (tenant=%s)", url[:120], tenant_id or "default")
+    return _arm_request(
+        "GET",
+        url,
+        headers=headers,
+        params=params,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+
+
+def arm_post(
+    url: str,
+    *,
+    json: dict[str, Any],
+    tenant_id: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """POST to an ARM endpoint with authentication, retry on 429/5xx, and error handling.
+
+    Parameters
+    ----------
+    url:
+        Full ARM URL.
+    json:
+        Request body as a dictionary.
+    tenant_id:
+        Scope the Bearer token to a specific Azure AD tenant.
+    timeout:
+        HTTP request timeout in seconds (default 30).
+    max_retries:
+        Maximum number of attempts (default 3).
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed JSON response body.
+
+    Raises
+    ------
+    ArmAuthorizationError
+        On HTTP 403.
+    ArmNotFoundError
+        On HTTP 404.
+    ArmRequestError
+        On other failures after all retries are exhausted.
+    """
+    headers = _get_headers(tenant_id)
+    logger.debug("ARM POST %s (tenant=%s)", url[:120], tenant_id or "default")
+    return _arm_request(
+        "POST",
+        url,
+        headers=headers,
+        json_body=json,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+
+
+def arm_paginate(
+    url: str,
+    *,
+    params: dict[str, str] | None = None,
+    tenant_id: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> list[dict[str, Any]]:
+    """Fetch all pages from an ARM list endpoint and return the merged ``value`` items.
+
+    Follows ``nextLink`` references automatically.  Each page request uses
+    ``arm_get`` (with retry and 429 handling).
+
+    Parameters
+    ----------
+    url:
+        Initial ARM list URL.
+    params:
+        Optional query parameters for the **first** request only (``nextLink``
+        URLs include their own query parameters).
+    tenant_id:
+        Scope the Bearer token to a specific Azure AD tenant.
+    timeout:
+        Per-page HTTP request timeout in seconds (default 30).
+    max_retries:
+        Maximum retry attempts per page (default 3).
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Merged ``value`` items from all pages.
+    """
+    headers = _get_headers(tenant_id)
+    items: list[dict[str, Any]] = []
+    page_count = 0
+    current_params = params
+
+    while url:
+        data = _arm_request(
+            "GET",
+            url,
+            headers=headers,
+            params=current_params,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+        page_items = data.get("value", [])
+        items.extend(page_items)
+        page_count += 1
+        url = data.get("nextLink", "")
+        # nextLink URLs include query params — don't re-send ours
+        current_params = None
+
+    logger.debug("ARM paginate: %d pages, %d items total", page_count, len(items))
+    return items
+
+
+# Public aliases for the stable API
+get_headers = _get_headers
+"""Public alias for ``_get_headers`` — returns Bearer-token headers.
+
+Use this when you need raw authorization headers for a custom HTTP call
+(e.g. non-ARM endpoints or custom libraries).  For standard ARM calls,
+prefer ``arm_get`` / ``arm_post`` / ``arm_paginate`` instead.
+"""

--- a/src/az_scout/azure_api/discovery.py
+++ b/src/az_scout/azure_api/discovery.py
@@ -6,18 +6,15 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-import requests
-
+from az_scout.azure_api._arm import arm_get, arm_paginate
 from az_scout.azure_api._auth import (
     AZURE_API_VERSION,
     AZURE_MGMT_URL,
     _check_tenant_auth,
     _get_default_tenant_id,
-    _get_headers,
     _suppress_stderr,
 )
 from az_scout.azure_api._cache import _cache_set, _cached
-from az_scout.azure_api._pagination import _paginate
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +32,8 @@ def list_tenants(tenant_id: str | None = None) -> dict[str, Any]:
     if cached is not None:
         return cached  # type: ignore[return-value]
 
-    headers = _get_headers(tenant_id)
     url = f"{AZURE_MGMT_URL}/tenants?api-version={AZURE_API_VERSION}"
-    all_tenants = _paginate(url, headers)
+    all_tenants = arm_paginate(url, tenant_id=tenant_id)
 
     tenant_ids = [t["tenantId"] for t in all_tenants]
 
@@ -63,9 +59,8 @@ def list_tenants(tenant_id: str | None = None) -> dict[str, Any]:
 
 def list_subscriptions(tenant_id: str | None = None) -> list[dict[str, Any]]:
     """Return enabled subscriptions as ``[{"id": ..., "name": ...}, ...]``."""
-    headers = _get_headers(tenant_id)
     url = f"{AZURE_MGMT_URL}/subscriptions?api-version={AZURE_API_VERSION}"
-    all_subs = _paginate(url, headers)
+    all_subs = arm_paginate(url, tenant_id=tenant_id)
     logger.debug("list_subscriptions: %d total, tenant=%s", len(all_subs), tenant_id or "default")
 
     subs = [
@@ -85,27 +80,21 @@ def list_regions(
 
     When *subscription_id* is ``None`` the first enabled subscription is used.
     """
-    headers = _get_headers(tenant_id)
-
     sub_id = subscription_id
     if not sub_id:
         subs_url = f"{AZURE_MGMT_URL}/subscriptions?api-version={AZURE_API_VERSION}"
-        subs_resp = requests.get(subs_url, headers=headers, timeout=30)
-        subs_resp.raise_for_status()
+        subs_data = arm_get(subs_url, tenant_id=tenant_id)
         enabled = [
-            s["subscriptionId"]
-            for s in subs_resp.json().get("value", [])
-            if s.get("state") == "Enabled"
+            s["subscriptionId"] for s in subs_data.get("value", []) if s.get("state") == "Enabled"
         ]
         if not enabled:
             raise LookupError("No enabled subscriptions found")
         sub_id = enabled[0]
 
     url = f"{AZURE_MGMT_URL}/subscriptions/{sub_id}/locations?api-version={AZURE_API_VERSION}"
-    resp = requests.get(url, headers=headers, timeout=30)
-    resp.raise_for_status()
+    loc_data = arm_get(url, tenant_id=tenant_id)
 
-    locations = resp.json().get("value", [])
+    locations = loc_data.get("value", [])
     regions = [
         {"name": loc["name"], "displayName": loc["displayName"]}
         for loc in locations
@@ -132,27 +121,21 @@ def list_locations(
     Zones.  When *subscription_id* is ``None`` the first enabled subscription
     (sorted by ID) is used.
     """
-    headers = _get_headers(tenant_id)
-
     sub_id = subscription_id
     if not sub_id:
         subs_url = f"{AZURE_MGMT_URL}/subscriptions?api-version={AZURE_API_VERSION}"
-        subs_resp = requests.get(subs_url, headers=headers, timeout=30)
-        subs_resp.raise_for_status()
+        subs_data = arm_get(subs_url, tenant_id=tenant_id)
         enabled = sorted(
-            s["subscriptionId"]
-            for s in subs_resp.json().get("value", [])
-            if s.get("state") == "Enabled"
+            s["subscriptionId"] for s in subs_data.get("value", []) if s.get("state") == "Enabled"
         )
         if not enabled:
             raise LookupError("No enabled subscriptions found")
         sub_id = enabled[0]
 
     url = f"{AZURE_MGMT_URL}/subscriptions/{sub_id}/locations?api-version={AZURE_API_VERSION}"
-    resp = requests.get(url, headers=headers, timeout=30)
-    resp.raise_for_status()
+    loc_data = arm_get(url, tenant_id=tenant_id)
 
-    locations = resp.json().get("value", [])
+    locations = loc_data.get("value", [])
     result = sorted(
         [
             {"name": loc["name"], "displayName": loc["displayName"]}

--- a/src/az_scout/azure_api/quotas.py
+++ b/src/az_scout/azure_api/quotas.py
@@ -6,9 +6,8 @@ import logging
 import time
 from typing import Any
 
-import requests
-
-from az_scout.azure_api._auth import AZURE_MGMT_URL, _get_headers
+from az_scout.azure_api._arm import ArmAuthorizationError, arm_get
+from az_scout.azure_api._auth import AZURE_MGMT_URL
 
 logger = logging.getLogger(__name__)
 
@@ -46,43 +45,24 @@ def get_compute_usages(
         if now - ts < _USAGE_CACHE_TTL:
             return data
 
-    headers = _get_headers(tenant_id)
     url = (
         f"{AZURE_MGMT_URL}/subscriptions/{subscription_id}/providers/"
         f"Microsoft.Compute/locations/{region}/usages?api-version={COMPUTE_API_VERSION}"
     )
 
-    resp = None
-    for attempt in range(3):
-        resp = requests.get(url, headers=headers, timeout=30)
-        if resp.status_code == 429:
-            try:
-                retry_after = int(resp.headers.get("Retry-After", str(2**attempt)))
-            except (TypeError, ValueError):
-                retry_after = 2**attempt
-            logger.warning(
-                "Compute usages 429, retrying in %ss (attempt %s/3)",
-                retry_after,
-                attempt + 1,
-            )
-            time.sleep(retry_after)
-            continue
-        if resp.status_code == 403:
-            logger.warning(
-                "Access denied (403) for compute usages: %s / %s",
-                subscription_id,
-                region,
-            )
-            return []
-        resp.raise_for_status()
-        result: list[dict[str, Any]] = resp.json().get("value", [])
-        _usage_cache[cache_key] = (time.monotonic(), result)
-        return result
+    try:
+        resp_data = arm_get(url, tenant_id=tenant_id)
+    except ArmAuthorizationError:
+        logger.warning(
+            "Access denied (403) for compute usages: %s / %s",
+            subscription_id,
+            region,
+        )
+        return []
 
-    # Exhausted retries on 429
-    if resp is not None:
-        resp.raise_for_status()
-    return []
+    result: list[dict[str, Any]] = resp_data.get("value", [])
+    _usage_cache[cache_key] = (time.monotonic(), result)
+    return result
 
 
 def enrich_skus_with_quotas(

--- a/src/az_scout/azure_api/skus.py
+++ b/src/az_scout/azure_api/skus.py
@@ -6,14 +6,11 @@ import logging
 import time
 from typing import Any
 
-import requests
-
+from az_scout.azure_api._arm import arm_get, arm_paginate
 from az_scout.azure_api._auth import (
     AZURE_API_VERSION,
     AZURE_MGMT_URL,
-    _get_headers,
 )
-from az_scout.azure_api._pagination import _paginate
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +57,6 @@ def _fetch_sku_list(
     tenant_id: str | None,
 ) -> list[dict[str, Any]]:
     """Fetch the raw SKU list from ARM with retry on timeout."""
-    headers = _get_headers(tenant_id)
     # ARM SKU API only reliably supports `location` in $filter.
     # The `resourceType` condition is filtered client-side in get_skus().
     url = (
@@ -69,28 +65,14 @@ def _fetch_sku_list(
         f"&$filter=location eq '{region}'"
     )
 
-    for attempt in range(3):
-        try:
-            result = _paginate(url, headers, timeout=60)
-            logger.info(
-                "Fetched %d SKUs from ARM: region=%s, type=%s",
-                len(result),
-                region,
-                resource_type,
-            )
-            return result
-        except requests.ReadTimeout:
-            if attempt < 2:
-                wait_time = 2**attempt
-                logger.warning(
-                    "SKU API timeout, retrying in %ss (attempt %s/3)",
-                    wait_time,
-                    attempt + 1,
-                )
-                time.sleep(wait_time)
-            else:
-                raise
-    return []  # unreachable but satisfies type checker
+    result = arm_paginate(url, tenant_id=tenant_id, timeout=60)
+    logger.info(
+        "Fetched %d SKUs from ARM: region=%s, type=%s",
+        len(result),
+        region,
+        resource_type,
+    )
+    return result
 
 
 def get_skus(
@@ -209,15 +191,13 @@ def get_mappings(
     tenant_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Return logical→physical zone mappings per subscription."""
-    headers = _get_headers(tenant_id)
     results: list[dict[str, Any]] = []
 
     for sub_id in subscription_ids:
         url = f"{AZURE_MGMT_URL}/subscriptions/{sub_id}/locations?api-version={AZURE_API_VERSION}"
         try:
-            resp = requests.get(url, headers=headers, timeout=30)
-            resp.raise_for_status()
-            locations = resp.json().get("value", [])
+            data = arm_get(url, tenant_id=tenant_id)
+            locations = data.get("value", [])
 
             mappings: list[dict[str, str]] = []
             for loc in locations:

--- a/src/az_scout/azure_api/spot.py
+++ b/src/az_scout/azure_api/spot.py
@@ -6,9 +6,13 @@ import logging
 import time
 from typing import Any
 
-import requests
-
-from az_scout.azure_api._auth import AZURE_MGMT_URL, _get_headers
+from az_scout.azure_api._arm import (
+    ArmAuthorizationError,
+    ArmNotFoundError,
+    ArmRequestError,
+    arm_post,
+)
+from az_scout.azure_api._auth import AZURE_MGMT_URL
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +45,6 @@ def _fetch_spot_batch(
     Returns a dict mapping VM size → {zone → score}.
     Handles 429 with retry/back-off and 403/404 gracefully.
     """
-    headers = _get_headers(tenant_id)
     url = (
         f"{AZURE_MGMT_URL}/subscriptions/{subscription_id}/providers/"
         f"Microsoft.Compute/locations/{region}/placementScores/spot/generate"
@@ -54,71 +57,34 @@ def _fetch_spot_batch(
         "availabilityZones": True,
     }
 
-    max_retries = 3
-    resp = None
-    for attempt in range(max_retries):
-        resp = requests.post(url, headers=headers, json=payload, timeout=30)
-        if resp.status_code == 429:
-            retry_header = resp.headers.get("Retry-After")
-            if retry_header:
-                try:
-                    retry_after = min(int(retry_header), 8)
-                except (TypeError, ValueError):
-                    retry_after = 2**attempt  # 1, 2, 4
-            else:
-                retry_after = 2**attempt  # 1, 2, 4
-            logger.warning(
-                "Spot scores 429, retrying in %ss (attempt %s/%s)",
-                retry_after,
-                attempt + 1,
-                max_retries,
-            )
-            time.sleep(retry_after)
-            continue
-        if resp.status_code == 400:
-            body = resp.text[:500]
+    try:
+        data = arm_post(url, json=payload, tenant_id=tenant_id)
+    except ArmAuthorizationError:
+        msg = (
+            f"Access denied (403) for spot placement scores on subscription "
+            f"{subscription_id}. Ensure the identity has the "
+            f"'Compute Recommendations Role' RBAC role."
+        )
+        logger.warning(msg)
+        raise PermissionError(msg) from None
+    except ArmNotFoundError:
+        msg = (
+            f"Spot placement scores endpoint not found (404) for "
+            f"subscription {subscription_id} / region {region}. "
+            f"Ensure Microsoft.Compute resource provider is registered."
+        )
+        logger.warning(msg)
+        raise FileNotFoundError(msg) from None
+    except ArmRequestError as exc:
+        if exc.status_code == 400:
             msg = (
                 f"Bad request (400) for spot placement scores on "
-                f"subscription {subscription_id} / region {region}: {body}"
+                f"subscription {subscription_id} / region {region}: {exc}"
             )
             logger.warning(msg)
-            raise ValueError(msg)
-        if resp.status_code == 403:
-            msg = (
-                f"Access denied (403) for spot placement scores on subscription "
-                f"{subscription_id}. Ensure the identity has the "
-                f"'Compute Recommendations Role' RBAC role."
-            )
-            logger.warning(msg)
-            raise PermissionError(msg)
-        if resp.status_code == 404:
-            msg = (
-                f"Spot placement scores endpoint not found (404) for "
-                f"subscription {subscription_id} / region {region}. "
-                f"Ensure Microsoft.Compute resource provider is registered."
-            )
-            logger.warning(msg)
-            raise FileNotFoundError(msg)
-        if resp.status_code >= 500:
-            wait_time = 2**attempt  # 1, 2, 4
-            logger.warning(
-                "Spot scores %s, retrying in %ss (attempt %s/%s)",
-                resp.status_code,
-                wait_time,
-                attempt + 1,
-                max_retries,
-            )
-            time.sleep(wait_time)
-            continue
-        resp.raise_for_status()
-        break
+            raise ValueError(msg) from None
+        raise
 
-    if resp is None or resp.status_code >= 400:
-        if resp is not None:
-            resp.raise_for_status()
-        return {}
-
-    data = resp.json()
     scores: dict[str, dict[str, str]] = {}
     for item in data.get("placementScores", []):
         sku_name = item.get("sku", "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,21 @@ def client():
 
 
 @pytest.fixture(autouse=True)
+def _sync_arm_requests_mock():
+    """Ensure ``_arm.requests`` uses the same mock as ``azure_api.requests``.
+
+    Tests patch ``az_scout.azure_api.requests.get`` (the re-exported module in
+    ``__init__.py``).  The ``_arm`` module has its own ``import requests``, so
+    we alias it to the same object so mocks flow through.
+    """
+    import az_scout.azure_api as api_pkg
+    import az_scout.azure_api._arm as arm_mod
+
+    arm_mod.requests = api_pkg.requests  # type: ignore[attr-defined]
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _mock_credential():
     """Prevent real Azure credential calls in every test."""
     mock_token = MagicMock()

--- a/tests/test_azure_api.py
+++ b/tests/test_azure_api.py
@@ -1,6 +1,19 @@
 """Tests for azure_api helper functions."""
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from az_scout.azure_api import _sku_name_matches
+from az_scout.azure_api._arm import (
+    ArmAuthorizationError,
+    ArmNotFoundError,
+    ArmRequestError,
+    arm_get,
+    arm_paginate,
+    arm_post,
+    get_headers,
+)
 
 
 class TestSkuNameMatches:
@@ -39,3 +52,238 @@ class TestSkuNameMatches:
     def test_no_false_positive_partial_overlap(self) -> None:
         # "d48-v3" should not match "standard_d4s_v3" (d4 != d48)
         assert not _sku_name_matches("d48-v3", "standard_d4s_v3")
+
+
+# ---------------------------------------------------------------------------
+# Helpers for ARM tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    headers: dict | None = None,
+    text: str = "",
+) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    resp.text = text
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# get_headers
+# ---------------------------------------------------------------------------
+
+
+class TestGetHeaders:
+    """Tests for the promoted get_headers public alias."""
+
+    def test_returns_authorization_header(self) -> None:
+        headers = get_headers()
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Bearer ")
+
+    def test_passes_tenant_id(self) -> None:
+        headers = get_headers(tenant_id="my-tenant")
+        assert "Authorization" in headers
+
+
+# ---------------------------------------------------------------------------
+# arm_get
+# ---------------------------------------------------------------------------
+
+
+class TestArmGet:
+    """Tests for arm_get."""
+
+    def test_success(self) -> None:
+        mock_resp = _mock_response(json_data={"value": [1, 2, 3]})
+        with patch("az_scout.azure_api._arm.requests.get", return_value=mock_resp):
+            result = arm_get("https://management.azure.com/test")
+        assert result == {"value": [1, 2, 3]}
+
+    def test_passes_params(self) -> None:
+        mock_resp = _mock_response(json_data={"ok": True})
+        with patch(
+            "az_scout.azure_api._arm.requests.get",
+            return_value=mock_resp,
+        ) as mock_get:
+            arm_get(
+                "https://management.azure.com/test",
+                params={"api-version": "2024-01-01"},
+            )
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {"api-version": "2024-01-01"}
+
+    def test_raises_on_403(self) -> None:
+        mock_resp = _mock_response(status_code=403, text="Forbidden")
+        with (
+            patch("az_scout.azure_api._arm.requests.get", return_value=mock_resp),
+            pytest.raises(ArmAuthorizationError),
+        ):
+            arm_get("https://management.azure.com/test")
+
+    def test_raises_on_404(self) -> None:
+        mock_resp = _mock_response(status_code=404, text="Not Found")
+        with (
+            patch("az_scout.azure_api._arm.requests.get", return_value=mock_resp),
+            pytest.raises(ArmNotFoundError),
+        ):
+            arm_get("https://management.azure.com/test")
+
+    def test_retries_on_429(self) -> None:
+        resp_429 = _mock_response(status_code=429, headers={"Retry-After": "0"})
+        resp_ok = _mock_response(json_data={"ok": True})
+        with patch(
+            "az_scout.azure_api._arm.requests.get",
+            side_effect=[resp_429, resp_ok],
+        ):
+            result = arm_get("https://management.azure.com/test", max_retries=2)
+        assert result == {"ok": True}
+
+    def test_retries_on_500(self) -> None:
+        resp_500 = _mock_response(status_code=500)
+        resp_ok = _mock_response(json_data={"ok": True})
+        with patch(
+            "az_scout.azure_api._arm.requests.get",
+            side_effect=[resp_500, resp_ok],
+        ):
+            result = arm_get("https://management.azure.com/test", max_retries=2)
+        assert result == {"ok": True}
+
+    def test_raises_after_retries_exhausted(self) -> None:
+        import requests as req_lib
+
+        with (
+            patch(
+                "az_scout.azure_api._arm.requests.get",
+                side_effect=req_lib.exceptions.ReadTimeout(),
+            ),
+            pytest.raises(ArmRequestError, match="failed after"),
+        ):
+            arm_get("https://management.azure.com/test", max_retries=2)
+
+
+# ---------------------------------------------------------------------------
+# arm_post
+# ---------------------------------------------------------------------------
+
+
+class TestArmPost:
+    """Tests for arm_post."""
+
+    def test_success(self) -> None:
+        mock_resp = _mock_response(json_data={"result": "ok"})
+        with patch("az_scout.azure_api._arm.requests.post", return_value=mock_resp):
+            result = arm_post(
+                "https://management.azure.com/test",
+                json={"input": "data"},
+            )
+        assert result == {"result": "ok"}
+
+    def test_raises_on_403(self) -> None:
+        mock_resp = _mock_response(status_code=403, text="Forbidden")
+        with (
+            patch("az_scout.azure_api._arm.requests.post", return_value=mock_resp),
+            pytest.raises(ArmAuthorizationError),
+        ):
+            arm_post("https://management.azure.com/test", json={})
+
+    def test_retries_on_429(self) -> None:
+        resp_429 = _mock_response(status_code=429, headers={"Retry-After": "0"})
+        resp_ok = _mock_response(json_data={"ok": True})
+        with patch(
+            "az_scout.azure_api._arm.requests.post",
+            side_effect=[resp_429, resp_ok],
+        ):
+            result = arm_post(
+                "https://management.azure.com/test",
+                json={},
+                max_retries=2,
+            )
+        assert result == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# arm_paginate
+# ---------------------------------------------------------------------------
+
+
+class TestArmPaginate:
+    """Tests for arm_paginate."""
+
+    def test_single_page(self) -> None:
+        mock_resp = _mock_response(json_data={"value": [{"id": 1}], "nextLink": ""})
+        with patch("az_scout.azure_api._arm.requests.get", return_value=mock_resp):
+            items = arm_paginate("https://management.azure.com/test")
+        assert items == [{"id": 1}]
+
+    def test_multi_page(self) -> None:
+        page1 = _mock_response(
+            json_data={
+                "value": [{"id": 1}],
+                "nextLink": "https://management.azure.com/test?page=2",
+            },
+        )
+        page2 = _mock_response(json_data={"value": [{"id": 2}], "nextLink": ""})
+        with patch(
+            "az_scout.azure_api._arm.requests.get",
+            side_effect=[page1, page2],
+        ):
+            items = arm_paginate("https://management.azure.com/test")
+        assert items == [{"id": 1}, {"id": 2}]
+
+    def test_empty_result(self) -> None:
+        mock_resp = _mock_response(json_data={"value": []})
+        with patch("az_scout.azure_api._arm.requests.get", return_value=mock_resp):
+            items = arm_paginate("https://management.azure.com/test")
+        assert items == []
+
+    def test_params_only_on_first_page(self) -> None:
+        page1 = _mock_response(
+            json_data={
+                "value": [{"id": 1}],
+                "nextLink": "https://management.azure.com/test?skiptoken=abc",
+            },
+        )
+        page2 = _mock_response(json_data={"value": [{"id": 2}]})
+        with patch(
+            "az_scout.azure_api._arm.requests.get",
+            side_effect=[page1, page2],
+        ) as mock_get:
+            arm_paginate(
+                "https://management.azure.com/test",
+                params={"api-version": "2024-01-01"},
+            )
+        calls = mock_get.call_args_list
+        assert calls[0].kwargs["params"] == {"api-version": "2024-01-01"}
+        assert calls[1].kwargs["params"] is None
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestArmExceptionHierarchy:
+    """Verify exception types and attributes."""
+
+    def test_authorization_error_is_arm_error(self) -> None:
+        exc = ArmAuthorizationError("denied", status_code=403, url="/test")
+        assert isinstance(exc, ArmRequestError)
+        assert exc.status_code == 403
+
+    def test_not_found_error_is_arm_error(self) -> None:
+        exc = ArmNotFoundError("missing", status_code=404, url="/test")
+        assert isinstance(exc, ArmRequestError)
+        assert exc.status_code == 404
+
+    def test_arm_request_error_attributes(self) -> None:
+        exc = ArmRequestError("fail", status_code=500, url="/endpoint")
+        assert str(exc) == "fail"
+        assert exc.status_code == 500
+        assert exc.url == "/endpoint"


### PR DESCRIPTION
## Description

Adds public ARM HTTP helpers (`arm_get`, `arm_post`, `arm_paginate`) with built-in authentication, 429/5xx retry with exponential backoff, `Retry-After` header support, and structured error handling. Promotes `get_headers()` as the public escape hatch for non-ARM endpoints.

Migrates all internal `azure_api` modules (`discovery.py`, `skus.py`, `quotas.py`, `spot.py`) from raw `requests.get`/`requests.post` + ad-hoc retry loops to the new helpers, eliminating ~160 lines of duplicated retry/backoff/error-handling code.

Also includes:
- 5 reusable Copilot prompt files for common workflows (triage-issue, review-plugin, add-plugin-to-catalog, tag-release, ship-code-change)
- Plugin docs updated with ARM helpers section
- Architecture diagram updated with avs-sku plugin
- `PLUGIN_API_VERSION` bumped from `1.0` to `1.1`
- 19 new dedicated tests for the ARM helpers

## Related issue

Closes #97
Closes #95

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors