### PR TITLE
fix(plugins): add --system flag for uv pip in non-venv environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Fixed
+
+- **Plugin uninstall in ACA** – `uv pip uninstall` now appends `--system` when running outside a virtual environment (e.g. in Azure Container Apps), fixing `No virtual environment found` errors (#115).
+
 ### Added
 
 - **On-Behalf-Of (OBO) authentication** – Multi-user mode where each user signs in with their Microsoft account and az-scout accesses Azure ARM APIs with their RBAC permissions instead of the app's managed identity. Enabled via `AZ_SCOUT_CLIENT_ID`, `AZ_SCOUT_CLIENT_SECRET`, and `AZ_SCOUT_TENANT_ID` environment variables.

--- a/src/az_scout/plugin_manager/_installer.py
+++ b/src/az_scout/plugin_manager/_installer.py
@@ -18,6 +18,11 @@ def _find_uv() -> str | None:
     return shutil.which("uv")
 
 
+def _in_virtualenv() -> bool:
+    """Return True if running inside a virtual environment."""
+    return sys.prefix != sys.base_prefix
+
+
 def _pip_env() -> dict[str, str]:
     """Return an environment dict for pip/uv subprocess calls."""
     env = os.environ.copy()
@@ -38,6 +43,10 @@ def run_pip(args: list[str]) -> subprocess.CompletedProcess[str]:
 
     if uv:
         cmd: list[str] = [uv, "pip", *sub_args, "--target", str(_storage._PACKAGES_DIR)]
+        # In containerized environments (e.g. ACA) there may be no virtual
+        # environment.  uv requires --system in that case.
+        if not _in_virtualenv():
+            cmd.append("--system")
     else:
         if sub_args and sub_args[0] == "uninstall" and "-y" not in sub_args:
             sub_args.insert(1, "-y")


### PR DESCRIPTION
## Description

Fix plugin uninstall (and install) failing in Azure Container Apps with `No virtual environment found` error. When `uv pip` runs outside a virtual environment, it requires `--system` flag.

## Related issue

Closes #115

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors