### PR TITLE
fix(plugins): use lenient protocol check for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 ### Fixed
 
 - **Plugin uninstall in ACA** – `uv pip uninstall` now appends `--system` when running outside a virtual environment (e.g. in Azure Container Apps), fixing `No virtual environment found` errors (#115).
+- **Plugin compatibility** – Plugin protocol check now uses a lenient attribute check instead of `isinstance(obj, AzScoutPlugin)`. Plugins missing newer optional methods (e.g. `get_navbar_actions`) load correctly again (#116).
+- **Broken versioning** – Removed non-CalVer tag (`obo-single-tenant-v1`) that caused `hatch-vcs` to produce `2.dev4` instead of `2026.3.x.devN` (#117).
 
 ### Added
 

--- a/src/az_scout/plugins.py
+++ b/src/az_scout/plugins.py
@@ -48,6 +48,18 @@ def _ensure_plugin_packages_on_path() -> None:
         logger.info("Added plugin packages to sys.path: %s", pkg_str)
 
 
+def _satisfies_plugin_protocol(obj: Any) -> bool:
+    """Check if *obj* has the minimum attributes required by the plugin protocol.
+
+    Uses a manual check instead of ``isinstance(obj, AzScoutPlugin)`` because
+    ``runtime_checkable`` Protocols reject objects missing *any* method — even
+    optional ones added in newer versions.  This allows older plugins (that
+    don't implement newly-added optional methods like ``get_navbar_actions``)
+    to still load correctly.
+    """
+    return hasattr(obj, "name") and hasattr(obj, "version") and hasattr(obj, "get_router")
+
+
 def _discover_plugin_packages_entry_points() -> list[importlib.metadata.EntryPoint]:
     """Discover ``az_scout.plugins`` entry points from ``plugin-packages``."""
     if not _PACKAGES_DIR.exists():
@@ -89,7 +101,7 @@ def discover_plugins() -> list[AzScoutPlugin]:
     for ep in all_eps:
         try:
             obj = ep.load()
-            if isinstance(obj, AzScoutPlugin):
+            if _satisfies_plugin_protocol(obj):
                 plugins.append(obj)
                 # Remember the pip distribution name for metadata lookups
                 if ep.dist is not None:


### PR DESCRIPTION
## Description

Fix plugin compatibility broken by the `get_navbar_actions` addition to the `AzScoutPlugin` protocol. The `runtime_checkable` Protocol's `isinstance` check rejects plugins missing **any** method — even optional ones added in newer versions.

Replace with a lenient `_satisfies_plugin_protocol()` check that only requires the minimum: `name`, `version`, and `get_router`. New optional methods can be added to the protocol without breaking existing plugins.

Also documents the #117 versioning fix (non-CalVer tag deletion) in the CHANGELOG.

## Related issue

Closes #116

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors