### PR TITLE
feat(plugin_api): PluginError boundary + apiFetch detail fix + biome lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 - **Public ARM helpers** – new `arm_get()`, `arm_post()`, and `arm_paginate()` functions in `azure_api` provide authenticated ARM calls with built-in 429/5xx retry, exponential backoff, `Retry-After` header support, and structured error handling (`ArmAuthorizationError`, `ArmNotFoundError`, `ArmRequestError`). These are the recommended way for plugins and core modules to interact with Azure Resource Manager (#97).
 - **`get_headers()` public alias** – promoted from internal `_get_headers()` for plugins that need raw Bearer-token headers for non-ARM endpoints (#95).
 - **`PLUGIN_API_VERSION` bumped to `1.1`** – additive change, backward compatible.
-- **Copilot prompts** – added `triage-issue`, `review-plugin`, `add-plugin-to-catalog`, and `tag-release` reusable prompt files for coding agents.
+- **Plugin error boundary** – `PluginError`, `PluginValidationError`, and `PluginUpstreamError` exception classes in `plugin_api` with a global handler that returns consistent `{"error", "detail"}` JSON responses. Plugins can raise typed exceptions from route handlers instead of manual try/except + JSONResponse (#98).
+- **Copilot prompts** – added `triage-issue`, `review-plugin`, `add-plugin-to-catalog`, `tag-release`, and `ship-code-change` reusable prompt files for coding agents.
 
 ### Changed
 
 - **Internal modules migrated to ARM helpers** – `discovery.py`, `skus.py`, `quotas.py`, and `spot.py` now use `arm_get`/`arm_post`/`arm_paginate` instead of raw `requests.get`/`requests.post` + manual retry loops. This eliminates duplicated retry/backoff/error handling code across 4 modules.
+
+### Fixed
+
+- **`apiFetch`/`apiPost` error messages** – now reads both `body.error` and `body.detail` keys so FastAPI's standard `HTTPException` pattern works for all plugins without workarounds (#96).
+- **Biome JS lint errors** – fixed optional chaining, `Number.isNaN`, `useConst`, arrow functions, and redundant `use strict` across all JS files.
 
 ## [2026.3.3] - 2026-03-06
 

--- a/docs/plugin-scaffold/.github/copilot-instructions.md
+++ b/docs/plugin-scaffold/.github/copilot-instructions.md
@@ -66,6 +66,28 @@ example = "az_scout_example:plugin"
 - Tools are automatically available in the AI chat assistant after plugin registration.
 - Keep tool functions stateless — use parameters, not global state.
 
+## Azure ARM helpers
+
+For authenticated ARM API calls, use the public helpers from `az_scout.azure_api`:
+
+- `arm_get(url, tenant_id=...)` — GET with auth + retry on 429/5xx
+- `arm_post(url, json=..., tenant_id=...)` — POST with auth + retry
+- `arm_paginate(url, tenant_id=...)` — GET + follow `nextLink` pages
+- `get_headers(tenant_id=...)` — raw Bearer-token headers for non-ARM endpoints
+
+These handle authentication, 429/5xx retry with backoff, and raise typed exceptions
+(`ArmAuthorizationError`, `ArmNotFoundError`, `ArmRequestError`).
+
+## Error handling in routes
+
+Use the typed plugin exceptions from `az_scout.plugin_api` instead of manual
+try/except + JSONResponse. The core app catches them automatically:
+
+- `PluginError("message")` — generic error (HTTP 500)
+- `PluginValidationError("message")` — invalid input (HTTP 422)
+- `PluginUpstreamError("message")` — upstream API failure (HTTP 502)
+- All accept `status_code=...` keyword to override the default
+
 ## Testing patterns
 
 - Test API routes using FastAPI's `TestClient`.

--- a/docs/plugin-scaffold/src/az_scout_example/routes.py
+++ b/docs/plugin-scaffold/src/az_scout_example/routes.py
@@ -1,5 +1,6 @@
 """Example API routes for the plugin."""
 
+from az_scout.plugin_api import PluginValidationError
 from fastapi import APIRouter
 
 router = APIRouter()
@@ -16,12 +17,19 @@ async def hello(
 
     Receives the current tenant, region and subscription context
     from the plugin's frontend.
+
+    Error handling:
+        Raise ``PluginValidationError`` for invalid input (HTTP 422)
+        or ``PluginUpstreamError`` for upstream API failures (HTTP 502).
+        The core app catches these and returns a consistent JSON response.
     """
+    if not region:
+        raise PluginValidationError("Region is required")
+
     parts = ["Hello from the example plugin!"]
     if tenant:
         parts.append(f"Tenant: {tenant}")
-    if region:
-        parts.append(f"Region: {region}")
+    parts.append(f"Region: {region}")
     if subscription_name:
         parts.append(f"Subscription: {subscription_name} ({subscription_id})")
     return {"message": " | ".join(parts)}

--- a/docs/plugin-scaffold/src/az_scout_example/tools.py
+++ b/docs/plugin-scaffold/src/az_scout_example/tools.py
@@ -1,4 +1,18 @@
-"""Example MCP tools for the plugin."""
+"""Example MCP tools for the plugin.
+
+To make authenticated Azure ARM API calls, use the public helpers::
+
+    from az_scout.azure_api import arm_get, arm_paginate, get_headers
+
+    # GET with auth + retry + 429/5xx handling
+    data = arm_get(url, tenant_id=tenant_id)
+
+    # Paginated GET (follows nextLink automatically)
+    items = arm_paginate(url, tenant_id=tenant_id)
+
+    # Raw headers for non-ARM endpoints
+    headers = get_headers(tenant_id)
+"""
 
 
 def example_tool(name: str) -> str:

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -250,6 +250,42 @@ All three helpers handle:
 
 ---
 
+## Error handling for plugin routes
+
+Plugins can raise typed exceptions from route handlers to produce consistent
+JSON error responses without manual try/except boilerplate:
+
+```python
+from az_scout.plugin_api import PluginError, PluginValidationError, PluginUpstreamError
+
+@router.get("/skus")
+async def skus(region: str = "") -> dict[str, object]:
+    if not region:
+        raise PluginValidationError("Region is required")  # → 422
+    try:
+        return get_data(region=region)
+    except Exception as exc:
+        raise PluginUpstreamError(f"Failed to load data: {exc}") from exc  # → 502
+```
+
+The core app catches `PluginError` and returns `{"error": "…", "detail": "…"}`
+with the appropriate HTTP status code. The frontend `apiFetch` helper displays
+the message automatically.
+
+| Exception | Default status | Use case |
+|-----------|:---:|---|
+| `PluginError` | 500 | Generic plugin error |
+| `PluginValidationError` | 422 | Invalid input from the client |
+| `PluginUpstreamError` | 502 | Upstream API call failure |
+
+All three accept an optional `status_code` keyword to override the default:
+
+```python
+raise PluginError("Rate limited", status_code=429)
+```
+
+---
+
 ## Plugin `pyproject.toml` template
 
 ```toml

--- a/src/az_scout/app.py
+++ b/src/az_scout/app.py
@@ -20,6 +20,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.responses import Response, StreamingResponse
 
 from az_scout import __version__, azure_api
+from az_scout.plugin_api import PluginError
 from az_scout.plugin_manager import reconcile_installed_plugins
 from az_scout.plugins import get_plugin_metadata, register_plugins
 from az_scout.routes import router as plugin_manager_router
@@ -92,6 +93,24 @@ async def _generic_error_handler(_request: Request, exc: Exception) -> JSONRespo
     """Return ``{"error": …}`` with status 500 for any unhandled exception."""
     logging.getLogger(__name__).exception("Unhandled error")
     return JSONResponse({"error": str(exc)}, status_code=500)
+
+
+# ---------------------------------------------------------------------------
+# Plugin error boundary – catches PluginError and subclasses, returns
+# {"error": …, "detail": …} with the status code from the exception.
+# Registered *before* the generic handler so it takes priority.
+# ---------------------------------------------------------------------------
+
+
+@app.exception_handler(PluginError)
+async def _plugin_error_handler(_request: Request, exc: PluginError) -> JSONResponse:
+    """Return ``{"error": …, "detail": …}`` for PluginError exceptions."""
+    message = str(exc)
+    logging.getLogger(__name__).warning("Plugin error (%d): %s", exc.status_code, message)
+    return JSONResponse(
+        {"error": message, "detail": message},
+        status_code=exc.status_code,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/az_scout/plugin_api.py
+++ b/src/az_scout/plugin_api.py
@@ -82,3 +82,45 @@ class AzScoutPromptContributor(Protocol):
     """
 
     def get_system_prompt_addendum(self) -> str | None: ...
+
+
+# ---------------------------------------------------------------------------
+# Plugin error boundary — typed exceptions for automatic error responses
+# ---------------------------------------------------------------------------
+
+
+class PluginError(Exception):
+    """Base exception for plugin route errors.
+
+    Raise from a plugin route handler to produce a consistent JSON error
+    response without manual try/except boilerplate.  The global exception
+    handler in ``app.py`` catches ``PluginError`` and returns::
+
+        {"error": "<message>", "detail": "<message>"}
+
+    with the HTTP status code specified by ``status_code`` (default 500).
+
+    Subclasses:
+
+    * :class:`PluginValidationError` — 422 (client sent bad input)
+    * :class:`PluginUpstreamError` — 502 (upstream API failure)
+    """
+
+    status_code: int = 500
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class PluginValidationError(PluginError):
+    """Raised when a plugin receives invalid input (HTTP 422)."""
+
+    status_code: int = 422
+
+
+class PluginUpstreamError(PluginError):
+    """Raised when an upstream API call fails (HTTP 502)."""
+
+    status_code: int = 502

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -38,6 +38,70 @@ class TestGlobalExceptionHandler:
 
 
 # ---------------------------------------------------------------------------
+# Plugin error boundary
+# ---------------------------------------------------------------------------
+
+
+class TestPluginErrorBoundary:
+    """Tests for the PluginError exception handler."""
+
+    def test_plugin_error_returns_500_with_both_keys(self, client):
+        from az_scout.plugin_api import PluginError
+
+        with patch(
+            "az_scout.azure_api.requests.get",
+            side_effect=PluginError("plugin broke"),
+        ):
+            resp = client.get("/api/tenants")
+
+        assert resp.status_code == 500
+        data = resp.json()
+        assert data["error"] == "plugin broke"
+        assert data["detail"] == "plugin broke"
+
+    def test_plugin_validation_error_returns_422(self, client):
+        from az_scout.plugin_api import PluginValidationError
+
+        with patch(
+            "az_scout.azure_api.requests.get",
+            side_effect=PluginValidationError("bad input"),
+        ):
+            resp = client.get("/api/tenants")
+
+        assert resp.status_code == 422
+        data = resp.json()
+        assert data["error"] == "bad input"
+        assert data["detail"] == "bad input"
+
+    def test_plugin_upstream_error_returns_502(self, client):
+        from az_scout.plugin_api import PluginUpstreamError
+
+        with patch(
+            "az_scout.azure_api.requests.get",
+            side_effect=PluginUpstreamError("Azure timeout"),
+        ):
+            resp = client.get("/api/tenants")
+
+        assert resp.status_code == 502
+        data = resp.json()
+        assert data["error"] == "Azure timeout"
+        assert data["detail"] == "Azure timeout"
+
+    def test_plugin_error_custom_status_code(self, client):
+        from az_scout.plugin_api import PluginError
+
+        with patch(
+            "az_scout.azure_api.requests.get",
+            side_effect=PluginError("rate limited", status_code=429),
+        ):
+            resp = client.get("/api/tenants")
+
+        assert resp.status_code == 429
+        data = resp.json()
+        assert data["error"] == "rate limited"
+
+
+# ---------------------------------------------------------------------------
 # GET /
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Adds typed plugin exceptions (`PluginError`, `PluginValidationError`, `PluginUpstreamError`) with a global exception handler that returns consistent `{"error": "…", "detail": "…"}` JSON responses. Plugin authors can now raise typed exceptions from route handlers instead of manual try/except + JSONResponse.

Also fixes `apiFetch`/`apiPost` to read both `body.error` and `body.detail` keys so FastAPI's standard `HTTPException` pattern works for all plugins, and fixes all biome JS lint errors.

Updates plugin docs, scaffold routes/tools/copilot-instructions with examples of the new API patterns.

## Related issue

Closes #98
Closes #96

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors