### PR TITLE
feat(chat): UX improvements – pin/open persistence, table overflow, h1 headers, clickable choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 - **Plugin uninstall in ACA** – `uv pip uninstall` now appends `--system` when running outside a virtual environment (e.g. in Azure Container Apps), fixing `No virtual environment found` errors (#115).
 - **Plugin compatibility** – Plugin protocol check now uses a lenient attribute check instead of `isinstance(obj, AzScoutPlugin)`. Plugins missing newer optional methods (e.g. `get_navbar_actions`) load correctly again (#116).
 - **Broken versioning** – Removed non-CalVer tag (`obo-single-tenant-v1`) that caused `hatch-vcs` to produce `2.dev4` instead of `2026.3.x.devN` (#117).
+- **Chat tables overflow** – Tables in chat bubbles now scroll horizontally instead of overflowing outside the panel.
+
+### Added
+
+- **Chat pin/open persistence** – Chat panel pinned state and open/closed state are saved to localStorage and restored on reload.
+- **Chat h1 rendering** – Markdown `# heading` (h1) is now rendered in chat bubbles (previously only `##` and `###` were handled).
+- **Clickable choices for all chat modes** – The `[[option]]` formatting instruction is now appended to all chat modes (including plugin-contributed modes like ODCR Advisor), so LLM responses consistently use clickable chips for selectable options.
+- **Chat history for plugin modes** – `_restoreChatHistory` now restores all saved modes (including plugin-contributed ones), not just `discussion` and `planner`.
 
 ### Added
 

--- a/src/az_scout/services/ai_chat/_prompts.py
+++ b/src/az_scout/services/ai_chat/_prompts.py
@@ -2,6 +2,22 @@
 
 from __future__ import annotations
 
+_RESPONSE_FORMAT_INSTRUCTIONS = """\
+
+Response formatting:
+- Use Markdown for structured data (tables, lists, bold, code).
+- **Interactive choices:** When asking the user to pick from a list of options \
+(e.g. subscriptions, regions, SKUs, actions), wrap each option in double brackets: \
+`[[option text]]`. The UI renders these as clickable buttons. Example:
+  - [[contoso-prod]]
+  - [[contoso-dev]]
+  Do NOT use plain bullet lists for selectable options — always use `[[…]]` so the \
+user can click instead of typing.
+- **Subscription resolution:** Tools require subscription **IDs** (UUIDs), not display \
+names. When the user provides a subscription **name**, first call `list_subscriptions` \
+to find the matching subscription ID, then use that ID in subsequent tool calls.
+"""
+
 SYSTEM_PROMPT = """\
 You are **Azure Scout Assistant**, an AI assistant embedded in the Azure Scout \
 web tool. You help users explore Azure infrastructure: tenants, subscriptions, \
@@ -19,14 +35,6 @@ Guidelines:
 - You can combine multiple tool calls to answer complex questions.
 - Prices are per hour, Linux, from the Azure Retail Prices API.
 - Confidence scores range 0–100 (High ≥80, Medium ≥60, Low ≥40, Very Low <40).
-- **Interactive choices:** When asking the user to choose (e.g. subscription, region, \
-SKU), present each option as `[[option text]]` on its own bullet line. The UI renders \
-these as clickable chips. Example:
-  - [[subscription-1-name (xxxxxxxx…)]]
-  - [[subscription-2-name (yyyyyyyy…)]]
-- **Subscription resolution:** Tools require subscription **IDs** (UUIDs), not display \
-names. When the user provides a subscription **name**, first call `list_subscriptions` \
-to find the matching subscription ID, then use that ID in subsequent tool calls.
 - **Tenant context:** The user's currently selected tenant ID is provided as context. \
 All your tool calls automatically use this tenant unless you specify a different one. \
 If the user asks to switch tenant, call `list_tenants` to find available tenants, then \
@@ -100,4 +108,5 @@ def _build_system_prompt(
             f"calls that require a `subscription_id` parameter, unless the user "
             f"explicitly asks you to use a different one."
         )
+    prompt += _RESPONSE_FORMAT_INSTRUCTIONS
     return prompt

--- a/src/az_scout/static/css/style.css
+++ b/src/az_scout/static/css/style.css
@@ -198,6 +198,8 @@ select.no-arrow {
     line-height: 1.45;
     word-wrap: break-word;
     overflow-wrap: break-word;
+    max-width: 100%;
+    overflow-x: auto;
 }
 
 .chat-message.user .chat-bubble {

--- a/src/az_scout/static/js/chat.js
+++ b/src/az_scout/static/js/chat.js
@@ -20,6 +20,8 @@ const _CHAT_STORAGE_KEY = "azm-chat-history";
 const _CHAT_PERSIST_KEY = "azm-chat-persist";
 const _CHAT_INPUT_HIST_KEY = "azm-chat-input-history";
 const _CHAT_MODE_KEY = "azm-chat-mode";
+const _CHAT_PINNED_KEY = "azm-chat-pinned";
+const _CHAT_OPEN_KEY = "azm-chat-open";
 
 // Per-mode conversation state: { discussion: {messages, inputHistory}, planner: {messages, inputHistory} }
 const _chatModeState = {
@@ -50,13 +52,15 @@ function toggleChatPanel() {
     const panel = document.getElementById("chat-panel");
     if (!panel) return;
     panel.classList.toggle("d-none");
-    if (!panel.classList.contains("d-none")) {
+    const isOpen = !panel.classList.contains("d-none");
+    if (isOpen) {
         document.getElementById("chat-input")?.focus();
     }
     // If pinned and closing, unpin
-    if (panel.classList.contains("d-none") && _chatPinned) {
+    if (!isOpen && _chatPinned) {
         _setChatPinned(false);
     }
+    try { localStorage.setItem(_CHAT_OPEN_KEY, isOpen ? "1" : "0"); } catch {}
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +141,7 @@ function toggleChatPin() {
 
 function _setChatPinned(pinned) {
     _chatPinned = pinned;
+    try { localStorage.setItem(_CHAT_PINNED_KEY, _chatPinned ? "1" : "0"); } catch {}
     document.body.classList.toggle("chat-pinned", _chatPinned);
     const btn = document.getElementById("chat-pin-btn");
     if (btn) {
@@ -208,7 +213,10 @@ function _restoreChatHistory() {
 
         // Restore saved mode
         const savedMode = localStorage.getItem(_CHAT_MODE_KEY);
-        if (savedMode && (savedMode === "discussion" || savedMode === "planner")) {
+        if (savedMode) {
+            if (!_chatModeState[savedMode]) {
+                _chatModeState[savedMode] = { messages: [], inputHistory: [] };
+            }
             _chatMode = savedMode;
             document.querySelectorAll("#chat-mode-toggle button").forEach(b => {
                 b.classList.toggle("active", b.dataset.mode === _chatMode);
@@ -226,10 +234,17 @@ function _restoreChatHistory() {
                     // Legacy: migrate old format into discussion mode
                     _chatModeState.discussion.messages = state;
                 } else if (state && typeof state === "object") {
-                    // Support old "assistant" key for backward compat
-                    const disc = state.discussion || state.assistant;
-                    if (disc?.messages) _chatModeState.discussion = disc;
-                    if (state.planner?.messages) _chatModeState.planner = state.planner;
+                    // Restore all mode states (discussion, planner, plugin modes)
+                    for (const [mode, data] of Object.entries(state)) {
+                        // Support old "assistant" key → map to "discussion"
+                        const targetMode = mode === "assistant" ? "discussion" : mode;
+                        if (data?.messages) {
+                            if (!_chatModeState[targetMode]) {
+                                _chatModeState[targetMode] = { messages: [], inputHistory: [] };
+                            }
+                            _chatModeState[targetMode] = data;
+                        }
+                    }
                 }
 
                 // Load current mode's state
@@ -263,6 +278,17 @@ function _restoreChatHistory() {
             input.placeholder = _chatMode === "planner"
                 ? "Describe your deployment needs…"
                 : "Ask about Azure SKUs, zones, pricing…";
+        }
+
+        // Restore pinned state
+        if (localStorage.getItem(_CHAT_PINNED_KEY) === "1") {
+            _setChatPinned(true);
+        }
+
+        // Restore open state
+        const panel = document.getElementById("chat-panel");
+        if (panel && localStorage.getItem(_CHAT_OPEN_KEY) === "1") {
+            panel.classList.remove("d-none");
         }
     } catch {}
 }
@@ -677,6 +703,7 @@ function _renderMarkdown(md) {
     // Headers (## and ###)
     html = html.replace(/^### (.+)$/gm, '<h6 class="mt-2 mb-1">$1</h6>');
     html = html.replace(/^## (.+)$/gm, '<h5 class="mt-2 mb-1">$1</h5>');
+    html = html.replace(/^# (.+)$/gm, '<h4 class="mt-2 mb-1">$1</h4>');
     // Horizontal rule
     html = html.replace(/^---$/gm, "<hr>");
 

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 from az_scout.internal_plugins.planner.chat_mode import PLANNER_CHAT_MODE
 from az_scout.services.ai_chat import (
-    SYSTEM_PROMPT,
     TOOL_DEFINITIONS,
     _build_openai_tools,
     _build_system_prompt,
@@ -83,8 +82,9 @@ class TestBuildSystemPrompt:
         assert "Spot" in prompt
 
     def test_assistant_prompt_contains_guidelines(self):
-        assert "Interactive choices" in SYSTEM_PROMPT
-        assert "Subscription resolution" in SYSTEM_PROMPT
+        prompt = _build_system_prompt()
+        assert "Interactive choices" in prompt
+        assert "Subscription resolution" in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Several chat panel UX improvements:

- **Pin & open persistence** – Chat panel pinned state and open/closed state are saved to `localStorage` and restored on page reload.
- **Table overflow fix** – Tables in chat bubbles now scroll horizontally (`overflow-x: auto`) instead of overflowing outside the panel.
- **h1 markdown rendering** – `# heading` (h1) is now rendered in chat bubbles. Previously only `##` and `###` were handled, causing emoji-prefixed h1 titles to render as raw text.
- **Clickable choices for all chat modes** – The `[[option]]` formatting instruction was extracted into a shared `_RESPONSE_FORMAT_INSTRUCTIONS` block and appended to all chat modes (including plugin-contributed modes like ODCR Advisor), so the LLM consistently uses clickable chips for selectable options.
- **Chat history for plugin modes** – `_restoreChatHistory` now restores all saved modes (including plugin-contributed ones), not just the built-in `discussion` and `planner`.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors