### PR TITLE
feat(auth): extend session TTL to 8h with sliding expiry

### DIFF
--- a/src/az_scout/routes/auth.py
+++ b/src/az_scout/routes/auth.py
@@ -48,7 +48,7 @@ def _build_redirect_uri(request: Request) -> str:
 
 # In-memory session store: session_id → session data
 _sessions: dict[str, dict[str, Any]] = {}
-_SESSION_TTL = 7200  # 2 hours
+_SESSION_TTL = 28800  # 8 hours (a workday)
 _COOKIE_NAME = "az_scout_sid"
 
 # CSRF nonces for OAuth state parameter: nonce → {tenant, expires_at}
@@ -81,7 +81,10 @@ def _cleanup_expired() -> None:
 
 
 def get_session(request: Request) -> dict[str, Any] | None:
-    """Get the current user's session from the cookie, or None."""
+    """Get the current user's session from the cookie, or None.
+
+    Uses sliding expiry: each access extends the session TTL.
+    """
     from az_scout.azure_api._obo import CLIENT_SECRET
 
     cookie = request.cookies.get(_COOKIE_NAME)
@@ -96,6 +99,8 @@ def get_session(request: Request) -> dict[str, Any] | None:
     if session.get("expires_at", 0) < time.time():
         del _sessions[session_id]
         return None
+    # Sliding expiry: extend session on each access
+    session["expires_at"] = time.time() + _SESSION_TTL
     return session
 
 


### PR DESCRIPTION
## Description

Extend OBO session lifetime and add sliding expiry for longer active sessions.

### Changes

- **Session TTL**: Increased from 2 hours to 8 hours (a full workday)
- **Sliding expiry**: Each request resets the 8h countdown — active users stay logged in all day
- **Token renewal**: MSAL refresh token (24h–90 days) handles access token renewal transparently via `acquire_token_silent()` — no periodic polling needed

### How session lifecycle works

| Component | Lifetime | Renewed by |
|-----------|----------|------------|
| Session cookie | 8h (sliding) | Every request resets |
| MSAL access token | ~1h | `acquire_token_silent` on next request |
| MSAL refresh token | 24h–90 days | Azure AD policy, automatic |
| OBO ARM token cache | ~1h (minus 2min) | Re-exchanged on next ARM call |

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors