### PR TITLE
fix(frontend): apiFetch/apiPost reads FastAPI `detail` field in errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/src/az_scout/internal_plugins/planner/static/js/planner.js
+++ b/src/az_scout/internal_plugins/planner/static/js/planner.js
@@ -746,7 +746,7 @@ function renderZoneAvailability(profile, confidence) {
     const spotSignal = _components.find(b => b.name === "spot");
     const spotScore = spotSignal?.score100;
     const physicalZoneMap = getPlannerPhysicalZoneMap();
-    const spotZoneScores = (lastSpotScores?.scores || {})[_pricingModalSku] || {};
+    const spotZoneScores = lastSpotScores?.scores?.[_pricingModalSku] || {};
 
     function row(label, value) {
         return `<div class="vm-profile-row"><span class="vm-profile-label">${escapeHtml(label)}</span><span>${value}</span></div>`;
@@ -1185,7 +1185,7 @@ function renderSkuTable(skus) {
 
         // Spot Score
         if (showSpot) {
-            const spotZoneScores = (lastSpotScores?.scores || {})[sku.name] || {};
+            const spotZoneScores = lastSpotScores?.scores?.[sku.name] || {};
             const spotZones = Object.keys(spotZoneScores).sort();
             const hasSpotPrice = sku.pricing?.spot != null;
             if (spotZones.length > 0) {
@@ -1345,7 +1345,7 @@ function _parseNumericFilter(val) {
 /** Test a cell value against a parsed numeric filter. */
 function _matchNumericFilter(cellVal, filter) {
     const n = parseFloat(cellVal);
-    if (isNaN(n)) return false;
+    if (Number.isNaN(n)) return false;
     switch (filter.op) {
         case ">": return n > filter.val;
         case ">=": return n >= filter.val;
@@ -1376,7 +1376,7 @@ function _buildColumnFilters(tableEl, filterableCols, numericCols) {
             const input = document.createElement("input");
             input.type = "search";
             input.className = "datatable-column-filter";
-            const isNumeric = numericCols && numericCols.has(idx);
+            const isNumeric = numericCols?.has(idx);
             input.placeholder = isNumeric ? ">5, <32, 4-16\u2026" : "Filter\u2026";
             if (isNumeric) input.dataset.numeric = "1";
             input.dataset.col = idx;
@@ -1478,7 +1478,7 @@ function exportSkuCSV() {
         return [
             sku.name, sku.family || "", sku.capabilities.vCPUs || "", sku.capabilities.MemoryGB || "",
             quota.limit ?? "", quota.used ?? "", quota.remaining ?? "",
-            Object.entries((lastSpotScores?.scores || {})[sku.name] || {}).sort(([a], [b]) => a.localeCompare(b)).map(([z, s]) => `Z${z}:${s}`).join(" ") || "",
+            Object.entries(lastSpotScores?.scores?.[sku.name] || {}).sort(([a], [b]) => a.localeCompare(b)).map(([z, s]) => `Z${z}:${s}`).join(" ") || "",
             sku.confidence?.score ?? "", sku.confidence?.label || "",
             ...(hasPricing ? [sku.pricing?.paygo ?? "", sku.pricing?.spot ?? ""] : []),
             ...zoneCols

--- a/src/az_scout/internal_plugins/topology/static/js/az-mapping.js
+++ b/src/az_scout/internal_plugins/topology/static/js/az-mapping.js
@@ -33,7 +33,7 @@
 // ---------------------------------------------------------------------------
 // Topology tab state
 // ---------------------------------------------------------------------------
-let topoSelectedSubs = new Set();           // selected subscription IDs for topology
+const topoSelectedSubs = new Set();           // selected subscription IDs for topology
 let lastMappingData = null;                 // cached /api/mappings result
 
 // ---------------------------------------------------------------------------

--- a/src/az_scout/static/js/app.js
+++ b/src/az_scout/static/js/app.js
@@ -112,7 +112,7 @@ async function apiFetch(url) {
     const resp = await fetch(url);
     if (!resp.ok) {
         const body = await resp.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${resp.status}`);
+        throw new Error(body.error || body.detail || `HTTP ${resp.status}`);
     }
     return resp.json();
 }
@@ -125,7 +125,7 @@ async function apiPost(url, body) {
     });
     if (!resp.ok) {
         const data = await resp.json().catch(() => ({}));
-        throw new Error(data.error || `HTTP ${resp.status}`);
+        throw new Error(data.error || data.detail || `HTTP ${resp.status}`);
     }
     return resp.json();
 }

--- a/src/az_scout/static/js/chat.js
+++ b/src/az_scout/static/js/chat.js
@@ -493,7 +493,7 @@ function _navigateChatHistory(direction, e) {
     input.setSelectionRange(input.value.length, input.value.length);
 }
 
-function _appendToolStatus(msgDiv, toolName, status, argsJson) {
+function _appendToolStatus(msgDiv, toolName, _status, argsJson) {
     let toolsDiv = msgDiv.querySelector(".chat-tool-calls");
     if (!toolsDiv) {
         toolsDiv = document.createElement("div");
@@ -745,7 +745,7 @@ function _containsOnlyChoiceChips(content) {
 
 function _renderMarkdownTables(html) {
     const lines = html.split("\n");
-    let result = [];
+    const result = [];
     let inTable = false;
     let tableRows = [];
 

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -1,8 +1,8 @@
 /* Plugin Manager offcanvas logic */
 /* global apiFetch, apiPost, bootstrap */
 
-(function () {
-    "use strict";
+(() => {
+
 
     const container = document.getElementById("plugin-manager-body");
     if (!container) return;
@@ -241,7 +241,7 @@
 
     // ---- Validate ----
 
-    window.pmValidate = async function () {
+    window.pmValidate = async () => {
         const repoUrl = (document.getElementById("pm-repo-url").value || "").trim();
         const ref = (document.getElementById("pm-ref").value || "").trim();
         if (!repoUrl) return;
@@ -265,7 +265,7 @@
 
     // ---- Install ----
 
-    window.pmInstall = async function () {
+    window.pmInstall = async () => {
         const repoUrl = (document.getElementById("pm-repo-url").value || "").trim();
         const ref = (document.getElementById("pm-ref").value || "").trim();
         if (!repoUrl) return;
@@ -290,7 +290,7 @@
 
     // ---- Uninstall ----
 
-    window.pmUninstall = async function (distName) {
+    window.pmUninstall = async (distName) => {
         if (!confirm("Uninstall plugin \"" + distName + "\"?")) return;
 
         try {
@@ -308,7 +308,7 @@
 
     // ---- Check updates ----
 
-    window.pmCheckUpdates = async function () {
+    window.pmCheckUpdates = async () => {
         showSpinner("Checking for updates…");
         try {
             const data = await apiFetch("/api/plugins/updates");
@@ -326,7 +326,7 @@
 
     // ---- Update single ----
 
-    window.pmUpdate = async function (distName) {
+    window.pmUpdate = async (distName) => {
         showSpinner("Updating " + distName + "…");
         try {
             const data = await apiPost("/api/plugins/update", { distribution_name: distName });
@@ -345,7 +345,7 @@
 
     // ---- Update all ----
 
-    window.pmUpdateAll = async function () {
+    window.pmUpdateAll = async () => {
         if (!confirm("Update all plugins with available updates?")) return;
 
         showSpinner("Updating all plugins…");
@@ -425,7 +425,7 @@
         }
     }
 
-    window.pmQuickInstall = async function (source, version) {
+    window.pmQuickInstall = async (source, version) => {
         showSpinner("Installing…");
         try {
             const data = await apiPost("/api/plugins/install", { repo_url: source, ref: version });


### PR DESCRIPTION
## Description

`apiFetch()` and `apiPost()` only checked `body.error` when building error messages from non-2xx responses. FastAPI's `HTTPException` returns `{"detail": "..."}` — no `error` key — so plugins using the standard pattern got generic "HTTP 502" in the UI instead of the descriptive message.

Now checks `body.error || body.detail || fallback`. Backward-compatible — existing `error` keys still work.

## Related issue

Closes #96

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors