### PR TITLE
feat(cli): add interactive CLI chat mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Added
+
+- **Interactive CLI chat** (`az-scout chat`) – terminal-based AI chat with Rich-rendered markdown responses, tool call panels with spinners, `[[choice]]` patterns as numbered options, and conversation history with Up/Down navigation. Supports one-shot queries (`az-scout chat "question"`) and interactive sessions (#103).
+- **Slash commands** – `/help`, `/context`, `/tenant`, `/subscription`, `/region`, `/mode`, `/tenants`, `/subscriptions`, `/regions`, `/clear`, `/new`, `/exit` with Tab auto-completion for commands and arguments (mode names, region names, tenant/subscription names).
+- **New dependency** – `prompt-toolkit>=3.0` for interactive terminal input with completion and history.
+
+### Changed
+
+- **Domain migration** – updated documentation site URL from `azscout.vupti.me` to `az-scout.com`.
+
 ## [2026.3.5] - 2026-03-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Scout Azure regions for VM availability, zone mappings, pricing, spot scores, and quota — then plan deployments with confidence.
 
-📖 **Full documentation:** [azscout.vupti.me](https://azscout.vupti.me)
+📖 **Full documentation:** [az-scout.com](https://az-scout.com)
 
 **az-scout** helps Azure operators and architects answer the questions that matter when planning resilient, cost-efficient VM deployments:
 
@@ -121,6 +121,7 @@ az-scout [COMMAND] [OPTIONS]
 az-scout --help.     # show global help
 az-scout web --help  # show web subcommand help
 az-scout mcp --help  # show mcp subcommand help
+az-scout chat --help # show chat subcommand help
 az-scout --version   # show version
 ```
 
@@ -147,6 +148,40 @@ Run the MCP server.
   -v, --verbose   Enable verbose logging.
   --help          Show this message and exit.
 ```
+
+#### `az-scout chat`
+
+Interactive AI chat in the terminal. Requires Azure OpenAI credentials.
+
+```bash
+# Start an interactive session
+az-scout chat
+
+# One-shot query
+az-scout chat "What SKUs are available in francecentral?"
+```
+
+```
+  -v, --verbose   Enable verbose logging.
+  --help          Show this message and exit.
+```
+
+Slash commands are available during the chat session:
+
+| Command | Description |
+|---|---|
+| `/help` | Show available commands |
+| `/context` | Show current tenant, subscription, region, and mode |
+| `/tenant [id]` | Switch tenant (interactive picker or direct) |
+| `/subscription [id]` | Switch subscription (interactive picker or direct) |
+| `/region [name]` | Switch region (interactive picker or direct) |
+| `/mode [name]` | Switch chat mode (discussion, planner, …) |
+| `/tenants` | List accessible tenants |
+| `/subscriptions` | List enabled subscriptions |
+| `/regions` | List AZ-enabled regions |
+| `/clear` | Clear conversation history |
+| `/new` | Start a new session (re-select tenant, clear history) |
+| `/exit` | Exit (or press Ctrl+D) |
 
 ### MCP server
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Azure Scout
 site_description: Scout Azure regions for VM availability, zone mappings, pricing, spot scores, and quota — then plan deployments with confidence.
-site_url: https://azscout.vupti.me
+site_url: https://az-scout.com
 repo_url: https://github.com/az-scout/az-scout
 repo_name: az-scout/az-scout
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,11 @@ dependencies = [
     "mcp[cli]>=1.9",
     "httpx>=0.28",
     "rich>=13.9",
+    "prompt-toolkit>=3.0",
 ]
 
 [project.urls]
-Homepage = "https://github.com/az-scout/az-scout"
+Homepage = "https://az-scout.com"
 Repository = "https://github.com/az-scout/az-scout"
 Issues = "https://github.com/az-scout/az-scout/issues"
 

--- a/src/az_scout/cli.py
+++ b/src/az_scout/cli.py
@@ -155,6 +155,40 @@ def mcp(http: bool, port: int, verbose: bool) -> None:
         mcp_server.run(transport="stdio")
 
 
+@cli.command()
+@click.argument("prompt", nargs=-1, required=False)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Enable verbose logging.",
+)
+def chat(prompt: tuple[str, ...], verbose: bool) -> None:
+    """Interactive AI chat in the terminal.
+
+    Optionally pass a prompt as arguments:
+
+        az-scout chat "What SKUs are available in francecentral?"
+
+    Without a prompt, starts an interactive session.
+    """
+    import asyncio
+    import logging
+    import os
+
+    from az_scout.logging_config import _setup_logging
+
+    env_level = "DEBUG" if verbose else "WARNING"
+    os.environ["AZ_SCOUT_LOG_LEVEL"] = env_level
+    _setup_logging(level=logging.DEBUG if verbose else logging.WARNING)
+
+    from az_scout.services.cli_chat import run_cli_chat
+
+    initial_prompt = " ".join(prompt) if prompt else None
+    asyncio.run(run_cli_chat(initial_prompt=initial_prompt))
+
+
 @cli.command("create-plugin")
 @click.option("--name", "display_name", help="Plugin display name.")
 @click.option(

--- a/src/az_scout/services/cli_chat.py
+++ b/src/az_scout/services/cli_chat.py
@@ -1,0 +1,831 @@
+"""Interactive CLI chat for az-scout.
+
+Renders AI chat streaming events in the terminal using Rich for styled output
+and prompt_toolkit for interactive input.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.history import InMemoryHistory
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+from az_scout.services.ai_chat._config import is_chat_enabled
+from az_scout.services.ai_chat._stream import chat_stream
+
+# Regex to find [[choice text]] patterns in assistant responses
+_CHOICE_RE = re.compile(r"\[\[(.+?)\]\]")
+
+# Slash commands
+_SLASH_COMMANDS = {
+    "/exit": "Exit the chat session",
+    "/new": "Start a new session (re-select tenant, clear history)",
+    "/clear": "Clear conversation history",
+    "/mode": "Switch chat mode (discussion, planner, …)",
+    "/help": "Show available commands",
+    "/context": "Show current tenant, region, subscription, and mode",
+    "/tenant": "Switch tenant (interactive picker)",
+    "/region": "Switch region (interactive picker)",
+    "/subscription": "Switch subscription (interactive picker)",
+    "/tenants": "List accessible tenants",
+    "/subscriptions": "List enabled subscriptions",
+    "/regions": "List AZ-enabled regions",
+}
+
+console = Console()
+
+
+class _SlashCompleter(Completer):
+    """Auto-complete slash commands and their arguments."""
+
+    def get_completions(self, document: Document, complete_event: object) -> Iterable[Completion]:
+        text = document.text_before_cursor
+        if not text.startswith("/"):
+            return
+
+        parts = text.split(maxsplit=1)
+        cmd = parts[0]
+
+        # If still typing the command name (no space yet), complete commands
+        if len(parts) == 1 and not text.endswith(" "):
+            for name, desc in _SLASH_COMMANDS.items():
+                if name.startswith(cmd):
+                    yield Completion(
+                        name,
+                        start_position=-len(text),
+                        display=name,
+                        display_meta=desc,
+                    )
+            return
+
+        # Command is complete — suggest arguments
+        arg_prefix = parts[1] if len(parts) > 1 else ""
+        yield from self._complete_args(cmd, arg_prefix)
+
+    def _complete_args(self, cmd: str, prefix: str) -> Iterable[Completion]:
+        """Yield argument completions for a given command."""
+        if cmd == "/mode":
+            yield from self._complete_mode(prefix)
+        elif cmd == "/region":
+            yield from self._complete_region(prefix)
+        elif cmd == "/tenant":
+            yield from self._complete_tenant(prefix)
+        elif cmd == "/subscription":
+            yield from self._complete_subscription(prefix)
+
+    @staticmethod
+    def _complete_mode(prefix: str) -> Iterable[Completion]:
+        modes = {"discussion": "General assistant", "planner": "Deployment planner"}
+        try:
+            from az_scout.plugins import get_plugin_chat_modes
+
+            for mode_id, cm in get_plugin_chat_modes().items():
+                modes[mode_id] = cm.label
+        except Exception:
+            pass
+        for mode_id, label in modes.items():
+            if mode_id.startswith(prefix):
+                yield Completion(
+                    mode_id,
+                    start_position=-len(prefix),
+                    display=mode_id,
+                    display_meta=label,
+                )
+
+    @staticmethod
+    def _complete_region(prefix: str) -> Iterable[Completion]:
+        try:
+            from az_scout.azure_api.discovery import list_regions
+
+            regions = list_regions()
+            for r in regions:
+                name = r.get("name", "")
+                display_name = r.get("displayName", "")
+                if name.startswith(prefix):
+                    yield Completion(
+                        name,
+                        start_position=-len(prefix),
+                        display=name,
+                        display_meta=display_name,
+                    )
+        except Exception:
+            pass
+
+    @staticmethod
+    def _complete_tenant(prefix: str) -> Iterable[Completion]:
+        try:
+            from az_scout.azure_api.discovery import list_tenants
+
+            result = list_tenants()
+            for t in result.get("tenants", []):
+                tid = t.get("id", "")
+                name = t.get("name", "")
+                if name.lower().startswith(prefix) or tid.startswith(prefix):
+                    yield Completion(
+                        tid,
+                        start_position=-len(prefix),
+                        display=name,
+                        display_meta=tid[:13] + "…",
+                    )
+        except Exception:
+            pass
+
+    @staticmethod
+    def _complete_subscription(prefix: str) -> Iterable[Completion]:
+        try:
+            from az_scout.azure_api.discovery import list_subscriptions
+
+            subs = list_subscriptions()
+            for s in subs:
+                sid = s.get("id", "")
+                name = s.get("name", "")
+                if name.lower().startswith(prefix) or sid.startswith(prefix):
+                    yield Completion(
+                        sid,
+                        start_position=-len(prefix),
+                        display=name,
+                        display_meta=sid[:13] + "…",
+                    )
+        except Exception:
+            pass
+
+
+_cli_tools_registered = False
+
+
+def _register_cli_tools() -> None:
+    """Register internal + external plugin MCP tools for CLI chat.
+
+    The web app does this in its lifespan via ``register_plugins()``, but the
+    CLI chat has no FastAPI app.  We only need to register MCP tools (not
+    routes or static assets), then refresh the OpenAI tool definitions.
+    """
+    global _cli_tools_registered  # noqa: PLW0603
+    if _cli_tools_registered:
+        return
+    _cli_tools_registered = True
+
+    import logging
+
+    from az_scout.internal_plugins import discover_internal_plugins
+    from az_scout.mcp_server import mcp as mcp_server
+    from az_scout.plugins import discover_plugins
+    from az_scout.services.ai_chat._tools import refresh_tool_definitions
+
+    logger = logging.getLogger(__name__)
+
+    # Collect names of already-registered tools to avoid duplicates
+    existing = {t.name for t in mcp_server._tool_manager.list_tools()}
+
+    for plugin in [*discover_internal_plugins(), *discover_plugins()]:
+        try:
+            tools = plugin.get_mcp_tools()
+            if tools:
+                added = 0
+                for fn in tools:
+                    if fn.__name__ not in existing:
+                        mcp_server.tool()(fn)
+                        existing.add(fn.__name__)
+                        added += 1
+                if added:
+                    logger.debug("CLI: registered %d tool(s) from '%s'", added, plugin.name)
+        except Exception:
+            logger.exception("CLI: failed to register tools from '%s'", plugin.name)
+
+    refresh_tool_definitions()
+    logger.debug("CLI: tool definitions refreshed")
+
+
+def _render_welcome(
+    tenant_name: str | None = None,
+    region: str | None = None,
+    subscription_name: str | None = None,
+) -> Panel:
+    """Build the welcome panel."""
+    lines = [
+        "[bold]🔭 Azure Scout Assistant[/bold]",
+        "",
+    ]
+    if tenant_name:
+        lines.append(f"  Tenant:       [cyan]{tenant_name}[/cyan]")
+    else:
+        lines.append("  Tenant:       [dim]not selected[/dim]")
+
+    if subscription_name:
+        lines.append(f"  Subscription: [cyan]{subscription_name}[/cyan]")
+    else:
+        lines.append("  Subscription: [dim]not selected — I'll ask when needed[/dim]")
+
+    if region:
+        lines.append(f"  Region:       [cyan]{region}[/cyan]")
+    else:
+        lines.append("  Region:       [dim]not selected — I'll ask when needed[/dim]")
+
+    lines += [
+        "",
+        "  [dim]Type your question, or try:[/dim]",
+        '  • [italic]"What SKUs are available in swedencentral?"[/italic]',
+        '  • [italic]"Compare zones for Standard_D4s_v5 across subscriptions"[/italic]',
+        '  • [italic]"Show spot scores for GPU SKUs in eastus"[/italic]',
+        "",
+        "  [dim]Type /help for commands, Ctrl+D to exit.[/dim]",
+    ]
+    return Panel(
+        "\n".join(lines),
+        border_style="bright_blue",
+        title="[bold bright_blue]az-scout[/bold bright_blue]",
+        padding=(1, 2),
+    )
+
+
+def _render_tool_call(name: str, arguments: dict[str, Any]) -> Panel:
+    """Render a tool call notification panel."""
+    args_parts: list[str] = []
+    for k, v in arguments.items():
+        if isinstance(v, list):
+            v = ", ".join(str(i) for i in v)
+        args_parts.append(f"[dim]{k}:[/dim] {v}")
+    body = "  " + "\n  ".join(args_parts) if args_parts else ""
+    return Panel(
+        body,
+        title=f"[bold yellow]🔧 {name}[/bold yellow]",
+        border_style="yellow",
+        padding=(0, 1),
+    )
+
+
+def _render_tool_result_panel(name: str, content: str) -> Panel:
+    """Render a collapsed tool result panel."""
+    # Try to show as a compact summary
+    try:
+        data = json.loads(content)
+        if isinstance(data, list):
+            summary = f"[dim]Returned {len(data)} items[/dim]"
+        elif isinstance(data, dict) and "error" in data:
+            summary = f"[red]Error: {data['error']}[/red]"
+        elif isinstance(data, dict):
+            summary = f"[dim]Returned {len(data)} fields[/dim]"
+        else:
+            summary = f"[dim]{str(data)[:100]}[/dim]"
+    except (json.JSONDecodeError, ValueError):
+        summary = f"[dim]{content[:100]}{'…' if len(content) > 100 else ''}[/dim]"
+
+    return Panel(
+        summary,
+        title=f"[bold green]✓ {name}[/bold green]",
+        border_style="green",
+        padding=(0, 1),
+    )
+
+
+def _render_choices(text: str) -> tuple[str, list[str]]:
+    """Extract [[choice]] patterns and replace with numbered options.
+
+    Returns the cleaned text and a list of choice strings.
+    """
+    choices: list[str] = _CHOICE_RE.findall(text)
+    if not choices:
+        return text, []
+
+    # Remove the [[...]] markers from the text
+    cleaned = _CHOICE_RE.sub("", text)
+    # Remove any trailing blank bullet lines left behind
+    cleaned = re.sub(r"\n\s*[-•]\s*\n", "\n", cleaned)
+    cleaned = cleaned.rstrip()
+
+    return cleaned, choices
+
+
+def _render_choices_bar(choices: list[str]) -> Text:
+    """Render choices as a numbered bar."""
+    t = Text()
+    for i, choice in enumerate(choices, 1):
+        t.append(f"  [{i}] ", style="bold cyan")
+        t.append(choice, style="cyan")
+    return t
+
+
+async def _stream_response(
+    messages: list[dict[str, Any]],
+    *,
+    tenant_id: str | None = None,
+    region: str | None = None,
+    subscription_id: str | None = None,
+    mode: str = "discussion",
+) -> tuple[str, list[str]]:
+    """Consume the chat_stream and render events to the terminal.
+
+    Returns (full_assistant_text, choices_list).
+    """
+    content_parts: list[str] = []
+    spinner_live: Live | None = None
+
+    try:
+        async for sse_line in chat_stream(
+            messages,
+            tenant_id=tenant_id,
+            region=region,
+            subscription_id=subscription_id,
+            mode=mode,
+        ):
+            # Parse SSE line
+            if not sse_line.startswith("data: "):
+                continue
+            try:
+                event = json.loads(sse_line[6:])
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type")
+
+            if event_type == "delta":
+                # Accumulate streamed text
+                chunk = event.get("content", "")
+                content_parts.append(chunk)
+
+            elif event_type == "tool_call":
+                # Show tool call panel
+                name = event.get("name", "unknown")
+                try:
+                    args = json.loads(event.get("arguments", "{}"))
+                except json.JSONDecodeError:
+                    args = {}
+                console.print(_render_tool_call(name, args))
+
+                # Show spinner while tool executes
+                spinner_live = Live(
+                    Spinner("dots", text=f"  Running {name}…", style="yellow"),
+                    console=console,
+                    transient=True,
+                )
+                spinner_live.start()
+
+            elif event_type == "tool_result":
+                # Stop spinner, show result summary
+                if spinner_live:
+                    spinner_live.stop()
+                    spinner_live = None
+                name = event.get("name", "unknown")
+                content = event.get("content", "")
+                console.print(_render_tool_result_panel(name, content))
+
+            elif event_type == "status":
+                msg = event.get("content", "")
+                console.print(f"  [dim italic]{msg}[/dim italic]")
+
+            elif event_type == "error":
+                if spinner_live:
+                    spinner_live.stop()
+                    spinner_live = None
+                msg = event.get("content", "")
+                console.print(Panel(msg, title="[bold red]Error[/bold red]", border_style="red"))
+
+            elif event_type == "done":
+                break
+
+    finally:
+        if spinner_live:
+            spinner_live.stop()
+
+    # Render the full response as markdown
+    full_text = "".join(content_parts)
+    if full_text.strip():
+        cleaned, choices = _render_choices(full_text)
+        console.print()
+        console.print(Markdown(cleaned))
+        if choices:
+            console.print()
+            console.print(_render_choices_bar(choices))
+        console.print()
+        return full_text, choices
+
+    return full_text, []
+
+
+async def _pick_from_list(
+    items: list[dict[str, str]],
+    label_key: str,
+    id_key: str,
+    title: str,
+) -> str | None:
+    """Interactive picker for tenants/subscriptions/regions."""
+    if not items:
+        console.print(f"  [dim]No {title} available.[/dim]")
+        return None
+
+    table = Table(title=title, border_style="bright_blue", show_lines=False)
+    table.add_column("#", style="bold cyan", width=4)
+    table.add_column("Name", style="white")
+    table.add_column("ID", style="dim")
+
+    for i, item in enumerate(items, 1):
+        table.add_row(str(i), item[label_key], item.get(id_key, ""))
+
+    console.print(table)
+
+    session: PromptSession[str] = PromptSession()
+    try:
+        answer = await session.prompt_async(
+            HTML("<b>  Select #: </b>"),
+        )
+        idx = int(answer.strip()) - 1
+        if 0 <= idx < len(items):
+            return items[idx][id_key]
+        console.print("  [red]Invalid selection.[/red]")
+    except (ValueError, KeyboardInterrupt, EOFError):
+        pass
+    return None
+
+
+async def _resolve_context() -> tuple[str | None, str | None, str | None]:
+    """Resolve initial tenant context only.
+
+    Subscription and region are deferred — the AI will ask when needed.
+    """
+    from az_scout.azure_api.discovery import list_tenants
+
+    # Tenant — auto-select if only one authenticated
+    tenant_id: str | None = None
+    try:
+        result = list_tenants()
+        tenants: list[dict[str, Any]] = result.get("tenants", [])
+        authed = [t for t in tenants if t.get("authenticated")]
+        if len(authed) == 1:
+            tenant_id = authed[0]["id"]
+            console.print(f"  [dim]Auto-selected tenant:[/dim] [cyan]{authed[0]['name']}[/cyan]")
+        elif authed:
+            console.print()
+            items = [{"name": t["name"], "id": t["id"]} for t in authed]
+            tenant_id = await _pick_from_list(items, "name", "id", "Select Tenant")
+    except Exception as exc:
+        console.print(f"  [yellow]Could not list tenants: {exc}[/yellow]")
+
+    # Subscription and region are left unset — the AI will use
+    # list_subscriptions / list_regions tools when the conversation needs them.
+    return tenant_id, None, None
+
+
+async def _handle_slash_command(
+    command: str,
+    state: dict[str, Any],
+) -> bool:
+    """Handle a slash command, mutating *state* in place.
+
+    Returns True if the session should exit.
+    """
+    parts = command.strip().lower().split(maxsplit=1)
+    cmd = parts[0]
+    arg = parts[1] if len(parts) > 1 else None
+
+    if cmd == "/exit":
+        return True
+
+    if cmd == "/new":
+        state["messages"].clear()
+        state["choices"] = []
+        console.print("  [dim]Session reset — re-selecting context…[/dim]")
+        tid, _, _ = await _resolve_context()
+        state["tenant_id"] = tid
+        state["subscription_id"] = None
+        state["region"] = None
+        state["mode"] = "discussion"
+        console.print("  [green]New session ready.[/green]")
+        return False
+
+    if cmd == "/clear":
+        state["messages"].clear()
+        state["choices"] = []
+        console.print("  [dim]Conversation cleared.[/dim]")
+        return False
+
+    if cmd == "/mode":
+        from az_scout.plugins import get_plugin_chat_modes
+
+        modes = {"discussion": "General assistant", "planner": "Deployment planner"}
+        for mode_id, cm in get_plugin_chat_modes().items():
+            modes[mode_id] = cm.label
+
+        # Direct argument: /mode planner
+        if arg and arg in modes:
+            state["mode"] = arg
+            state["messages"].clear()
+            state["choices"] = []
+            console.print(f"  [green]Mode set to {arg} — conversation cleared.[/green]")
+            return False
+        if arg:
+            console.print(f"  [red]Unknown mode: {arg}. Available: {', '.join(modes.keys())}[/red]")
+            return False
+
+        # Interactive picker
+        items = [{"name": f"{label} ({mid})", "id": mid} for mid, label in modes.items()]
+        current = state.get("mode", "discussion")
+        console.print(f"  Current mode: [cyan]{current}[/cyan]")
+        picked = await _pick_from_list(items, "name", "id", "Select Chat Mode")
+        if picked:
+            state["mode"] = picked
+            state["messages"].clear()
+            state["choices"] = []
+            console.print(f"  [green]Mode set to {picked} — conversation cleared.[/green]")
+        return False
+
+    if cmd == "/help":
+        table = Table(border_style="bright_blue", show_header=False)
+        table.add_column("Command", style="bold cyan")
+        table.add_column("Description", style="white")
+        for cmd_name, desc in _SLASH_COMMANDS.items():
+            table.add_row(cmd_name, desc)
+        console.print(table)
+        return False
+
+    if cmd == "/context":
+        console.print(f"  Tenant:       [cyan]{state.get('tenant_id') or 'not set'}[/cyan]")
+        console.print(f"  Subscription: [cyan]{state.get('subscription_id') or 'not set'}[/cyan]")
+        console.print(f"  Region:       [cyan]{state.get('region') or 'not set'}[/cyan]")
+        console.print(f"  Mode:         [cyan]{state.get('mode', 'discussion')}[/cyan]")
+        return False
+
+    if cmd == "/tenant":
+        from az_scout.azure_api.discovery import list_tenants
+
+        try:
+            result = list_tenants()
+            tenants: list[dict[str, Any]] = result.get("tenants", [])
+            items = [{"name": t["name"], "id": t["id"]} for t in tenants]
+
+            # Direct argument: /tenant <id-or-name>
+            if arg:
+                match = next(
+                    (t for t in tenants if t["id"] == arg or t["name"].lower() == arg),
+                    None,
+                )
+                if match:
+                    state["tenant_id"] = match["id"]
+                    state["subscription_id"] = None
+                    console.print(f"  [green]Tenant set to {match['name']}[/green]")
+                else:
+                    names = ", ".join(t["name"] for t in tenants)
+                    console.print(f"  [red]Unknown tenant: {arg}. Available: {names}[/red]")
+                return False
+
+            # Interactive picker
+            picked = await _pick_from_list(items, "name", "id", "Select Tenant")
+            if picked:
+                state["tenant_id"] = picked
+                state["subscription_id"] = None
+                console.print(f"  [green]Tenant set to {picked}[/green]")
+        except Exception as exc:
+            console.print(f"  [red]Failed: {exc}[/red]")
+        return False
+
+    if cmd == "/subscription":
+        from az_scout.azure_api.discovery import list_subscriptions
+
+        try:
+            subs = list_subscriptions(tenant_id=state.get("tenant_id"))
+            items = [{"name": s["name"], "id": s["id"]} for s in subs]
+
+            # Direct argument: /subscription <id-or-name>
+            if arg:
+                match = next(
+                    (s for s in subs if s["id"] == arg or s["name"].lower() == arg),
+                    None,
+                )
+                if match:
+                    state["subscription_id"] = match["id"]
+                    console.print(f"  [green]Subscription set to {match['name']}[/green]")
+                else:
+                    names = ", ".join(s["name"] for s in subs)
+                    console.print(f"  [red]Unknown subscription: {arg}. Available: {names}[/red]")
+                return False
+
+            # Interactive picker
+            picked = await _pick_from_list(items, "name", "id", "Select Subscription")
+            if picked:
+                state["subscription_id"] = picked
+                console.print(f"  [green]Subscription set to {picked}[/green]")
+        except Exception as exc:
+            console.print(f"  [red]Failed: {exc}[/red]")
+        return False
+
+    if cmd == "/region":
+        from az_scout.azure_api.discovery import list_regions
+
+        try:
+            sub_for_regions = state.get("subscription_id")
+            if not sub_for_regions:
+                from az_scout.azure_api.discovery import list_subscriptions as _list_subs
+
+                subs = _list_subs(tenant_id=state.get("tenant_id"))
+                if subs:
+                    sub_for_regions = subs[0]["id"]
+            regions = list_regions(
+                subscription_id=sub_for_regions, tenant_id=state.get("tenant_id")
+            )
+            items = [
+                {"name": r.get("displayName", r.get("name", "?")), "id": r.get("name", "")}
+                for r in regions
+            ]
+
+            # Direct argument: /region <name>
+            if arg:
+                valid_names = [r.get("name", "") for r in regions]
+                if arg in valid_names:
+                    state["region"] = arg
+                    console.print(f"  [green]Region set to {arg}[/green]")
+                else:
+                    console.print(
+                        f"  [red]Unknown region: {arg}. "
+                        f"Type /regions to see available regions.[/red]"
+                    )
+                return False
+
+            # Interactive picker
+            picked = await _pick_from_list(items, "name", "id", "Select Region")
+            if picked:
+                state["region"] = picked
+                console.print(f"  [green]Region set to {picked}[/green]")
+        except Exception as exc:
+            console.print(f"  [red]Failed: {exc}[/red]")
+        return False
+
+    # ---- MCP tool shortcuts (read-only data display) ----
+
+    if cmd == "/tenants":
+        from az_scout.azure_api.discovery import list_tenants
+
+        try:
+            result = list_tenants(tenant_id=state.get("tenant_id"))
+            tenants_list: list[dict[str, Any]] = result.get("tenants", [])
+            table = Table(title="Tenants", border_style="bright_blue", show_lines=False)
+            table.add_column("Name", style="white")
+            table.add_column("ID", style="dim")
+            table.add_column("Auth", style="green")
+            for t in tenants_list:
+                auth = "✓" if t.get("authenticated") else "✗"
+                auth_style = "green" if t.get("authenticated") else "red"
+                table.add_row(t["name"], t["id"], Text(auth, style=auth_style))
+            console.print(table)
+        except Exception as exc:
+            console.print(f"  [red]Failed: {exc}[/red]")
+        return False
+
+    if cmd == "/subscriptions":
+        from az_scout.azure_api.discovery import list_subscriptions
+
+        try:
+            subs = list_subscriptions(tenant_id=state.get("tenant_id"))
+            table = Table(title="Subscriptions", border_style="bright_blue", show_lines=False)
+            table.add_column("Name", style="white")
+            table.add_column("ID", style="dim")
+            for s in subs:
+                table.add_row(s["name"], s["id"])
+            console.print(table)
+        except Exception as exc:
+            console.print(f"  [red]Failed: {exc}[/red]")
+        return False
+
+    if cmd == "/regions":
+        from az_scout.azure_api.discovery import list_regions
+
+        try:
+            sub_for_regions = state.get("subscription_id")
+            if not sub_for_regions:
+                from az_scout.azure_api.discovery import list_subscriptions
+
+                subs = list_subscriptions(tenant_id=state.get("tenant_id"))
+                if subs:
+                    sub_for_regions = subs[0]["id"]
+            regions = list_regions(
+                subscription_id=sub_for_regions, tenant_id=state.get("tenant_id")
+            )
+            table = Table(title="AZ-Enabled Regions", border_style="bright_blue", show_lines=False)
+            table.add_column("Name", style="cyan")
+            table.add_column("Display Name", style="white")
+            for r in regions:
+                table.add_row(r.get("name", "?"), r.get("displayName", ""))
+            console.print(table)
+        except Exception as exc:
+            console.print(f"  [red]Failed: {exc}[/red]")
+        return False
+
+    console.print(f"  [red]Unknown command: {cmd}. Type /help for options.[/red]")
+    return False
+
+
+async def run_cli_chat(initial_prompt: str | None = None) -> None:
+    """Main entry point for the interactive CLI chat session."""
+    if not is_chat_enabled():
+        console.print(
+            Panel(
+                "[bold red]Azure OpenAI is not configured.[/bold red]\n\n"
+                "Set these environment variables:\n"
+                "  • AZURE_OPENAI_ENDPOINT\n"
+                "  • AZURE_OPENAI_API_KEY\n"
+                "  • AZURE_OPENAI_DEPLOYMENT",
+                title="[bold red]Configuration Error[/bold red]",
+                border_style="red",
+            )
+        )
+        return
+
+    # Register internal + external plugins so their MCP tools are available
+    _register_cli_tools()
+
+    # Resolve initial context
+    tenant_id, subscription_id, region = await _resolve_context()
+
+    console.print()
+    console.print(_render_welcome(tenant_id, region, subscription_id))
+    console.print()
+
+    # Session state — mutated by slash commands
+    state: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "subscription_id": subscription_id,
+        "region": region,
+        "mode": "discussion",
+        "messages": [],
+        "choices": [],
+    }
+
+    session: PromptSession[str] = PromptSession(
+        history=InMemoryHistory(),
+        completer=_SlashCompleter(),
+    )
+
+    # If an initial prompt was provided, process it first
+    if initial_prompt:
+        console.print(f"  [bold bright_green]you ❯[/bold bright_green] {initial_prompt}")
+        console.print()
+        state["messages"].append({"role": "user", "content": initial_prompt})
+        _, state["choices"] = await _stream_response(
+            state["messages"],
+            tenant_id=state["tenant_id"],
+            region=state["region"],
+            subscription_id=state["subscription_id"],
+            mode=state["mode"],
+        )
+
+    while True:
+        try:
+            user_input = await session.prompt_async(
+                HTML("<style fg='ansibrightgreen'><b>you ❯ </b></style>"),
+            )
+        except KeyboardInterrupt:
+            # Ctrl+C — clear the current input, show a fresh prompt
+            console.print()
+            continue
+        except EOFError:
+            # Ctrl+D — exit
+            console.print("\n  [dim]Goodbye![/dim]")
+            break
+
+        user_input = user_input.strip()
+        if not user_input:
+            continue
+
+        # Handle numbered choice selection
+        if state["choices"] and user_input.isdigit():
+            idx = int(user_input) - 1
+            if 0 <= idx < len(state["choices"]):
+                user_input = state["choices"][idx]
+                console.print(f"  [dim]→ {user_input}[/dim]")
+            state["choices"] = []
+
+        # Handle slash commands
+        if user_input.startswith("/"):
+            should_exit = await _handle_slash_command(user_input, state)
+            if should_exit:
+                console.print("  [dim]Goodbye![/dim]")
+                break
+            continue
+
+        # Regular message — send to AI
+        state["messages"].append({"role": "user", "content": user_input})
+        console.print()
+
+        full_text, state["choices"] = await _stream_response(
+            state["messages"],
+            tenant_id=state["tenant_id"],
+            region=state["region"],
+            subscription_id=state["subscription_id"],
+            mode=state["mode"],
+        )
+
+        # Track assistant response in conversation history
+        if full_text.strip():
+            state["messages"].append({"role": "assistant", "content": full_text})

--- a/src/az_scout/templates/index.html
+++ b/src/az_scout/templates/index.html
@@ -179,7 +179,7 @@
                     <h4 id="aboutModalLabel">Azure Scout</h4>
                     <span class="about-version">{{ version }}</span>
                     <div class="about-links">
-                        <a href="https://azscout.vupti.me" target="_blank" rel="noopener"
+                        <a href="https://az-scout.com" target="_blank" rel="noopener"
                            class="btn btn-sm btn-outline-primary">
                             <i class="bi bi-house-door me-1"></i>Homepage
                         </a>

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1,0 +1,206 @@
+"""Tests for the CLI chat module."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from az_scout.services.cli_chat import (
+    _render_choices,
+    _render_choices_bar,
+    _render_tool_call,
+    _render_tool_result_panel,
+    _render_welcome,
+)
+
+
+class TestRenderWelcome:
+    """Tests for _render_welcome()."""
+
+    def test_with_tenant_and_region(self) -> None:
+        panel = _render_welcome("my-tenant", "francecentral")
+        rendered = panel.renderable
+        assert isinstance(rendered, str)
+        assert "my-tenant" in rendered
+        assert "francecentral" in rendered
+
+    def test_without_context(self) -> None:
+        panel = _render_welcome()
+        rendered = panel.renderable
+        assert isinstance(rendered, str)
+        assert "not selected" in rendered
+
+    def test_panel_title(self) -> None:
+        panel = _render_welcome()
+        assert panel.title is not None
+
+
+class TestRenderChoices:
+    """Tests for _render_choices()."""
+
+    def test_extracts_choices(self) -> None:
+        text = "Pick one:\n- [[Option A]]\n- [[Option B]]"
+        cleaned, choices = _render_choices(text)
+        assert choices == ["Option A", "Option B"]
+        assert "[[" not in cleaned
+
+    def test_no_choices(self) -> None:
+        text = "No choices here."
+        cleaned, choices = _render_choices(text)
+        assert cleaned == text
+        assert choices == []
+
+    def test_single_choice(self) -> None:
+        text = "Try this: [[Do something]]"
+        cleaned, choices = _render_choices(text)
+        assert choices == ["Do something"]
+        assert "[[" not in cleaned
+
+    def test_choices_bar_rendering(self) -> None:
+        bar = _render_choices_bar(["Option A", "Option B"])
+        plain = bar.plain
+        assert "[1]" in plain
+        assert "[2]" in plain
+        assert "Option A" in plain
+        assert "Option B" in plain
+
+
+class TestRenderToolCall:
+    """Tests for _render_tool_call()."""
+
+    def test_basic_tool_call(self) -> None:
+        panel = _render_tool_call("get_sku_availability", {"region": "eastus"})
+        assert panel.title is not None
+        assert "get_sku_availability" in str(panel.title)
+
+    def test_empty_arguments(self) -> None:
+        panel = _render_tool_call("list_tenants", {})
+        assert panel.title is not None
+
+    def test_list_argument(self) -> None:
+        panel = _render_tool_call("get_zone_mappings", {"subscription_ids": ["a", "b"]})
+        rendered = panel.renderable
+        assert isinstance(rendered, str)
+        assert "a, b" in rendered
+
+
+class TestRenderToolResult:
+    """Tests for _render_tool_result_panel()."""
+
+    def test_list_result(self) -> None:
+        import json
+
+        content = json.dumps([{"sku": "Standard_D2s_v5"}, {"sku": "Standard_D4s_v5"}])
+        panel = _render_tool_result_panel("get_sku_availability", content)
+        assert panel.title is not None
+        assert "get_sku_availability" in str(panel.title)
+
+    def test_error_result(self) -> None:
+        import json
+
+        content = json.dumps({"error": "Not authorized"})
+        panel = _render_tool_result_panel("list_tenants", content)
+        rendered = panel.renderable
+        assert isinstance(rendered, str)
+        assert "Not authorized" in rendered
+
+    def test_plain_text_result(self) -> None:
+        panel = _render_tool_result_panel("some_tool", "plain text output")
+        assert panel.title is not None
+
+
+class TestSlashCommands:
+    """Tests for slash command handling."""
+
+    @staticmethod
+    def _make_state(**overrides: Any) -> dict[str, Any]:
+        state: dict[str, Any] = {
+            "tenant_id": "tid",
+            "subscription_id": "sid",
+            "region": "eastus",
+            "mode": "discussion",
+            "messages": [],
+            "choices": [],
+        }
+        state.update(overrides)
+        return state
+
+    def test_exit(self) -> None:
+        import asyncio
+
+        from az_scout.services.cli_chat import _handle_slash_command
+
+        state = self._make_state()
+        should_exit = asyncio.run(_handle_slash_command("/exit", state))
+        assert should_exit is True
+
+    def test_clear(self) -> None:
+        import asyncio
+
+        from az_scout.services.cli_chat import _handle_slash_command
+
+        state = self._make_state(messages=[{"role": "user", "content": "hello"}])
+        should_exit = asyncio.run(_handle_slash_command("/clear", state))
+        assert should_exit is False
+        assert state["messages"] == []
+
+    def test_context(self) -> None:
+        import asyncio
+
+        from az_scout.services.cli_chat import _handle_slash_command
+
+        state = self._make_state()
+        should_exit = asyncio.run(_handle_slash_command("/context", state))
+        assert should_exit is False
+        assert state["tenant_id"] == "tid"
+        assert state["subscription_id"] == "sid"
+        assert state["region"] == "eastus"
+
+    def test_help(self) -> None:
+        import asyncio
+
+        from az_scout.services.cli_chat import _handle_slash_command
+
+        state = self._make_state()
+        should_exit = asyncio.run(_handle_slash_command("/help", state))
+        assert should_exit is False
+
+    def test_unknown_command(self) -> None:
+        import asyncio
+
+        from az_scout.services.cli_chat import _handle_slash_command
+
+        state = self._make_state()
+        should_exit = asyncio.run(_handle_slash_command("/unknown", state))
+        assert should_exit is False
+
+
+class TestChatCliCommand:
+    """Tests for the Click chat command."""
+
+    def test_chat_help(self) -> None:
+        from click.testing import CliRunner
+
+        from az_scout.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["chat", "--help"])
+        assert result.exit_code == 0
+        assert "Interactive AI chat" in result.output
+
+    def test_chat_without_openai_config(self) -> None:
+        from click.testing import CliRunner
+
+        from az_scout.cli import cli
+
+        runner = CliRunner()
+        with patch.dict(
+            "os.environ",
+            {
+                "AZURE_OPENAI_ENDPOINT": "",
+                "AZURE_OPENAI_API_KEY": "",
+                "AZURE_OPENAI_DEPLOYMENT": "",
+            },
+        ):
+            result = runner.invoke(cli, ["chat"])
+            assert "not configured" in result.output or result.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "mcp", extra = ["cli"] },
+    { name = "prompt-toolkit" },
     { name = "requests" },
     { name = "rich" },
     { name = "uvicorn", extra = ["standard"] },
@@ -80,6 +81,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9" },
+    { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "rich", specifier = ">=13.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
@@ -1233,6 +1235,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2128,6 +2142,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add an interactive terminal chat interface (`az-scout chat`) so users can query az-scout directly from the command line without opening a browser or web UI.

**Features:**
- **Rich-rendered streaming** — markdown responses, tool call panels with spinners, error panels
- **12 slash commands** — `/help`, `/context`, `/tenant`, `/subscription`, `/region`, `/mode`, `/tenants`, `/subscriptions`, `/regions`, `/clear`, `/new`, `/exit`
- **Tab auto-completion** — for slash commands and their arguments (mode names, region names, tenant/subscription names)
- **Input validation** — `/region`, `/tenant`, `/subscription` validate arguments against live Azure data
- **One-shot mode** — `az-scout chat "question"` for scripting-friendly usage
- **Interactive pickers** — numbered table pickers for tenant, subscription, region, and mode selection
- **`[[choice]]` patterns** — rendered as numbered options the user can select by typing the number
- **Keyboard shortcuts** — Ctrl+C clears input, Ctrl+D exits
- **Plugin tools** — internal + external plugin MCP tools registered at startup (no web server needed)

Also includes:
- Domain migration: `azscout.vupti.me` → `az-scout.com` (README, mkdocs.yml, index.html, pyproject.toml Homepage)

## Related issue

Closes #103

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
