### PR TITLE
refactor(docs): split copilot-instructions into file instructions + create-plugin skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,104 +23,22 @@ src/az_scout/
 ├── plugin_manager.py   # Install/validate/uninstall plugins (GitHub + PyPI)
 ├── plugins.py          # Plugin discovery, registration, hot-reload
 ├── azure_api/          # Shared Azure ARM logic (auth, pagination, data functions)
-│   ├── __init__.py     # Public API surface (PLUGIN_API_VERSION, __all__)
-│   ├── _arm.py         # arm_get/arm_post/arm_paginate + get_headers (public)
-│   ├── _auth.py        # DefaultAzureCredential, _get_headers, OBO fallback (internal)
-│   ├── _obo.py         # On-Behalf-Of token exchange via MSAL (internal)
-│   ├── _pagination.py  # Legacy _paginate (internal, use arm_paginate instead)
-│   ├── discovery.py    # Tenants, subscriptions, regions
-│   ├── skus.py         # SKU catalogue + zone mappings
-│   ├── pricing.py      # Retail prices API
-│   ├── quotas.py       # Compute usage / quota
-│   └── spot.py         # Spot Placement Scores
 ├── scoring/            # Deployment Confidence Score (shared by plugins)
 ├── services/           # Business logic (deployment planner, AI chat, etc.)
 ├── models/             # Pydantic models (deployment plan)
-├── routes/
-│   ├── __init__.py     # Plugin manager API routes
-│   └── discovery.py    # Discovery routes (tenants, subscriptions, regions, locations)
-├── internal_plugins/
-│   ├── __init__.py     # discover_internal_plugins()
-│   ├── topology/       # AZ Topology tab (routes, MCP tool, JS, CSS, HTML)
-│   └── planner/        # Deployment Planner tab (routes, MCP tools, JS, CSS, HTML, ChatMode)
-├── templates/
-│   └── index.html      # Single-page Jinja2 template (dynamic plugin tabs)
-└── static/
-    ├── js/app.js       # Core frontend logic (shared utilities, init)
-    ├── js/chat.js      # AI chat panel
-    ├── js/plugins.js   # Plugin Manager UI
-    ├── css/style.css   # Core + chat styles (plugin CSS loaded via TabDefinition)
-    └── img/            # SVG icons (favicon, filter icons)
-tests/
-├── test_routes.py      # pytest tests for FastAPI routes (mocked Azure API)
-├── test_mcp_server.py  # pytest tests for MCP tools
-├── test_plugins.py     # pytest tests for plugin system
-└── e2e/                # Playwright E2E tests
+├── routes/             # API routes (discovery, plugin manager, auth)
+├── internal_plugins/   # Built-in plugins (topology, planner)
+├── templates/          # Jinja2 templates (index.html, login.html)
+└── static/             # JS, CSS, images
+tests/                  # pytest unit tests + e2e (Playwright)
 ```
 
 ## Code conventions
 
-- **Python:** All functions must have type annotations (`disallow_untyped_defs = true`). Use `from __future__ import annotations` is not required (3.11+). Follow ruff rules: `E, F, I, W, UP, B, SIM`. Line length is 100.
+- **Python:** All functions must have type annotations (`disallow_untyped_defs = true`). Follow ruff rules: `E, F, I, W, UP, B, SIM`. Line length is 100.
 - **JavaScript:** Vanilla JS only — no npm, no bundler, no frameworks. Use `const`/`let` (never `var`). Functions and variables use `camelCase`.
-- **CSS:** Use CSS custom properties (defined in `:root`) for theming. Both light and dark themes must be maintained. Dark mode uses `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` selectors.
+- **CSS:** Use CSS custom properties for theming. Both light and dark themes must be maintained.
 - **HTML:** Minimal Jinja2 templating. Static assets referenced via `url_for('static', ...)`.
-
-## Azure API patterns
-
-- Auth uses `DefaultAzureCredential` with optional `tenant_id` parameter.
-- All ARM calls should use the public helpers: `arm_get()`, `arm_post()`, `arm_paginate()`.
-- These helpers provide automatic Bearer-token auth, 429/5xx retry with backoff, and structured error handling (`ArmAuthorizationError`, `ArmNotFoundError`, `ArmRequestError`).
-- For raw token access (non-ARM endpoints), use `get_headers(tenant_id)`.
-- API base URL: `https://management.azure.com`.
-- Handle pagination (`nextLink`) via `arm_paginate()` for list endpoints.
-- Per-subscription errors should be included in the response (not fail the whole request).
-
-## OBO (On-Behalf-Of) authentication
-
-When `AZ_SCOUT_CLIENT_ID` and `AZ_SCOUT_CLIENT_SECRET` are set, OBO mode is activated:
-
-- **Server-side auth flow**: Users sign in via `/auth/login` → Microsoft login → `/auth/callback`. Sessions stored as HMAC-signed HTTP-only cookies. No client-side token management.
-- **Single-tenant-per-session**: Each session is scoped to the login tenant (extracted from the JWT `tid` claim). No cross-tenant OBO. To switch tenants, sign out and sign in again.
-- **OBO validation at login**: The OBO exchange is tested in the callback before creating the session. Consent/MFA/user errors redirect to the login page with specific error messages.
-- **Web requests**: Unauthenticated requests get `_NO_TOKEN` sentinel via the middleware → `OboTokenError("Authentication required")` → redirect to `/auth/login`.
-- **CLI mode** (`az-scout chat`, `az-scout mcp --stdio`) has no middleware, so `_get_headers()` falls back to `DefaultAzureCredential`.
-- **Auth context propagation**: The `_AuthContextMiddleware` (raw ASGI) reads tokens from Authorization header (MCP) or session cookie (web), sets module-level global + context vars.
-- **Admin role**: Entra ID App Role `Admin` from home tenant controls plugin management. `_require_admin()` guard on write endpoints.
-- **OBO token cache**: Keyed by full token hash + tenant to prevent cross-user cache pollution.
-- **`OboTokenError`**: Exception with `error_code` and optional `claims` fields. Handled by a dedicated exception handler in `app.py` returning 401 responses.
-
-## MCP tools reference
-
-The MCP server exposes discovery tools directly (in `mcp_server.py`) and feature-specific
-tools via internal plugins (topology, planner). When calling them, use the **exact parameter
-names** listed below.
-
-| Tool | Source | Parameters | Description |
-|---|---|---|---|
-| `list_tenants` | core | *(none)* | List Azure AD tenants with auth status |
-| `list_subscriptions` | core | `tenant_id?` | List enabled subscriptions |
-| `list_regions` | core | `subscription_id?`, `tenant_id?` | List AZ-enabled regions |
-| `get_zone_mappings` | topology plugin | `region`, `subscription_ids`, `tenant_id?` | Logical-to-physical zone mappings |
-| `get_sku_availability` | planner plugin | `region`, `subscription_id`, `tenant_id?`, `resource_type?`, `name?`, `family?`, `min_vcpus?`, `max_vcpus?`, `min_memory_gb?`, `max_memory_gb?` | SKU availability per zone |
-| `get_sku_deployment_confidence` | planner plugin | `region`, `subscription_id`, `skus`, `prefer_spot?`, `instance_count?`, `include_signals?`, `include_provenance?`, `tenant_id?` | Deployment confidence scoring per SKU |
-
-### `get_sku_availability` filter parameters
-
-Use these optional filters to reduce output size (important in conversational contexts):
-
-- **`name`** *(str)* – case-insensitive substring match on SKU name (e.g. `"D2s"` matches `Standard_D2s_v3`)
-- **`family`** *(str)* – case-insensitive substring match on SKU family (e.g. `"DSv3"` matches `standardDSv3Family`)
-- **`min_vcpus`** / **`max_vcpus`** *(int)* – vCPU count range (inclusive)
-- **`min_memory_gb`** / **`max_memory_gb`** *(float)* – memory in GB range (inclusive)
-
-When no filters are provided, all SKUs for the resource type are returned.
-
-## Testing patterns
-
-- Tests use FastAPI's `TestClient` (backed by httpx).
-- Azure API calls are mocked with `unittest.mock.patch` on `requests.get` and `DefaultAzureCredential`.
-- Tests are grouped by endpoint in pytest test classes.
-- Run with: `uv run pytest`
 
 ## Quality checks
 
@@ -135,256 +53,41 @@ uv run pytest
 
 Pre-commit hooks run these automatically on `git commit`.
 
-## Plugin development
-
-az-scout supports plugins — pip-installable Python packages that extend the app with API routes, MCP tools, UI tabs, static assets, and AI chat modes.
-
-### Plugin architecture
-
-- Plugins are discovered at startup via `importlib.metadata.entry_points(group="az_scout.plugins")`.
-- Each plugin must expose a module-level object satisfying the `AzScoutPlugin` protocol from `az_scout.plugin_api`.
-- Registration is automatic — no manual configuration needed.
-- A ready-to-use scaffold is at `docs/plugin-scaffold/`.
-
-### Plugin protocol
-
-```python
-from az_scout.plugin_api import AzScoutPlugin, TabDefinition, ChatMode
-
-class MyPlugin:
-    name = "my-plugin"       # unique identifier
-    version = "0.1.0"
-
-    def get_router(self) -> APIRouter | None: ...       # FastAPI routes → /plugins/{name}/
-    def get_mcp_tools(self) -> list[Callable] | None: ... # MCP tool functions
-    def get_static_dir(self) -> Path | None: ...        # served at /plugins/{name}/static/
-    def get_tabs(self) -> list[TabDefinition] | None: ... # UI tabs in main app
-    def get_chat_modes(self) -> list[ChatMode] | None: ... # AI chat modes
-
-plugin = MyPlugin()  # module-level instance referenced by entry point
-```
-
-All methods are optional — return `None` to skip a layer.
-
-### Entry point registration
-
-```toml
-[project.entry-points."az_scout.plugins"]
-my_plugin = "az_scout_myplugin:plugin"
-```
-
-### Plugin conventions
-
-- **Package layout:** Use src-layout (`src/az_scout_myplugin/`) with hatchling build backend.
-- **Naming:** Package name `az-scout-plugin-{name}`, module `az_scout_{name}`.
-- **Dependencies:** Declare `az-scout` and `fastapi` as dependencies in `pyproject.toml`.
-- **Type annotations:** Follow the same mypy strict rules as the main project (`disallow_untyped_defs = true`).
-- **Linting:** Use `ruff` with the same rules: `E, F, I, W, UP, B, SIM`, line length 100.
-- **Lazy imports:** Use deferred imports inside methods (e.g. `from az_scout_myplugin.routes import router`) to avoid circular imports at plugin discovery time.
-- **Static dir:** Define `_STATIC_DIR = Path(__file__).parent / "static"` at module level.
-
-### API routes
-
-- Routes are mounted under `/plugins/{name}/` — define endpoints with relative paths (e.g. `@router.get("/hello")` → `/plugins/my-plugin/hello`).
-- Routes receive context (tenant, region, subscription) as query parameters from the frontend.
-- Use `async def` for route handlers.
-
-### MCP tools
-
-- MCP tool functions are plain Python functions with type annotations and docstrings.
-- The docstring is the tool description shown to LLMs — keep it concise and helpful.
-- Functions are registered on the MCP server automatically at startup.
-
-### UI tabs
-
-- Tabs use `TabDefinition(id, label, icon, js_entry, css_entry?)`.
-- `icon` uses Bootstrap Icon classes (e.g. `"bi bi-puzzle"`).
-- `js_entry` / `css_entry` are relative paths inside the plugin's static dir.
-- Plugin tabs appear after built-in tabs (AZ Topology, Deployment Planner, Strategy Advisor).
-- Plugin JS targets `#plugin-tab-{id}` as its container.
-- URL hash `#{tab-id}` activates the plugin tab (deep-linking support).
-
-### Frontend integration
-
-Plugin JS runs after `app.js` and can use these globals:
-
-| Global | Description |
-|---|---|
-| `apiFetch(url)` | GET with JSON parsing + error handling |
-| `apiPost(url, body)` | POST helper |
-| `aiComplete(prompt, options?)` | Non-streaming AI completion (returns `{content, tool_calls}`) |
-| `aiEnabled` | `true` if AI chat/completion is configured |
-| `renderMarkdown(md)` | Render Markdown to HTML via marked.js (for AI output display) |
-| `tenantQS(prefix)` | Returns `?tenantId=…` or `""` |
-| `subscriptions` | `[{id, name}]` array |
-| `regions` | `[{name, displayName}]` array |
-
-React to context changes:
-
-```javascript
-// Tenant change
-document.getElementById("tenant-select")
-    .addEventListener("change", () => { /* reload */ });
-
-// Region change (hidden input, use MutationObserver)
-const regionEl = document.getElementById("region-select");
-let lastRegion = regionEl.value;
-new MutationObserver(() => {
-    if (regionEl.value !== lastRegion) {
-        lastRegion = regionEl.value;
-        // reload
-    }
-}).observe(regionEl, { attributes: true, attributeFilter: ["value"] });
-```
-
-Use the **HTML fragments pattern** — keep markup in `.html` files under `static/html/` and fetch at runtime instead of building HTML strings in JS.
-
-### Chat modes
-
-- `ChatMode(id, label, system_prompt, welcome_message)` adds extra buttons in the chat mode toggle.
-- `system_prompt` is sent to the LLM — craft it for the plugin's domain.
-- `welcome_message` is markdown displayed when the mode is activated.
-
-### Testing plugins
-
-- Test plugins independently with `pytest` and `httpx`.
-- Mock `discover_plugins()` to inject test plugin instances.
-- Use `register_plugins(app, mcp_server)` with a test FastAPI app.
-- Follow the same testing patterns as the main project (mocked Azure API, `TestClient`).
-
-### Plugin `pyproject.toml` template
-
-```toml
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[project]
-name = "az-scout-myplugin"
-version = "0.1.0"
-requires-python = ">=3.11"
-dependencies = ["az-scout", "fastapi"]
-
-[project.entry-points."az_scout.plugins"]
-my_plugin = "az_scout_myplugin:plugin"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/az_scout_myplugin"]
-
-[tool.ruff]
-line-length = 100
-target-version = "py311"
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "W", "UP", "B", "SIM"]
-
-[tool.mypy]
-python_version = "3.11"
-strict = true
-```
-
 ## Versioning
 
 - Version is derived from git tags via `hatch-vcs` — never hardcode a version.
-- `_version.py` is auto-generated and excluded from linting.
 - Tags follow CalVer: `v2026.2.0`, `v2026.2.1`, etc.
 - Update `CHANGELOG.md` before tagging a release.
 
-## Design constraints & architectural rules
+## Design rules
 
 ### Do
 
 - Reuse `azure_api/` for all Azure ARM interactions.
-- Keep FastAPI routes as thin wrappers.
-- Keep MCP tools as thin wrappers over `azure_api`.
+- Keep FastAPI routes and MCP tools as thin wrappers.
 - Include full type annotations on all public functions.
 - Preserve dark/light theme compatibility.
 
 ### Do NOT
 
 - Do NOT call Azure ARM APIs directly from route handlers or MCP tools.
-- Do NOT duplicate Azure API logic outside `azure_api/`.
 - Do NOT introduce frontend frameworks, npm, or build tooling.
 - Do NOT introduce global mutable state.
 - Do NOT perform heavy imports at module import time.
-- Do NOT bypass plugin auto-discovery.
-- Do NOT add synchronous blocking calls inside large subscription loops.
 - Do NOT change API response shapes without updating tests.
 
-## Backend design principles
+## Code generation expectations
 
-- All Azure ARM logic lives in `azure_api/`.
-- Scoring logic lives in `scoring/` (shared by internal + external plugins).
-- `app.py` is bootstrap-only — routes live in `routes/` or internal plugins.
-- `mcp_server.py` contains only core discovery tools — feature tools live in internal plugins.
-- Per-subscription failures must not break global execution.
-- Functions must be deterministic and side-effect free unless explicitly documented.
-- No hidden state between requests.
-
-### Response contract consistency
-
-- API responses must be stable and predictable.
-- If an error occurs for a specific subscription, return:
-
-```json
-{
-  "subscription_id": "00000000-0000-0000-0000-000000000000",
-  "error": {
-    "code": "AuthorizationFailed",
-    "message": "User is not authorized to perform this action."
-  }
-}
-```
-
-- Never raise an unhandled exception for per-subscription failures.
-
-## Performance constraints
-
-This tool may operate across dozens or hundreds of subscriptions. When generating code:
-
-- Avoid O(n²) loops over subscriptions.
-- Avoid re-authenticating inside loops.
-- Avoid fetching full SKU catalogs when filters are provided.
-- Respect ARM pagination (`nextLink`) efficiently.
-- Do not load large datasets into memory unnecessarily.
-- Future scalability should remain possible without architectural rewrite.
-
-## Plugin isolation rules
-
-Plugins must:
-
-- Be fully self-contained.
-- Not mutate global application state.
-- Not assume ordering of plugin registration.
-- Not introduce circular imports.
-- Not import heavy modules at import time.
-- Use lazy imports inside methods when possible.
-- Respect the core app’s authentication and context model.
-- Never override built-in routes.
-
-## Testing enforcement
-
-When modifying backend logic:
-
-- Update pytest coverage.
-- Maintain mocking of `requests.get` and `DefaultAzureCredential`.
-- Never require live Azure calls in unit tests.
-- Response schemas must remain backward compatible unless versioned.
-
-Breaking changes require:
-
-- Test updates
-- `CHANGELOG` update
-- New CalVer tag
-
-## Code generation expectations (for Copilot)
-
-When generating code:
-
-- Always include type annotations.
-- Prefer explicit return types.
-- Prefer small pure functions.
-- Prefer clarity over cleverness.
-- Avoid metaprogramming.
-- Avoid dynamic attribute access unless required.
+- Always include type annotations with explicit return types.
+- Prefer small pure functions. Prefer clarity over cleverness.
+- Avoid metaprogramming and dynamic attribute access.
 - Avoid magic constants — define named constants.
+
+## Contextual instructions
+
+Domain-specific guidance is loaded automatically via file instructions:
+
+- **`azure-api.instructions.md`** — ARM patterns, auth, pagination (when editing `azure_api/`)
+- **`obo-auth.instructions.md`** — OBO flow, sessions, admin roles (when editing auth files)
+- **`frontend.instructions.md`** — JS/CSS/template conventions (when editing `static/` or `templates/`)
+- **`plugin-dev.instructions.md`** — Plugin protocol, conventions, testing (when editing plugin code)

--- a/.github/instructions/azure-api.instructions.md
+++ b/.github/instructions/azure-api.instructions.md
@@ -1,0 +1,45 @@
+---
+description: "Azure ARM API patterns, authentication, pagination, and error handling for az-scout. USE WHEN editing files in azure_api/, or adding ARM calls."
+applyTo: "src/az_scout/azure_api/**"
+---
+
+# Azure API conventions
+
+## Authentication
+
+- Auth uses `DefaultAzureCredential` with optional `tenant_id` parameter.
+- When OBO is enabled (`AZ_SCOUT_CLIENT_ID` + `AZ_SCOUT_CLIENT_SECRET`), `_get_headers()` uses the OBO-exchanged token from the user's session.
+- CLI mode (`az-scout chat`, `az-scout mcp --stdio`) has no middleware, so `_get_headers()` falls back to `DefaultAzureCredential`.
+- The `_NO_TOKEN` sentinel prevents web requests from reaching `DefaultAzureCredential` when OBO is enabled.
+
+## ARM helpers
+
+All ARM calls **must** use the public helpers — never call `requests.get/post` directly:
+
+- `arm_get(url, tenant_id?)` — single GET with Bearer auth, retry on 429/5xx
+- `arm_post(url, body, tenant_id?)` — single POST with Bearer auth, retry
+- `arm_paginate(url, tenant_id?)` — GET with automatic `nextLink` pagination
+- `get_headers(tenant_id?)` — raw token for non-ARM endpoints (e.g. Retail Prices API)
+
+These provide: automatic Bearer-token auth, 429/5xx retry with exponential backoff, and structured error handling (`ArmAuthorizationError`, `ArmNotFoundError`, `ArmRequestError`).
+
+## API base URL
+
+`https://management.azure.com`
+
+## Error handling
+
+- Per-subscription errors must be included in the response, not fail the whole request.
+- Return error objects: `{"subscription_id": "...", "error": {"code": "...", "message": "..."}}`
+- Never raise unhandled exceptions for per-subscription failures.
+
+## Pagination
+
+Handle `nextLink` via `arm_paginate()` for all list endpoints. Never manually implement pagination loops.
+
+## Performance
+
+- Avoid O(n²) loops over subscriptions.
+- Avoid re-authenticating inside loops (token is cached per-tenant).
+- Avoid fetching full SKU catalogs when filters are provided.
+- Do not load large datasets into memory unnecessarily.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,52 @@
+---
+description: "Frontend conventions for az-scout: vanilla JS, CSS theming, Jinja2 templates, chat panel, marked.js. USE WHEN editing static JS/CSS files, HTML templates, or UI components."
+applyTo: "src/az_scout/static/**,src/az_scout/templates/**"
+---
+
+# Frontend conventions
+
+## JavaScript
+
+- Vanilla JS only — no npm, no bundler, no frameworks.
+- Use `const`/`let` (never `var`). Functions and variables use `camelCase`.
+- Biome lint is enforced via pre-commit hooks.
+- Scripts load order: auth.js → app.js → chat.js → plugins.js → plugin scripts → inline setup
+
+## CSS
+
+- Use CSS custom properties (defined in `:root`) for all theme colors.
+- Both light and dark themes **must** be maintained.
+- Dark mode uses `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` selectors.
+
+## HTML templates
+
+- Minimal Jinja2 templating in `templates/index.html`.
+- Static assets referenced via `url_for('static', ...)`.
+- Plugin tabs/actions injected dynamically from `get_plugin_metadata()`.
+
+## Shared globals (available to plugins)
+
+| Global | Description |
+|---|---|
+| `apiFetch(url)` | GET with JSON parsing + error handling |
+| `apiPost(url, body)` | POST helper |
+| `aiComplete(prompt, options?)` | Non-streaming AI completion (returns `{content, tool_calls}`) |
+| `aiEnabled` | `true` if AI chat/completion is configured |
+| `renderMarkdown(md)` | Render Markdown to HTML via marked.js |
+| `tenantQS(prefix)` | Returns `?tenantId=…` or `""` |
+| `escapeHtml(str)` | Escape HTML entities |
+| `subscriptions` | `[{id, name}]` array |
+| `regions` | `[{name, displayName}]` array |
+
+## Chat panel
+
+- `_renderMarkdown()` in chat.js uses marked.js with custom extensions:
+  - `[[choice text]]` → clickable chip buttons
+  - Tables get `chat-table` CSS class
+  - Headers use compact margins
+  - Lists of all-chip items become compact chip groups
+- Chat bubbles use `overflow-x: auto` for wide tables.
+
+## Context changes
+
+Plugins react to tenant/region changes via DOM events or MutationObserver on `#region-select`.

--- a/.github/instructions/obo-auth.instructions.md
+++ b/.github/instructions/obo-auth.instructions.md
@@ -1,0 +1,53 @@
+---
+description: "OBO authentication flow, session management, auth middleware, admin roles. USE WHEN editing auth routes, OBO token exchange, session cookies, or admin RBAC."
+applyTo: "src/az_scout/routes/auth.py,src/az_scout/azure_api/_obo.py,src/az_scout/auth.py,src/az_scout/templates/login.html"
+---
+
+# OBO (On-Behalf-Of) authentication
+
+Activated when `AZ_SCOUT_CLIENT_ID` and `AZ_SCOUT_CLIENT_SECRET` env vars are set.
+
+## Server-side auth flow
+
+1. User visits `/auth/login` → login page with sign-in options
+2. Click "Sign in" → `/auth/login/start` → redirect to Microsoft login
+3. Microsoft callback → `/auth/callback` → OBO exchange tested → session cookie created
+4. Session stored as HMAC-SHA256 signed HTTP-only cookie
+5. CSRF nonces on OAuth state parameter
+
+## Single-tenant-per-session model
+
+- Each session is scoped to the login tenant (extracted from JWT `tid` claim)
+- No cross-tenant OBO — to switch tenants, sign out and sign in again
+- `list_tenants` returns the single login tenant in OBO mode (no ARM call needed)
+
+## Auth context propagation
+
+- `_AuthContextMiddleware` (raw ASGI, not BaseHTTPMiddleware) reads tokens from:
+  - `Authorization: Bearer ...` header (MCP clients)
+  - Session cookie (web browser)
+- Sets module-level global + contextvars for downstream use
+- CLI mode has no middleware → falls through to `DefaultAzureCredential`
+
+## OBO validation at login
+
+- OBO exchange tested in callback before creating session
+- Consent/MFA/user errors redirect to login page with specific error messages
+- Session never created with invalid auth
+
+## Admin role
+
+- Entra ID App Role `Admin` from home tenant
+- `_require_admin()` guard on plugin management write endpoints
+- Only honored from the home tenant
+- `admin-only` CSS class for role-based UI visibility
+
+## Token cache
+
+- Keyed by full token hash + tenant to prevent cross-user cache pollution
+- Session TTL: 8 hours with sliding expiry
+
+## `OboTokenError`
+
+- Exception with `error_code` and optional `claims` fields
+- Handled by dedicated exception handler in `app.py` returning 401

--- a/.github/instructions/plugin-dev.instructions.md
+++ b/.github/instructions/plugin-dev.instructions.md
@@ -1,0 +1,64 @@
+---
+description: "Plugin development for az-scout: protocol, conventions, routes, MCP tools, tabs, chat modes, AI completion, testing. USE WHEN editing plugin_api.py, plugins.py, plugin_manager/, or developing a new plugin."
+applyTo: "src/az_scout/plugin_api.py,src/az_scout/plugins.py,src/az_scout/plugin_manager/**,docs/plugin-scaffold/**"
+---
+
+# Plugin development
+
+## Plugin protocol
+
+```python
+from az_scout.plugin_api import AzScoutPlugin, TabDefinition, ChatMode, NavbarAction
+
+class MyPlugin:
+    name = "my-plugin"       # unique identifier
+    version = "0.1.0"
+
+    def get_router(self) -> APIRouter | None: ...
+    def get_mcp_tools(self) -> list[Callable] | None: ...
+    def get_static_dir(self) -> Path | None: ...
+    def get_tabs(self) -> list[TabDefinition] | None: ...
+    def get_chat_modes(self) -> list[ChatMode] | None: ...
+    def get_navbar_actions(self) -> list[NavbarAction] | None: ...
+```
+
+All methods optional — return `None` to skip.
+
+## Conventions
+
+- **Package layout:** src-layout (`src/az_scout_myplugin/`) with hatchling
+- **Naming:** Package `az-scout-plugin-{name}`, module `az_scout_{name}`
+- **Entry point:** `[project.entry-points."az_scout.plugins"]`
+- **Lazy imports:** Inside methods to avoid circular imports at discovery time
+- **Static dir:** `Path(__file__).parent / "static"` at module level
+
+## AI completion helpers
+
+```python
+from az_scout.plugin_api import is_ai_enabled, plugin_ai_complete
+
+if is_ai_enabled():
+    result = await plugin_ai_complete(
+        "Analyse this data...",
+        system_prompt="You are an expert.",
+        region="eastus",
+        cache_ttl=600,  # 10 min cache, 0 to bypass
+    )
+    # result = {"content": "...", "tool_calls": [...]}
+```
+
+JS: `if (aiEnabled) { const r = await aiComplete("...", {cacheTtl: 600}); }`
+
+## Isolation rules
+
+- Fully self-contained — no global state mutation
+- No circular imports — use lazy imports
+- No heavy imports at module import time
+- Respect core authentication and context model
+- Never override built-in routes
+
+## Testing
+
+- Use `pytest` + `httpx` with `TestClient`
+- Mock `discover_plugins()` to inject test plugin instances
+- Mock Azure API calls — never require live Azure in tests

--- a/.github/instructions/plugin-scaffold.instructions.md
+++ b/.github/instructions/plugin-scaffold.instructions.md
@@ -1,0 +1,67 @@
+---
+description: "az-scout plugin conventions and API contract. Activates when working on plugin code using the az_scout_ module naming convention."
+applyTo: "**/az_scout_*/**/*.py"
+---
+
+# az-scout Plugin Conventions
+
+You are working on an az-scout plugin. Follow these conventions.
+
+## Plugin protocol
+
+Your plugin class must satisfy the `AzScoutPlugin` protocol from `az_scout.plugin_api`:
+
+```python
+class MyPlugin:
+    name = "my-plugin"       # unique identifier (kebab-case)
+    version = "0.1.0"
+
+    def get_router(self) -> APIRouter | None: ...
+    def get_mcp_tools(self) -> list[Callable] | None: ...
+    def get_static_dir(self) -> Path | None: ...
+    def get_tabs(self) -> list[TabDefinition] | None: ...
+    def get_chat_modes(self) -> list[ChatMode] | None: ...
+    def get_navbar_actions(self) -> list[NavbarAction] | None: ...
+
+plugin = MyPlugin()  # module-level instance
+```
+
+## Key imports from az_scout
+
+```python
+from az_scout.plugin_api import (
+    AzScoutPlugin, TabDefinition, ChatMode, NavbarAction,
+    get_plugin_logger, PluginError, PluginValidationError, PluginUpstreamError,
+    is_ai_enabled, plugin_ai_complete,
+)
+from az_scout.azure_api import arm_get, arm_post, arm_paginate, get_headers
+```
+
+## Conventions
+
+- **Lazy imports** inside protocol methods (avoid circular imports at discovery)
+- **Routes** mounted at `/plugins/{name}/` — use relative paths in the router
+- **MCP tools** are plain functions with type annotations + descriptive docstrings
+- **Static dir**: `Path(__file__).parent / "static"`
+- **Type annotations** on all functions (`disallow_untyped_defs = true`)
+- **Line length**: 100, ruff rules: `E, F, I, W, UP, B, SIM`
+- **No global mutable state** — plugins must be fully self-contained
+
+## AI completion (optional)
+
+```python
+if is_ai_enabled():
+    result = await plugin_ai_complete(
+        "Analyse this data...",
+        system_prompt="You are a domain expert.",
+        region="eastus",
+        cache_ttl=600,  # seconds, 0 to bypass cache
+    )
+    content = result["content"]  # markdown text
+    tools = result["tool_calls"]  # list of tool call metadata
+```
+
+## JS globals available to plugin scripts
+
+`apiFetch`, `apiPost`, `aiComplete`, `aiEnabled`, `renderMarkdown`,
+`tenantQS`, `escapeHtml`, `subscriptions`, `regions`

--- a/.github/skills/create-plugin/SKILL.md
+++ b/.github/skills/create-plugin/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: create-plugin
+description: "Scaffold a new az-scout plugin from the template. USE WHEN: create plugin, new plugin, scaffold plugin, build a plugin for az-scout."
+argument-hint: "Describe the plugin you want to create (e.g. 'a plugin that shows Azure Batch SKU availability')"
+---
+
+# Create az-scout Plugin
+
+Scaffold a new az-scout plugin using the built-in generator.
+
+## When to Use
+
+- Creating a brand-new az-scout plugin from scratch
+- Starting a new plugin project with the correct structure
+
+## Procedure
+
+### 1. Run the scaffold generator
+
+Run the interactive scaffold command:
+
+```bash
+uv run python tools/plugin-scaffold/create_plugin.py
+```
+
+This prompts for:
+- **Plugin name** (e.g. `batch-sku`) → creates `az-scout-plugin-batch-sku`
+- **Description**
+- **Author name and email**
+- **Capabilities** — which extension points to include:
+  - API routes (FastAPI router)
+  - MCP tools (AI agent tools)
+  - UI tab (frontend tab with JS/CSS)
+  - AI chat mode (custom chat persona)
+  - Navbar action (offcanvas panel button)
+
+### 2. Review the generated structure
+
+The generator creates a complete src-layout package:
+
+```
+az-scout-plugin-{name}/
+├── pyproject.toml              # hatchling, entry point, ruff, mypy
+├── README.md
+├── LICENSE.txt
+├── src/az_scout_{name}/
+│   ├── __init__.py             # Plugin class + module-level instance
+│   ├── routes.py               # FastAPI router (if routes selected)
+│   ├── tools.py                # MCP tool functions (if tools selected)
+│   └── static/
+│       ├── js/{name}-tab.js    # Tab JS (if tab selected)
+│       └── css/{name}-tab.css  # Tab CSS (if tab selected)
+└── tests/
+    └── test_{name}.py          # Basic test scaffold
+```
+
+### 3. Install for development
+
+```bash
+cd az-scout-plugin-{name}
+uv pip install -e .
+```
+
+### 4. Key conventions
+
+Refer to [plugin-dev.instructions.md](../../instructions/plugin-dev.instructions.md) for full conventions. Key points:
+
+- **Entry point** in `pyproject.toml`: `[project.entry-points."az_scout.plugins"]`
+- **Lazy imports** inside protocol methods to avoid circular imports
+- **Routes** mounted at `/plugins/{name}/` — use relative paths
+- **MCP tools** are plain functions with type annotations + docstrings
+- **Static dir** defined as `Path(__file__).parent / "static"`
+- **AI completion**: Use `plugin_ai_complete()` / `aiComplete()` for inline AI recommendations
+- **AI availability**: Check `is_ai_enabled()` (Python) or `aiEnabled` (JS) before calling AI
+
+### 5. Existing plugin examples
+
+Study these plugins for patterns:
+
+| Plugin | Capabilities | Notable patterns |
+|---|---|---|
+| `internal_plugins/topology/` | Routes, MCP tool, tab | Zone mapping visualization with D3.js |
+| `internal_plugins/planner/` | Routes, MCP tools, tab, chat mode | Multi-tool chat mode, deployment planning |
+| `az-scout-plugin-avs-sku` | Routes, MCP tools, tab, chat mode | AVS-specific SKU analysis |
+| `az-scout-plugin-odcr-coverage` | Routes, MCP tools, tab, chat mode, navbar action | ODCR analysis with AI recommendations |
+
+### 6. Quality checks
+
+Before publishing, ensure:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/
+uv run pytest
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Added
+
+- **File instructions** – Split `copilot-instructions.md` (390→93 lines) into 5 domain-specific file instructions that load automatically when editing relevant files: `azure-api`, `obo-auth`, `frontend`, `plugin-dev`, `plugin-scaffold`.
+- **`create-plugin` skill** – Interactive skill (`/create-plugin`) that guides plugin scaffold generation, conventions, and quality checks.
+
 ## [2026.3.7] - 2026-03-26
 
 ### Fixed


### PR DESCRIPTION
## Description

Split the monolithic `copilot-instructions.md` (390 lines) into a lean core (93 lines) plus domain-specific file instructions that load automatically when editing relevant files. Also adds a `create-plugin` skill for guided plugin scaffolding.

### Changes

**File instructions** (`.github/instructions/`):

| File | `applyTo` | Content |
|---|---|---|
| `azure-api.instructions.md` | `src/az_scout/azure_api/**` | ARM helpers, auth, pagination, error handling |
| `obo-auth.instructions.md` | Auth files (`routes/auth.py`, `_obo.py`, `auth.py`, `login.html`) | OBO flow, sessions, admin roles, middleware |
| `frontend.instructions.md` | `src/az_scout/static/**`, `templates/**` | Vanilla JS, CSS theming, chat panel, shared globals |
| `plugin-dev.instructions.md` | `plugin_api.py`, `plugins.py`, `plugin_manager/**`, `plugin-scaffold/**` | Plugin protocol, conventions, AI completion, testing |
| `plugin-scaffold.instructions.md` | `**/az_scout_*/**/*.py` | Activates in any plugin repo following the naming convention |

**Skill** (`.github/skills/create-plugin/`):
- Interactive `/create-plugin` slash command
- Guides through scaffold generation, conventions, and quality checks
- References existing plugin examples (topology, planner, ODCR, AVS SKU)

**`copilot-instructions.md`** slimmed to core essentials:
- Project overview and structure
- Code conventions and quality checks
- Versioning and design rules
- Pointer to contextual instructions

### Why

The full 390-line file was loaded into every agent context window regardless of what you were working on. OBO auth details don't help when editing CSS. Plugin conventions don't help when debugging ARM pagination. File instructions load only the relevant domain knowledge.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors