### PR TITLE
fix(azure_api): cache ARM tokens per-tenant + request timing + docs domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ### Changed
 
-- **Domain migration** – updated documentation site URL from `azscout.vupti.me` to `az-scout.com`.
+- **Domain migration** – updated documentation site URL from `azscout.vupti.me` to `docs.az-scout.com`.
+- **ARM token caching** – tokens are now cached per-tenant with thread-safe locking, eliminating redundant `credential.get_token()` calls and debug log spam during concurrent requests.
+- **ARM request timing** – all ARM HTTP calls now log elapsed time at DEBUG level (`ARM GET … → 200 (0.34s)`) for performance troubleshooting.
 
 ## [2026.3.5] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Scout Azure regions for VM availability, zone mappings, pricing, spot scores, and quota — then plan deployments with confidence.
 
-📖 **Full documentation:** [az-scout.com](https://az-scout.com)
+📖 **Full documentation:** [docs.az-scout.com](https://docs.az-scout.com)
 
 **az-scout** helps Azure operators and architects answer the questions that matter when planning resilient, cost-efficient VM deployments:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Azure Scout
 site_description: Scout Azure regions for VM availability, zone mappings, pricing, spot scores, and quota — then plan deployments with confidence.
-site_url: https://az-scout.com
+site_url: https://docs.az-scout.com
 repo_url: https://github.com/az-scout/az-scout
 repo_name: az-scout/az-scout
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://az-scout.com"
+Homepage = "https://docs.az-scout.com"
 Repository = "https://github.com/az-scout/az-scout"
 Issues = "https://github.com/az-scout/az-scout/issues"
 

--- a/src/az_scout/azure_api/_arm.py
+++ b/src/az_scout/azure_api/_arm.py
@@ -86,6 +86,7 @@ def _arm_request(
 
     for attempt in range(max_retries):
         try:
+            t0 = time.monotonic()
             if method == "POST":
                 resp = requests.post(
                     url,
@@ -100,6 +101,14 @@ def _arm_request(
                     params=params,
                     timeout=timeout,
                 )
+            elapsed = time.monotonic() - t0
+            logger.debug(
+                "ARM %s %s → %d (%.2fs)",
+                method,
+                url[:120],
+                resp.status_code,
+                elapsed,
+            )
 
             if resp.status_code == 403:
                 raise ArmAuthorizationError(

--- a/src/az_scout/azure_api/_auth.py
+++ b/src/az_scout/azure_api/_auth.py
@@ -6,6 +6,8 @@ import base64
 import json
 import logging
 import os
+import threading
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 
@@ -17,6 +19,11 @@ AZURE_API_VERSION = "2022-12-01"
 AZURE_MGMT_URL = "https://management.azure.com"
 
 credential = DefaultAzureCredential()
+
+# Token cache: (tenant_key → (token_str, expires_on_epoch))
+_token_cache: dict[str, tuple[str, float]] = {}
+_token_lock = threading.Lock()
+_TOKEN_REFRESH_MARGIN = 120  # refresh 2 min before expiry
 
 
 @contextmanager
@@ -41,17 +48,34 @@ def _get_headers(tenant_id: str | None = None) -> dict[str, str]:
     """Return authorization headers using *DefaultAzureCredential*.
 
     When *tenant_id* is provided the token is scoped to that tenant.
+    Tokens are cached in-memory and reused until 2 minutes before expiry.
     """
-    kwargs: dict[str, str] = {}
-    if tenant_id:
-        kwargs["tenant_id"] = tenant_id
-    logger.debug("Acquiring ARM token (tenant=%s)", tenant_id or "default")
-    token = credential.get_token(f"{AZURE_MGMT_URL}/.default", **kwargs)
-    logger.debug("ARM token acquired (tenant=%s)", tenant_id or "default")
-    return {
-        "Authorization": f"Bearer {token.token}",
-        "Content-Type": "application/json",
-    }
+    cache_key = tenant_id or "_default_"
+    with _token_lock:
+        cached = _token_cache.get(cache_key)
+        if cached:
+            token_str, expires_on = cached
+            if time.time() < expires_on - _TOKEN_REFRESH_MARGIN:
+                return {
+                    "Authorization": f"Bearer {token_str}",
+                    "Content-Type": "application/json",
+                }
+
+        kwargs: dict[str, str] = {}
+        if tenant_id:
+            kwargs["tenant_id"] = tenant_id
+        logger.debug("Acquiring ARM token (tenant=%s)", tenant_id or "default")
+        token = credential.get_token(f"{AZURE_MGMT_URL}/.default", **kwargs)
+        _token_cache[cache_key] = (token.token, token.expires_on)
+        logger.debug(
+            "ARM token acquired (tenant=%s, expires_on=%d)",
+            tenant_id or "default",
+            token.expires_on,
+        )
+        return {
+            "Authorization": f"Bearer {token.token}",
+            "Content-Type": "application/json",
+        }
 
 
 def _get_default_tenant_id() -> str | None:

--- a/src/az_scout/templates/index.html
+++ b/src/az_scout/templates/index.html
@@ -179,7 +179,7 @@
                     <h4 id="aboutModalLabel">Azure Scout</h4>
                     <span class="about-version">{{ version }}</span>
                     <div class="about-links">
-                        <a href="https://az-scout.com" target="_blank" rel="noopener"
+                        <a href="https://docs.az-scout.com" target="_blank" rel="noopener"
                            class="btn btn-sm btn-outline-primary">
                             <i class="bi bi-house-door me-1"></i>Homepage
                         </a>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,8 +57,12 @@ def _sync_arm_requests_mock():
 @pytest.fixture(autouse=True)
 def _mock_credential():
     """Prevent real Azure credential calls in every test."""
+    from az_scout.azure_api._auth import _token_cache
+
+    _token_cache.clear()
     mock_token = MagicMock()
     mock_token.token = "fake-token"
+    mock_token.expires_on = 9999999999  # far future
     with patch("az_scout.azure_api._auth.credential") as cred:
         cred.get_token.return_value = mock_token
         yield cred


### PR DESCRIPTION
## Description

Two improvements to the Azure API layer, plus docs domain migration:

**ARM token caching:**
- Tokens are now cached per-tenant in `_get_headers()` with a 2-minute refresh margin before expiry
- Added `threading.Lock` to prevent race conditions when `list_tenants()` checks multiple tenants concurrently via `ThreadPoolExecutor`
- Eliminates redundant `credential.get_token()` calls and debug log spam (previously one per ARM request, now one per tenant per ~60 min)

**ARM request timing:**
- All ARM HTTP calls now log elapsed time at DEBUG level: `ARM GET … → 200 (0.34s)`
- Helps identify slow API calls when running with `--verbose`

**Docs domain:**
- Updated all references from `az-scout.com` to `docs.az-scout.com` (mkdocs.yml, README, pyproject.toml, index.html)

## Related issue

N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
