### PR TITLE
feat(plugin-manager): redesign with shared catalog UI and card layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,25 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 - **`create-plugin` skill** – Interactive skill (`/create-plugin`) that guides plugin scaffold generation, conventions, and quality checks.
 - **Auth guard on API routes** – `require_auth` FastAPI dependency enforces OBO authentication on discovery, chat, AI completion, and all plugin API routes. Unauthenticated requests return 401 when OBO is enabled; in non-OBO mode the guard is a no-op.
 - **Native extension detection** – Plugin install/update routes detect newly installed compiled extensions (`.so`, `.pyd`, `.dylib`) and return `restart_required: true` in the API response, prompting users to restart the instance.
-- **Plugin Manager UI redesign** – Merged "Installed (UI)" and "Loaded (runtime)" into a single "Installed plugins" table showing all plugins with source, status, and management actions. Catalog section moved to the top with a filter input. Manual install moved to a collapsible section at the bottom.
+- **Shared catalog UI** – New `catalog.html` fragment renders plugin cards from `catalog.json` with filter, tags, authors, PyPI badges, long description truncation, and a 3-tab install modal (Plugin Manager / uv / pip). Used by both the Plugin Manager and future docs/standalone catalog pages.
+- **Plugin Manager redesign** – Switched from offcanvas to a responsive modal. Catalog cards rendered from shared `catalog.html` are progressively enhanced with install/update/uninstall buttons. Built-in, external, and dependency plugins are detected and displayed with appropriate badges and actions.
+- **Built-in plugin metadata** – Internal plugins (topology, planner) now have `display_name` and `description` attributes exposed in the plugin API.
+- **Dependency plugin management** – Plugins installed as dependencies into the packages directory (e.g. via another plugin) are now detected and manageable (uninstall) from the UI instead of being labeled "external".
 - **Restart banner** – Plugin Manager shows a warning banner when a plugin with native extensions is installed, indicating a container restart is required.
 - **Global status bar** – Plugin Manager shows an inline status bar with spinner during install/uninstall/update operations.
+- **Auto update check** – Plugin Manager silently checks for updates when opened, showing results immediately.
+- **CSP: shields.io** – Added `img.shields.io` to the Content-Security-Policy `img-src` directive for PyPI version badges.
 
 ### Changed
 
-- **Plugin catalog docs** – Catalog page now features a prominent button linking to the full [plugin-catalog.az-scout.com](https://plugin-catalog.az-scout.com) experience while keeping the simplified table listing inline.
+- **Plugin Manager layout** – Replaced table-based views with a card grid layout matching the catalog style. All plugins (catalog, installed, built-in, external) shown in a unified card grid with a filter, action bar, and manual install card.
+- **Modal sizing** – Plugin Manager modal uses `modal-xl` with `max-width: min(95vw, 1400px)` for responsive width.
+- **Plugin list API** – `/api/plugins` response now includes `display_name`, `description`, `in_packages_dir` fields for loaded plugins to support the enhanced UI.
 
 ### Removed
 
 - **Duplicate prompts** – Removed `add-plugin-to-catalog.prompt.md` and `review-plugin.prompt.md` from the core repo. These now live canonically in the [plugin-catalog](https://github.com/az-scout/plugin-catalog) repo.
+- **Separate catalog table** – Removed the old table-based catalog/installed views in the Plugin Manager in favour of the shared card-based catalog UI.
 
 ## [2026.3.7] - 2026-03-26
 

--- a/src/az_scout/app.py
+++ b/src/az_scout/app.py
@@ -155,7 +155,7 @@ _CSP_POLICY = "; ".join(
         "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net d3js.org",
         "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net",
         "font-src 'self' cdn.jsdelivr.net",
-        "img-src 'self' data: https://github.com https://*.githubusercontent.com",
+        "img-src 'self' data: https://github.com https://*.githubusercontent.com https://img.shields.io",
         "connect-src 'self' cdn.jsdelivr.net https://plugin-catalog.az-scout.com",
         "frame-ancestors 'none'",
     ]

--- a/src/az_scout/internal_plugins/planner/__init__.py
+++ b/src/az_scout/internal_plugins/planner/__init__.py
@@ -22,8 +22,12 @@ class PlannerPlugin:
     """Internal plugin: Deployment Planner tab."""
 
     name = "planner"
+    display_name = "Deployment Planner"
     version = __version__
     internal = True
+    description = (
+        "Plan VM deployments with SKU availability, pricing, spot scores, and capacity confidence."
+    )
 
     def get_router(self) -> APIRouter | None:
         from az_scout.internal_plugins.planner.routes import router

--- a/src/az_scout/internal_plugins/topology/__init__.py
+++ b/src/az_scout/internal_plugins/topology/__init__.py
@@ -22,8 +22,10 @@ class TopologyPlugin:
     """Internal plugin: AZ Topology tab."""
 
     name = "topology"
+    display_name = "AZ Topology"
     version = __version__
     internal = True  # Flag for registration logic
+    description = "Visualize logical-to-physical availability zone mappings across subscriptions."
 
     def get_router(self) -> APIRouter | None:
         from az_scout.internal_plugins.topology.routes import router

--- a/src/az_scout/plugins.py
+++ b/src/az_scout/plugins.py
@@ -237,6 +237,16 @@ def get_loaded_plugins() -> list[AzScoutPlugin]:
     return list(_loaded_plugins)
 
 
+def is_in_packages_dir(dist_name: str) -> bool:
+    """Return True if *dist_name* is installed in the plugin packages directory."""
+    if not dist_name or not _PACKAGES_DIR.exists():
+        return False
+    for dist in importlib.metadata.distributions(path=[str(_PACKAGES_DIR)]):
+        if dist.name == dist_name:
+            return True
+    return False
+
+
 def get_plugin_chat_modes() -> dict[str, ChatMode]:
     """Return all chat modes contributed by plugins, keyed by mode ID."""
     return dict(_plugin_chat_modes)

--- a/src/az_scout/routes/__init__.py
+++ b/src/az_scout/routes/__init__.py
@@ -9,7 +9,12 @@ from pydantic import BaseModel
 
 from az_scout import plugin_manager
 from az_scout.plugin_manager._installer import has_new_native_extensions, snapshot_native_files
-from az_scout.plugins import _plugin_dist_names, get_loaded_plugins, reload_plugins
+from az_scout.plugins import (
+    _plugin_dist_names,
+    get_loaded_plugins,
+    is_in_packages_dir,
+    reload_plugins,
+)
 
 _RESTART_WARNING = (
     "This plugin installed native compiled extensions (e.g. numpy). "
@@ -98,9 +103,12 @@ async def list_plugins() -> JSONResponse:
             "loaded": [
                 {
                     "name": p.name,
+                    "display_name": getattr(p, "display_name", ""),
                     "version": p.version,
                     "internal": bool(getattr(p, "internal", False)),
                     "distribution_name": _plugin_dist_names.get(p.name, ""),
+                    "description": getattr(p, "description", ""),
+                    "in_packages_dir": is_in_packages_dir(_plugin_dist_names.get(p.name, "")),
                 }
                 for p in loaded
             ],

--- a/src/az_scout/static/html/catalog.html
+++ b/src/az_scout/static/html/catalog.html
@@ -1,0 +1,268 @@
+<!-- Plugin Catalog — shared fragment
+     Used by: docs site (standalone), plugin manager (enhanced with PM features).
+     Expects Bootstrap 5 CSS + JS to be loaded by the host page.
+     Fetches catalog.json from the remote catalog URL and renders plugin cards.
+     Host pages can set window.CATALOG_JSON_URL before this script runs.
+     After rendering, calls window.onCatalogRendered(plugins) if defined.
+-->
+<style>
+  .catalog-card-plugin { transition: border-color 0.15s; min-height: 180px; }
+  .catalog-card-plugin:hover { border-color: var(--bs-primary) !important; }
+  .catalog-card-plugin.wip {
+    border-color: var(--bs-warning) !important;
+    border-style: dashed !important;
+    opacity: 0.75;
+  }
+  .catalog-card-plugin.wip:hover { opacity: 1; }
+  .catalog-tag-wip {
+    --bs-badge-color: var(--bs-warning) !important;
+    background-color: rgba(var(--bs-warning-rgb), 0.15) !important;
+    border: 1px solid var(--bs-warning) !important;
+  }
+  .catalog-authors img { width: 20px; height: 20px; border-radius: 50%; vertical-align: middle; }
+  .catalog-long-desc {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .catalog-long-desc.expanded {
+    -webkit-line-clamp: unset;
+    overflow: visible;
+  }
+  .catalog-expand-btn {
+    cursor: pointer;
+    font-size: 0.7rem;
+    color: var(--bs-primary);
+    border: none;
+    background: none;
+    padding: 0;
+  }
+  .catalog-expand-btn:hover { text-decoration: underline; }
+  .catalog-pypi-badge img { height: 18px; vertical-align: middle; }
+</style>
+
+<div id="catalog-container">
+  <div class="mb-2">
+    <input type="search" class="form-control form-control-sm" id="catalog-filter"
+           placeholder="Filter plugins…" autocomplete="off">
+  </div>
+  <div class="alert alert-secondary small py-2 mb-3" role="alert">
+    <strong>Disclaimer:</strong> Plugins listed in this catalog are reviewed before inclusion but are not
+    audited for security or correctness. Installation and usage of plugins is at your own risk and
+    is not the responsibility of az-scout maintainers. This catalog is a convenience listing of
+    declared and commonly used community plugins — plugins can also exist outside of this catalog
+    and be installed manually by users.
+  </div>
+  <div class="text-body-secondary small py-2" id="catalog-count"></div>
+  <div class="text-center text-body-secondary py-4" id="catalog-loading">
+    <div class="spinner-border spinner-border-sm me-2" role="status"></div>Loading catalog…
+  </div>
+  <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3" id="catalog-grid"></div>
+  <div class="text-center text-body-secondary py-3 d-none" id="catalog-empty">No plugins match the filter.</div>
+</div>
+
+<script>
+(function() {
+  const catalogUrl = window.CATALOG_JSON_URL || "https://plugin-catalog.az-scout.com/catalog.json";
+  const grid = document.getElementById("catalog-grid");
+  const loading = document.getElementById("catalog-loading");
+  const emptyEl = document.getElementById("catalog-empty");
+  const filterInput = document.getElementById("catalog-filter");
+  let plugins = [];
+
+  function esc(s) {
+    if (!s) return "";
+    const d = document.createElement("div");
+    d.textContent = s;
+    return d.innerHTML.replace(/'/g, "&#39;");
+  }
+
+  function renderCard(p) {
+    const isWip = (p.tags || []).some(function(t) { return t.toLowerCase() === "wip"; });
+
+    const authors = (p.authors || []).map(function(a) {
+      return '<a href="https://github.com/' + esc(a) + '" class="text-body-secondary text-decoration-none" title="' + esc(a) + '">' +
+        '<img class="catalog-authors" src="https://github.com/' + esc(a) + '.png?size=40" alt="' + esc(a) + '"> ' + esc(a) + '</a>';
+    }).join(", ");
+
+    const tags = (p.tags || []).map(function(t) {
+      if (t.toLowerCase() === "wip") {
+        return '<span class="badge catalog-tag-wip" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This plugin is under development and may experience instability or major changes.">🚧 ' + esc(t) + '</span>';
+      }
+      return '<span class="badge text-bg-info bg-opacity-10 border border-info-subtle text-info-emphasis">' + esc(t) + '</span>';
+    }).join(" ");
+
+    const sourceBadge = p.source === "pypi"
+      ? '<a href="https://pypi.org/project/' + esc(p.name) + '/" target="_blank" rel="noopener" class="catalog-pypi-badge"><img src="https://img.shields.io/pypi/v/' + esc(p.name) + '?label=pypi" alt="PyPI"></a>'
+      : '<span class="badge text-bg-secondary text-uppercase" style="font-size:0.65rem">github</span>';
+
+    const installSource = p.source === "pypi" ? p.name : p.repository;
+
+    return '<div class="col catalog-card-col" data-catalog-name="' + esc(p.name) + '" data-catalog-source="' + esc(installSource) + '" data-catalog-tags="' + esc((p.tags||[]).join(" ")) + '" data-catalog-desc="' + esc(p.description) + '">' +
+      '<div class="card catalog-card-plugin h-100' + (isWip ? ' wip' : '') + '">' +
+        '<div class="card-body d-flex flex-column gap-1" style="font-size:0.85rem;">' +
+          '<div class="d-flex align-items-baseline justify-content-between gap-2">' +
+            '<span class="d-flex align-items-center gap-1">' +
+              '<a href="' + esc(p.repository) + '" class="fw-semibold text-primary text-decoration-none" target="_blank" rel="noopener">' + esc(p.name) + '</a>' +
+              '<button class="btn btn-sm p-0 border-0 text-body-secondary" onclick="event.stopPropagation(); catalogCopyText(null, this, \'' + esc(p.name) + '\')" title="Copy name" style="font-size:0.7rem">\ud83d\udccb</button>' +
+            '</span> ' +
+            sourceBadge +
+          '</div>' +
+          '<p class="text-body-secondary small mb-0">' + esc(p.description) + '</p>' +
+          (p.long_description ? '<p class="catalog-long-desc text-body-tertiary mb-0" style="font-size:0.75rem">' + esc(p.long_description) + '</p>' +
+            '<button class="catalog-expand-btn" onclick="this.previousElementSibling.classList.toggle(&#39;expanded&#39;); this.textContent = this.previousElementSibling.classList.contains(&#39;expanded&#39;) ? &#39;Show less&#39; : &#39;Show more&#39;">Show more</button>' : '') +
+          '<div class="d-flex flex-wrap gap-1">' + tags + '</div>' +
+          '<div class="d-flex align-items-center justify-content-between mt-auto pt-1">' +
+            '<span class="small text-body-secondary catalog-authors">' + authors + '</span>' +
+            '<span class="d-flex align-items-center gap-2 catalog-actions">' +
+              '<button class="btn btn-sm btn-outline-primary" onclick="catalogShowInstall(\'' + esc(p.name) + '\', \'' + esc(installSource) + '\')"><i class="bi bi-download me-1"></i>Install</button>' +
+            '</span>' +
+          '</div>' +
+        '</div>' +
+      '</div>' +
+    '</div>';
+  }
+
+  function filterCards() {
+    const q = (filterInput.value || "").toLowerCase().trim();
+    const cards = grid.querySelectorAll(".catalog-card-col");
+    let visible = 0;
+    cards.forEach(function(col) {
+      var text = [col.dataset.catalogName, col.dataset.catalogTags, col.dataset.catalogDesc].join(" ").toLowerCase();
+      var show = !q || text.indexOf(q) !== -1;
+      col.style.display = show ? "" : "none";
+      if (show) visible++;
+    });
+    emptyEl.classList.toggle("d-none", visible > 0);    var countEl = document.getElementById("catalog-count");
+    if (countEl) {
+      countEl.textContent = q
+        ? visible + " of " + plugins.length + " plugin(s) matching \"" + filterInput.value + "\""
+        : plugins.length + " plugin(s)";
+    }  }
+
+  fetch(catalogUrl)
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      plugins = data;
+      if (loading) loading.remove();
+      grid.innerHTML = plugins.map(renderCard).join("");
+      var countEl = document.getElementById("catalog-count");
+      if (countEl) countEl.textContent = plugins.length + " plugin(s)";
+      // Initialize Bootstrap tooltips
+      if (typeof bootstrap !== "undefined") {
+        grid.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) { new bootstrap.Tooltip(el); });
+      }
+      if (typeof window.onCatalogRendered === "function") {
+        window.onCatalogRendered(plugins);
+      }
+    })
+    .catch(function() {
+      if (loading) loading.textContent = "Failed to load plugin catalog.";
+    });
+
+  if (filterInput) {
+    filterInput.addEventListener("input", filterCards);
+  }
+
+  // Install modal (used in standalone/docs context, overridden by PM)
+  window.catalogShowInstall = function(name, source) {
+    var title = document.getElementById("catalog-install-title");
+    var srcPm = document.getElementById("catalog-src-pm");
+    var srcUv = document.getElementById("catalog-src-uv");
+    var srcPip = document.getElementById("catalog-src-pip");
+    if (title) title.textContent = "Install " + name;
+    if (srcPm) srcPm.textContent = source;
+    if (srcUv) srcUv.textContent = "uv pip install " + source;
+    if (srcPip) srcPip.textContent = "pip install " + source;
+    // Reset to first tab
+    var firstTab = document.getElementById("catalog-tab-pm");
+    if (firstTab && typeof bootstrap !== "undefined") {
+      bootstrap.Tab.getOrCreateInstance(firstTab).show();
+    }
+    var modalEl = document.getElementById("catalog-install-modal");
+    if (modalEl && typeof bootstrap !== "undefined") {
+      bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+  };
+
+  window.catalogCopyText = function(id, btn, text) {
+    var copyText = text || document.getElementById(id).textContent;
+    navigator.clipboard.writeText(copyText).then(function() {
+      if (typeof bootstrap !== "undefined") {
+        var tooltip = bootstrap.Tooltip.getOrCreateInstance(btn, {
+          title: "Copied!", trigger: "manual", placement: "top"
+        });
+        tooltip.show();
+        setTimeout(function() { tooltip.hide(); tooltip.dispose(); }, 1500);
+      }
+    });
+  };
+})();
+</script>
+
+<!-- Install modal (standalone/docs context) -->
+<div class="modal fade" id="catalog-install-modal" tabindex="-1" aria-labelledby="catalog-install-title" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="catalog-install-title"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="nav nav-tabs nav-fill mb-3" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="catalog-tab-pm" data-bs-toggle="tab" data-bs-target="#catalog-pane-pm" type="button" role="tab">Plugin Manager</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="catalog-tab-uv" data-bs-toggle="tab" data-bs-target="#catalog-pane-uv" type="button" role="tab">uv</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="catalog-tab-pip" data-bs-toggle="tab" data-bs-target="#catalog-pane-pip" type="button" role="tab">pip</button>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div class="tab-pane fade show active" id="catalog-pane-pm" role="tabpanel">
+            <p class="small text-body-secondary">Copy the identifier below and paste it in the az-scout Plugin Manager install field.</p>
+            <div class="input-group mb-2">
+              <code class="form-control text-center bg-body-tertiary font-monospace" id="catalog-src-pm" readonly style="font-size:0.8rem"></code>
+              <button class="btn btn-outline-secondary" onclick="catalogCopyText('catalog-src-pm', this)" title="Copy">📋</button>
+            </div>
+            <h6 class="text-body-secondary">Steps</h6>
+            <ol class="small text-body-secondary">
+              <li>Open your az-scout instance</li>
+              <li>Click the <strong>🧩 Plugin Manager</strong> button in the top navigation bar</li>
+              <li>Open <strong>Manual install</strong> and paste the identifier in the source field</li>
+              <li>Click <strong>Install</strong> and wait for confirmation</li>
+            </ol>
+            <div class="small text-body-secondary border-start border-3 ps-3 mt-2">
+              ℹ️ On managed instances, the Plugin Manager is accessible only to instance administrators.
+            </div>
+          </div>
+          <div class="tab-pane fade" id="catalog-pane-uv" role="tabpanel">
+            <p class="small text-body-secondary">Install using <strong>uv</strong> in the az-scout environment:</p>
+            <div class="input-group mb-2">
+              <code class="form-control text-center bg-body-tertiary font-monospace" id="catalog-src-uv" readonly style="font-size:0.8rem"></code>
+              <button class="btn btn-outline-secondary" onclick="catalogCopyText('catalog-src-uv', this)" title="Copy">📋</button>
+            </div>
+            <div class="small text-body-secondary border-start border-3 ps-3">Restart az-scout after installation.</div>
+          </div>
+          <div class="tab-pane fade" id="catalog-pane-pip" role="tabpanel">
+            <p class="small text-body-secondary">Install using <strong>pip</strong> in the az-scout environment:</p>
+            <div class="input-group mb-2">
+              <code class="form-control text-center bg-body-tertiary font-monospace" id="catalog-src-pip" readonly style="font-size:0.8rem"></code>
+              <button class="btn btn-outline-secondary" onclick="catalogCopyText('catalog-src-pip', this)" title="Copy">📋</button>
+            </div>
+            <div class="small text-body-secondary border-start border-3 ps-3">Restart az-scout after installation.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Footer -->
+<div class="border-top text-center text-body-secondary small py-3 mt-3">
+  <a href="https://github.com/az-scout/plugin-catalog" target="_blank" rel="noopener">Plugin catalog repository</a> ·
+  <a href="https://github.com/az-scout/plugin-catalog/edit/main/catalog.json" target="_blank" rel="noopener">Submit your plugin</a>
+</div>

--- a/src/az_scout/static/html/plugins.html
+++ b/src/az_scout/static/html/plugins.html
@@ -15,137 +15,69 @@
         <span id="pm-global-status-text">Working…</span>
     </div>
 
-    <!-- Plugin catalog -->
-    <div>
-        <div class="card">
-            <div class="card-header">
-                <a href="https://plugin-catalog.az-scout.com" target="_blank" rel="noopener"
-                   class="text-decoration-none text-primary fw-semibold">
-                    Explore plugin catalog
-                    <i class="bi bi-box-arrow-up-right ms-1" style="font-size:0.8em;"></i>
-                </a>
-            </div>
-            <div class="card-body p-0">
-                <div class="p-2">
-                    <input type="text" class="form-control form-control-sm" id="pm-catalog-filter"
-                           placeholder="Filter by name…" autocomplete="off">
-                </div>
-                <div id="pm-recommended-empty" class="text-center text-body-secondary py-3">
-                    No plugins in catalog
-                </div>
-                <div id="pm-recommended-table-wrap" class="d-none">
-                    <div class="table-responsive">
-                    <table class="table table-sm table-hover mb-0" style="font-size:0.82rem;">
-                        <thead>
-                            <tr>
-                                <th>Plugin</th>
-                                <th>Description</th>
-                                <th>Source</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody id="pm-recommended-tbody"></tbody>
-                    </table>
+    <!-- Action bar -->
+    <div class="d-flex align-items-center justify-content-end gap-1">
+        <button class="btn btn-outline-info btn-sm py-0 px-2" id="pm-check-updates-btn"
+                onclick="pmCheckUpdates()" title="Check for updates">
+            <i class="bi bi-arrow-repeat me-1"></i>Check updates
+        </button>
+        <button class="btn btn-primary btn-sm py-0 px-2 d-none" id="pm-update-all-btn"
+                onclick="pmUpdateAll()" title="Update all plugins">
+            <i class="bi bi-cloud-download me-1"></i>Update all
+        </button>
+    </div>
+
+    <!-- Plugin catalog (loaded from catalog.html, enhanced with PM features) -->
+    <div id="pm-catalog-host">
+        <!-- catalog.html is injected here by plugins.js -->
+    </div>
+
+    <!-- Manual plugin install card (appended to the catalog grid by plugins.js) -->
+    <template id="pm-manual-install-template">
+        <div class="col catalog-card-col pm-dynamic-card" data-catalog-name="manual-install" data-catalog-tags="" data-catalog-desc="manual install">
+            <div class="card catalog-card-plugin h-100 border-info">
+                <div class="card-body d-flex flex-column gap-2" style="font-size:0.85rem;">
+                    <div class="d-flex align-items-baseline justify-content-between gap-2">
+                        <span class="fw-semibold text-info"><i class="bi bi-plus-circle me-1"></i>Manual install</span>
+                    </div>
+                    <p class="text-body-secondary small mb-0">Install a plugin from a PyPI package name or a public GitHub repository URL.</p>
+                    <div class="mt-2">
+                        <div class="mb-2">
+                            <input type="text" class="form-control form-control-sm" id="pm-repo-url"
+                                   placeholder="PyPI package name or https://github.com/owner/repo" autocomplete="off">
+                        </div>
+                        <div class="mb-2">
+                            <input type="text" class="form-control form-control-sm" id="pm-ref"
+                                   placeholder="Version / ref (optional)" autocomplete="off">
+                        </div>
+                        <div class="d-flex gap-2">
+                            <button class="btn btn-outline-primary btn-sm" id="pm-validate-btn" onclick="pmValidate()">
+                                <i class="bi bi-check-circle me-1"></i>Validate
+                            </button>
+                            <button class="btn btn-primary btn-sm" id="pm-install-btn" onclick="pmInstall()" disabled>
+                                <i class="bi bi-download me-1"></i>Install
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Validation result -->
+                    <div id="pm-validation-result" class="d-none mt-2">
+                        <hr class="my-2">
+                        <div id="pm-val-status" class="mb-1"></div>
+                        <div id="pm-val-meta" class="mb-1" style="font-size:0.82rem;"></div>
+                        <div id="pm-val-errors" class="d-none"></div>
+                        <div id="pm-val-warnings" class="d-none"></div>
+                    </div>
+
+                    <!-- Spinner -->
+                    <div id="pm-spinner" class="d-none mt-2 text-center">
+                        <div class="spinner-border spinner-border-sm text-primary" role="status">
+                            <span class="visually-hidden">Loading…</span>
+                        </div>
+                        <span class="ms-2 text-body-secondary" id="pm-spinner-text">Validating…</span>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-
-    <!-- Installed plugins (all: built-in + UI-installed) -->
-    <div>
-        <div class="card">
-            <div class="card-header d-flex align-items-center justify-content-between">
-                <span><i class="bi bi-box-seam me-1"></i>Installed plugins</span>
-                <div class="d-flex gap-1">
-                    <button class="btn btn-outline-info btn-sm py-0 px-2" id="pm-check-updates-btn"
-                            onclick="pmCheckUpdates()" title="Check for updates">
-                        <i class="bi bi-arrow-repeat me-1"></i>Check updates
-                    </button>
-                    <button class="btn btn-primary btn-sm py-0 px-2 d-none" id="pm-update-all-btn"
-                            onclick="pmUpdateAll()" title="Update all plugins">
-                        <i class="bi bi-cloud-download me-1"></i>Update all
-                    </button>
-                </div>
-            </div>
-            <div class="card-body p-0">
-                <div id="pm-installed-empty" class="text-center text-body-secondary py-3">
-                    No plugins installed
-                </div>
-                <div id="pm-installed-table-wrap" class="d-none">
-                    <div class="table-responsive">
-                    <table class="table table-sm table-hover mb-0" style="font-size:0.82rem;">
-                        <thead>
-                            <tr>
-                                <th>Plugin</th>
-                                <th>Version</th>
-                                <th>Source</th>
-                                <th>Status</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody id="pm-installed-tbody"></tbody>
-                    </table>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Manual plugin install (collapsible) -->
-    <div>
-        <div class="card border-info">
-            <div class="card-header p-0">
-                <button class="btn w-100 text-start text-white text-decoration-none border-0 rounded-0 py-2 px-3"
-                        id="pm-add-toggle"
-                        type="button"
-                        data-pm-collapse-target="#pm-add-collapse"
-                        aria-expanded="false"
-                        aria-controls="pm-add-collapse">
-                    <i class="bi bi-plus-circle me-1"></i>Manual plugin install
-                    <i class="bi bi-chevron-down float-end"></i>
-                </button>
-            </div>
-            <div id="pm-add-collapse" class="collapse">
-            <div class="card-body">
-                <div class="mb-2">
-                    <label for="pm-repo-url" class="form-label form-label-sm">Plugin source</label>
-                    <input type="text" class="form-control form-control-sm" id="pm-repo-url"
-                           placeholder="PyPI package name or https://github.com/owner/repo">
-                    <div class="form-text">PyPI package name (e.g. <code>az-scout-example</code>) or public GitHub URL</div>
-                </div>
-                <div class="mb-3">
-                    <label for="pm-ref" class="form-label form-label-sm">Version / Ref <span class="text-body-secondary">(optional – defaults to latest)</span></label>
-                    <input type="text" class="form-control form-control-sm" id="pm-ref"
-                           placeholder="latest">
-                </div>
-                <div class="d-flex gap-2">
-                    <button class="btn btn-outline-primary btn-sm" id="pm-validate-btn" onclick="pmValidate()">
-                        <i class="bi bi-check-circle me-1"></i>Validate
-                    </button>
-                    <button class="btn btn-primary btn-sm" id="pm-install-btn" onclick="pmInstall()" disabled>
-                        <i class="bi bi-download me-1"></i>Install
-                    </button>
-                </div>
-
-                <!-- Validation result -->
-                <div id="pm-validation-result" class="d-none mt-3">
-                    <hr>
-                    <div id="pm-val-status" class="mb-2"></div>
-                    <div id="pm-val-meta" class="mb-2" style="font-size:0.82rem;"></div>
-                    <div id="pm-val-errors" class="d-none"></div>
-                    <div id="pm-val-warnings" class="d-none"></div>
-                </div>
-
-                <!-- Spinner -->
-                <div id="pm-spinner" class="d-none mt-3 text-center">
-                    <div class="spinner-border spinner-border-sm text-primary" role="status">
-                        <span class="visually-hidden">Loading…</span>
-                    </div>
-                    <span class="ms-2 text-body-secondary" id="pm-spinner-text">Validating…</span>
-                </div>
-            </div>
-            </div>
-        </div>
-    </div>
+    </template>
 </div>

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -2,19 +2,13 @@
 /* global apiFetch, apiPost, bootstrap */
 
 (() => {
-
-
     const container = document.getElementById("plugin-manager-body");
     if (!container) return;
 
     let lastValidation = null;
     let initialized = false;
-    let updateInfo = {};  // distribution_name → update status from /api/plugins/updates
-
-    /** Return true when the source string looks like a PyPI package name (not a URL). */
-    function isPypiSource(source) {
-        return source && !source.startsWith("http");
-    }
+    let updateInfo = {};      // distribution_name → update status from /api/plugins/updates
+    let catalogPlugins = [];  // cached catalog data
 
     const modalEl = document.getElementById("pluginModal");
     if (!modalEl) return;
@@ -45,206 +39,313 @@
             '<div class="text-center py-4 text-muted">' +
             '<div class="spinner-border spinner-border-sm me-2" role="status"></div>' +
             "Loading…</div>";
+
+        // Set up the callback BEFORE injecting catalog.html so the inline script can call it
+        window.onCatalogRendered = function(plugins) {
+            catalogPlugins = plugins;
+            // Now that cards are rendered, fetch instance data and enhance
+            loadPlugins();
+            checkUpdatesQuiet();
+        };
+
         fetch("/static/html/plugins.html")
             .then(r => r.text())
             .then(html => {
                 container.innerHTML = html;
-                initPanelCollapses();
-                initCatalogFilter();
-                loadPlugins();
-                loadRecommended();
-                checkUpdatesQuiet();
+                // Inject catalog.html into the host container
+                const host = document.getElementById("pm-catalog-host");
+                if (host) {
+                    fetch("/static/html/catalog.html")
+                        .then(r => r.text())
+                        .then(catalogHtml => {
+                            host.innerHTML = catalogHtml;
+                            // Execute inline scripts in the injected HTML
+                            for (const script of host.querySelectorAll("script")) {
+                                const newScript = document.createElement("script");
+                                newScript.textContent = script.textContent;
+                                script.replaceWith(newScript);
+                            }
+                        });
+                }
             });
-    }
-
-    function initPanelCollapses() {
-        if (!bootstrap || !bootstrap.Collapse) return;
-        const toggles = container.querySelectorAll("[data-pm-collapse-target]");
-        for (const toggle of toggles) {
-            const targetSelector = toggle.getAttribute("data-pm-collapse-target");
-            if (!targetSelector) continue;
-            const panel = container.querySelector(targetSelector);
-            if (!panel) continue;
-
-            const collapse = bootstrap.Collapse.getOrCreateInstance(panel, { toggle: false });
-
-            panel.addEventListener("shown.bs.collapse", () => {
-                toggle.setAttribute("aria-expanded", "true");
-                toggle.classList.remove("collapsed");
-            });
-            panel.addEventListener("hidden.bs.collapse", () => {
-                toggle.setAttribute("aria-expanded", "false");
-                toggle.classList.add("collapsed");
-            });
-
-            toggle.classList.add("collapsed");
-            toggle.addEventListener("click", () => {
-                collapse.toggle();
-            });
-        }
     }
 
     // ---- Data loading ----
 
     function loadPlugins() {
         apiFetch("/api/plugins").then(data => {
-            renderInstalledMerged(data.installed || [], data.loaded || []);
+            enhanceCatalogCards(data.installed || [], data.loaded || []);
         }).catch(() => {});
     }
 
-    /**
-     * Build a merged list of all plugins (built-in + external) with UI
-     * management controls only for UI-installed ones.
-     */
-    function renderInstalledMerged(installed, loaded) {
-        const empty = document.getElementById("pm-installed-empty");
-        const wrap = document.getElementById("pm-installed-table-wrap");
-        const tbody = document.getElementById("pm-installed-tbody");
-        if (!empty || !wrap || !tbody) return;
+    // ---- Card enhancement (progressive enhancement of catalog.html) ----
 
-        // Build a lookup: distribution_name → installed record
+    function escHtml(s) {
+        const d = document.createElement("div");
+        d.textContent = String(s || "");
+        return d.innerHTML;
+    }
+
+    function escAttr(s) {
+        return String(s || "")
+            .replace(/\\/g, "\\\\")
+            .replace(/'/g, "\\'")
+            .replace(/\r/g, "\\r")
+            .replace(/\n/g, "\\n")
+            .replace(/\u2028/g, "\\u2028")
+            .replace(/\u2029/g, "\\u2029")
+            .replace(/"/g, "&quot;");
+    }
+
+    /** Inject an installed version label below the authors in a catalog card. */
+    function injectVersion(col, ver) {
+        if (!ver) return;
+        const authorsEl = col.querySelector('.catalog-authors');
+        if (!authorsEl) return;
+        const old = authorsEl.parentElement.querySelector('.catalog-version-info');
+        if (old) old.remove();
+        authorsEl.insertAdjacentHTML('afterend',
+            '<div class="catalog-version-info text-body-secondary" style="font-size:0.75rem">Installed: ' + ver + '</div>');
+    }
+
+    /**
+     * Enhance catalog cards with PM features and append cards for
+     * non-catalog plugins (built-in, external, UI-installed-not-in-catalog).
+     */
+    function enhanceCatalogCards(installed, loaded) {
+        const grid = document.getElementById("catalog-grid");
+        if (!grid) return;
+
+        // Remove dynamically added cards from previous runs
+        for (const el of grid.querySelectorAll(".pm-dynamic-card")) {
+            el.remove();
+        }
+
+        // Build lookups
         const installedByDist = {};
         for (const r of installed) {
             installedByDist[r.distribution_name] = r;
         }
-
-        // Build merged rows: start from loaded plugins (authoritative runtime list),
-        // then append any installed records that aren't loaded (failed to load, etc.)
-        const rows = [];
-        const seenDists = new Set();
-
+        const loadedByDist = {};
         for (const p of loaded) {
-            const distName = p.distribution_name || "";
-            const record = distName ? installedByDist[distName] : null;
-            if (distName) seenDists.add(distName);
-            rows.push({
-                name: p.name,
-                version: p.version,
-                internal: p.internal,
-                uiManaged: !!record,
-                record: record,
-                distName: distName,
-                loaded: true,
-            });
+            if (p.distribution_name) loadedByDist[p.distribution_name] = p;
         }
 
-        // Append installed-but-not-loaded plugins
-        for (const r of installed) {
-            if (!seenDists.has(r.distribution_name)) {
-                rows.push({
-                    name: r.distribution_name,
-                    version: r.ref || "",
-                    internal: false,
-                    uiManaged: true,
-                    record: r,
-                    distName: r.distribution_name,
-                    loaded: false,
-                });
-            }
-        }
-
-        if (rows.length === 0) {
-            empty.classList.remove("d-none");
-            wrap.classList.add("d-none");
-            return;
-        }
-        empty.classList.add("d-none");
-        wrap.classList.remove("d-none");
-        tbody.innerHTML = "";
+        const catalogNames = new Set(catalogPlugins.map(p => p.name));
+        const seenDists = new Set();
         let anyUpdate = false;
 
-        for (const row of rows) {
-            const tr = document.createElement("tr");
-            const r = row.record;
+        // 1. Enhance existing catalog cards
+        for (const col of grid.querySelectorAll(".catalog-card-col")) {
+            const name = col.dataset.catalogName;
+            const source = col.dataset.catalogSource;
+            const actionsEl = col.querySelector(".catalog-actions");
+            if (!actionsEl) continue;
 
-            // Name column
-            let nameHtml = "<code>" + escHtml(row.name) + "</code>";
-            if (row.internal) {
-                nameHtml += ' <span class="badge text-bg-secondary">built-in</span>';
-            } else if (!row.uiManaged && row.loaded) {
-                nameHtml += ' <span class="badge text-bg-light border" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Installed outside the plugin manager (e.g. pip, Dockerfile). Not manageable from this UI.">external</span>';
-            }
-            if (!row.loaded) {
-                nameHtml += ' <span class="badge text-bg-warning">not loaded</span>';
-            }
+            // Clear previously injected version info
+            const oldVer = col.querySelector(".catalog-version-info");
+            if (oldVer) oldVer.remove();
 
-            // Version column
-            const versionHtml = escHtml(row.version);
+            seenDists.add(name);
 
-            // Source column
-            let sourceHtml = "";
-            if (row.internal) {
-                sourceHtml = '<span class="text-body-secondary">built-in</span>';
-            } else if (r) {
-                const pypi = r.source === "pypi";
-                if (pypi) {
-                    const pypiUrl = "https://pypi.org/project/" + encodeURIComponent(r.distribution_name) + "/";
-                    sourceHtml = '<a href="' + escHtml(pypiUrl) + '" target="_blank" rel="noopener"><i class="bi bi-box-seam me-1"></i>PyPI</a>';
-                } else if (r.repo_url) {
-                    sourceHtml = '<a href="' + escHtml(r.repo_url) + '" target="_blank" rel="noopener"><i class="bi bi-github me-1"></i>GitHub</a>';
-                }
-            } else if (!row.uiManaged && row.loaded) {
-                sourceHtml = '<span class="text-body-secondary">pip / system</span>';
-            }
+            const record = installedByDist[name];
+            const loadedPlugin = loadedByDist[name];
+            const isInstalled = !!record || !!loadedPlugin;
 
-            // Status + actions — only for UI-managed plugins
-            let statusHtml = "";
-            let actionsHtml = "";
+            if (isInstalled && record) {
+                // UI-managed: show version + actions
+                const info = updateInfo[name];
+                const ver = escHtml(record.ref || '');
+                let btnsHtml = '';
 
-            if (row.uiManaged && r) {
-                const info = updateInfo[r.distribution_name];
-                let statusBadge = '<span class="badge bg-secondary">Unknown</span>';
-                let updateBtn = "";
-
-                if (info) {
-                    if (info.error) {
-                        statusBadge = '<span class="badge bg-warning text-dark">Unknown</span>';
-                    } else if (info.update_available) {
-                        statusBadge = '<span class="badge bg-info text-dark">Update available</span>';
-                        updateBtn = ' <button class="btn btn-outline-info btn-sm py-0 px-1" title="Update" onclick="pmUpdate(\'' + escAttr(r.distribution_name) + '\')"><i class="bi bi-cloud-download"></i></button>';
-                        anyUpdate = true;
-                    } else if (info.latest_ref) {
-                        statusBadge = '<span class="badge bg-success">Up to date</span>';
-                    }
-                } else if (r.update_available === true) {
-                    statusBadge = '<span class="badge bg-info text-dark">Update available</span>';
-                    updateBtn = ' <button class="btn btn-outline-info btn-sm py-0 px-1" title="Update" onclick="pmUpdate(\'' + escAttr(r.distribution_name) + '\')"><i class="bi bi-cloud-download"></i></button>';
+                if ((info && info.update_available) || record.update_available === true) {
+                    const latest = escHtml((info && info.latest_ref) || record.latest_ref || '');
+                    const label = latest ? ver + ' \u2192 ' + latest : 'Update';
+                    btnsHtml += '<button class="btn btn-outline-info btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Update plugin to latest version" onclick="pmUpdate(\'' + escAttr(name) + '\')"><i class="bi bi-cloud-download me-1"></i>' + label + '</button>';
                     anyUpdate = true;
-                } else if (r.update_available === false) {
-                    statusBadge = '<span class="badge bg-success">Up to date</span>';
                 }
+                btnsHtml += '<button class="btn btn-outline-danger btn-sm" onclick="pmUninstall(\'' + escAttr(name) + '\')"><i class="bi bi-trash me-1"></i>Uninstall</button>';
 
-                statusHtml = statusBadge;
-                actionsHtml = updateBtn +
-                    ' <button class="btn btn-outline-danger btn-sm py-0 px-1" title="Uninstall" onclick="pmUninstall(\'' + escAttr(r.distribution_name) + '\')">' +
-                    '<i class="bi bi-trash"></i></button>';
+                actionsEl.innerHTML = btnsHtml;
+                injectVersion(col, ver);
+            } else if (isInstalled && loadedPlugin && loadedPlugin.in_packages_dir) {
+                // Installed as a dependency via PM — manageable
+                actionsEl.innerHTML =
+                    '<button class="btn btn-outline-danger btn-sm" onclick="pmUninstall(\'' + escAttr(name) + '\')"><i class="bi bi-trash me-1"></i>Uninstall</button>';
+                injectVersion(col, escHtml(loadedPlugin.version || ''));
+            } else if (isInstalled) {
+                // Loaded but truly external (system pip, Dockerfile)
+                actionsEl.innerHTML = '<span class="badge bg-success" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Installed outside the plugin manager (e.g. pip, Dockerfile). Not manageable from this UI.">external</span>';
+                if (loadedPlugin) injectVersion(col, escHtml(loadedPlugin.version || ''));
             } else {
-                statusHtml = '<span class="badge bg-success">Active</span>';
+                // Not installed: show install button
+                actionsEl.innerHTML =
+                    '<button class="btn btn-sm btn-outline-primary" onclick="pmQuickInstall(\'' + escAttr(source) + '\', \'\')"><i class="bi bi-download me-1"></i>Install</button>';
+            }
+        }
+
+        // 2. Collect built-in plugins and append non-catalog external plugins
+        const builtins = [];
+        for (const p of loaded) {
+            const distName = p.distribution_name || p.name;
+            if (catalogNames.has(distName) || seenDists.has(distName)) continue;
+            seenDists.add(distName);
+
+            if (p.internal) {
+                builtins.push(p);
+                continue;
             }
 
-            tr.innerHTML =
-                "<td>" + nameHtml + "</td>" +
-                "<td>" + versionHtml + "</td>" +
-                "<td>" + sourceHtml + "</td>" +
-                "<td>" + statusHtml + "</td>" +
-                '<td class="text-nowrap">' + actionsHtml + "</td>";
-            tbody.appendChild(tr);
+            const record = installedByDist[distName];
+            grid.insertAdjacentHTML("beforeend", buildExtraCard(p, record));
+
+            if (record && ((updateInfo[distName] || {}).update_available || record.update_available === true)) {
+                anyUpdate = true;
+            }
+        }
+
+        // 2b. Single card for all built-in plugins
+        if (builtins.length > 0) {
+            const items = builtins.map(function(p) {
+                const label = p.display_name || p.name;
+                return '<li><strong>' + escHtml(label) + '</strong>' +
+                    (p.description ? ' — ' + escHtml(p.description) : '') + '</li>';
+            }).join("");
+            grid.insertAdjacentHTML("beforeend",
+                '<div class="col catalog-card-col pm-dynamic-card" data-catalog-name="built-in" data-catalog-tags="" data-catalog-desc="built-in">' +
+                    '<div class="card h-100">' +
+                        '<div class="card-body d-flex flex-column gap-1" style="font-size:0.85rem;">' +
+                            '<div class="d-flex align-items-baseline justify-content-between gap-2">' +
+                                '<span class="fw-semibold">Built-in plugins</span>' +
+                            '</div>' +
+                            '<ul class="text-body-secondary small mb-0 ps-3">' + items + '</ul>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>'
+            );
+        }
+
+        // 3. Append installed-but-not-loaded plugins
+        for (const r of installed) {
+            if (seenDists.has(r.distribution_name)) continue;
+            seenDists.add(r.distribution_name);
+            grid.insertAdjacentHTML("beforeend", buildNotLoadedCard(r));
+            if ((updateInfo[r.distribution_name] || {}).update_available || r.update_available === true) {
+                anyUpdate = true;
+            }
         }
 
         // Show/hide "Update all" button
         const updateAllBtn = document.getElementById("pm-update-all-btn");
         if (updateAllBtn) {
-            if (anyUpdate) {
-                updateAllBtn.classList.remove("d-none");
-            } else {
-                updateAllBtn.classList.add("d-none");
-            }
+            updateAllBtn.classList.toggle("d-none", !anyUpdate);
         }
 
-        // Initialize Bootstrap tooltips on newly rendered badges
-        for (const el of tbody.querySelectorAll('[data-bs-toggle="tooltip"]')) {
+        // Initialize Bootstrap tooltips
+        for (const el of grid.querySelectorAll('[data-bs-toggle="tooltip"]')) {
             new bootstrap.Tooltip(el);
         }
+
+        // 4. Append manual install card from template (if not already present)
+        if (!grid.querySelector('[data-catalog-name="manual-install"]')) {
+            const tpl = document.getElementById("pm-manual-install-template");
+            if (tpl) {
+                grid.appendChild(tpl.content.cloneNode(true));
+            }
+        }
+    }
+
+    /** Build a card for a loaded plugin that's NOT in the catalog. */
+    function buildExtraCard(p, record) {
+        const isInternal = p.internal;
+        let badges = "";
+        if (!isInternal && !record && !p.in_packages_dir) {
+            badges = '<span class="badge text-bg-light border" data-bs-toggle="tooltip" data-bs-placement="top" ' +
+                'data-bs-title="Installed outside the plugin manager (e.g. pip, Dockerfile). Not manageable from this UI.">external</span>';
+        }
+
+        let sourceHtml = "";
+        if (isInternal) {
+            sourceHtml = '<span class="text-body-secondary" style="font-size:0.75rem">built-in</span>';
+        } else if (record) {
+            sourceHtml = record.source === "pypi"
+                ? '<span class="badge text-bg-success text-uppercase" style="font-size:0.65rem">pypi</span>'
+                : '<span class="badge text-bg-secondary text-uppercase" style="font-size:0.65rem">github</span>';
+        } else {
+            sourceHtml = '<span class="text-body-secondary" style="font-size:0.75rem">pip / system</span>';
+        }
+
+        let actionsHtml = "";
+        let extraVersionHtml = isInternal ? "" : escHtml(p.version);
+        if (record) {
+            const info = updateInfo[record.distribution_name];
+            const ver = escHtml(record.ref || '');
+            let btnsHtml = '';
+            if ((info && info.update_available) || record.update_available === true) {
+                const latest = escHtml((info && info.latest_ref) || record.latest_ref || '');
+                const label = latest ? ver + ' \u2192 ' + latest : 'Update';
+                btnsHtml += '<button class="btn btn-outline-info btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Update plugin to latest version" onclick="pmUpdate(\'' + escAttr(record.distribution_name) + '\')"><i class="bi bi-cloud-download me-1"></i>' + label + '</button>';
+            }
+            btnsHtml += '<button class="btn btn-outline-danger btn-sm" onclick="pmUninstall(\'' + escAttr(record.distribution_name) + '\')"><i class="bi bi-trash me-1"></i>Uninstall</button>';
+            actionsHtml = btnsHtml;
+            extraVersionHtml = ver;
+        } else if (p.in_packages_dir) {
+            // Installed as a dependency via PM — manageable
+            actionsHtml = '<button class="btn btn-outline-danger btn-sm" onclick="pmUninstall(\'' + escAttr(p.distribution_name || p.name) + '\')"><i class="bi bi-trash me-1"></i>Uninstall</button>';
+        } else if (isInternal) {
+            actionsHtml = '<span class="badge text-bg-secondary">built-in</span>';
+        } else {
+            actionsHtml = '<span class="badge bg-success" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Installed outside the plugin manager (e.g. pip, Dockerfile). Not manageable from this UI.">external</span>';
+        }
+
+        return '<div class="col catalog-card-col pm-dynamic-card" data-catalog-name="' + escHtml(p.name) + '" data-catalog-tags="" data-catalog-desc="' + escHtml(p.description || '') + '">' +
+            '<div class="card catalog-card-plugin h-100">' +
+                '<div class="card-body d-flex flex-column gap-1" style="font-size:0.85rem;">' +
+                    '<div class="d-flex align-items-baseline justify-content-between gap-2">' +
+                        '<span class="fw-semibold">' + escHtml(p.name) + '</span> ' +
+                        sourceHtml +
+                    '</div>' +
+                    (p.description ? '<p class="text-body-secondary small mb-0">' + escHtml(p.description) + '</p>' : '') +
+                    '<div class="d-flex flex-wrap gap-1">' + badges + '</div>' +
+                    '<div class="d-flex align-items-center justify-content-between mt-auto pt-1">' +
+                        '<span class="small text-body-secondary">' + extraVersionHtml + '</span>' +
+                        '<span class="d-flex align-items-center gap-2 catalog-actions">' + actionsHtml + '</span>' +
+                    '</div>' +
+                '</div>' +
+            '</div>' +
+        '</div>';
+    }
+
+    /** Build a card for a plugin in installed.json but not loaded. */
+    function buildNotLoadedCard(r) {
+        let btnsLine = "";
+        if ((updateInfo[r.distribution_name] || {}).update_available || r.update_available === true) {
+            const latest = escHtml((updateInfo[r.distribution_name] || {}).latest_ref || r.latest_ref || '');
+            const ver = escHtml(r.ref || '');
+            const label = latest ? ver + ' \u2192 ' + latest : 'Update';
+            btnsLine += '<button class="btn btn-outline-info btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Update plugin to latest version" onclick="pmUpdate(\'' + escAttr(r.distribution_name) + '\')"><i class="bi bi-cloud-download me-1"></i>' + label + '</button> ';
+        }
+        btnsLine += '<button class="btn btn-outline-danger btn-sm" onclick="pmUninstall(\'' + escAttr(r.distribution_name) + '\')"><i class="bi bi-trash me-1"></i>Uninstall</button>';
+
+        const sourceBadge = r.source === "pypi"
+            ? '<span class="badge text-bg-success text-uppercase" style="font-size:0.65rem">pypi</span>'
+            : '<span class="badge text-bg-secondary text-uppercase" style="font-size:0.65rem">github</span>';
+
+        return '<div class="col catalog-card-col pm-dynamic-card" data-catalog-name="' + escHtml(r.distribution_name) + '" data-catalog-tags="" data-catalog-desc="">' +
+            '<div class="card catalog-card-plugin h-100 border-warning">' +
+                '<div class="card-body d-flex flex-column gap-1" style="font-size:0.85rem;">' +
+                    '<div class="d-flex align-items-baseline justify-content-between gap-2">' +
+                        '<span class="fw-semibold">' + escHtml(r.distribution_name) + '</span> ' +
+                        sourceBadge +
+                    '</div>' +
+                    '<div class="d-flex flex-wrap gap-1"><span class="badge text-bg-warning">not loaded</span></div>' +
+                    '<div class="d-flex align-items-center justify-content-between mt-auto pt-1">' +
+                        '<span class="small text-body-secondary">' + escHtml(r.ref || '') + '</span>' +
+                        '<span class="d-flex align-items-center gap-2 catalog-actions">' + btnsLine + '</span>' +
+                    '</div>' +
+                '</div>' +
+            '</div>' +
+        '</div>';
     }
 
     // ---- Validate ----
@@ -285,11 +386,8 @@
         try {
             const data = await apiPost("/api/plugins/install", { repo_url: repoUrl, ref: ref });
             if (data.ok) {
-                if (data.restart_required) {
-                    showRestartBanner();
-                }
-                loadPlugins();
-                loadRecommended();
+                if (data.restart_required) showRestartBanner();
+                refreshAll();
                 hideResult();
             } else {
                 showResultError((data.errors || []).join("; "));
@@ -306,14 +404,11 @@
 
     window.pmUninstall = async (distName) => {
         if (!confirm("Uninstall plugin \"" + distName + "\"?")) return;
-
         showGlobalStatus("Uninstalling " + distName + "…");
-
         try {
             const data = await apiPost("/api/plugins/uninstall", { distribution_name: distName });
             if (data.ok) {
-                loadPlugins();
-                loadRecommended();
+                refreshAll();
             } else {
                 alert("Uninstall failed: " + (data.errors || []).join("; "));
             }
@@ -326,7 +421,6 @@
 
     // ---- Check updates ----
 
-    /** Fetch update info and refresh the installed table. */
     async function fetchUpdates() {
         const data = await apiFetch("/api/plugins/updates");
         updateInfo = {};
@@ -336,20 +430,17 @@
         loadPlugins();
     }
 
-    /** Silent check on init — no spinners or error alerts. */
     function checkUpdatesQuiet() {
         fetchUpdates().catch(() => {});
     }
 
     window.pmCheckUpdates = async () => {
-        showSpinner("Checking for updates\u2026");
-        showGlobalStatus("Checking for updates\u2026");
+        showGlobalStatus("Checking for updates…");
         try {
             await fetchUpdates();
         } catch (e) {
             alert("Check updates error: " + e.message);
         } finally {
-            hideSpinner();
             hideGlobalStatus();
         }
     };
@@ -357,24 +448,19 @@
     // ---- Update single ----
 
     window.pmUpdate = async (distName) => {
-        showSpinner("Updating " + distName + "…");
         showGlobalStatus("Updating " + distName + "…");
         try {
             const data = await apiPost("/api/plugins/update", { distribution_name: distName });
             if (data.ok) {
-                if (data.restart_required) {
-                    showRestartBanner();
-                }
+                if (data.restart_required) showRestartBanner();
                 updateInfo = {};
-                loadPlugins();
-                loadRecommended();
+                refreshAll();
             } else {
                 alert("Update failed: " + (data.errors || []).join("; "));
             }
         } catch (e) {
             alert("Update error: " + e.message);
         } finally {
-            hideSpinner();
             hideGlobalStatus();
         }
     };
@@ -383,126 +469,44 @@
 
     window.pmUpdateAll = async () => {
         if (!confirm("Update all plugins with available updates?")) return;
-
-        showSpinner("Updating all plugins…");
         showGlobalStatus("Updating all plugins…");
         try {
             const data = await apiPost("/api/plugins/update-all", {});
-            if (data.updated > 0) {
-                if (data.restart_required) {
-                    showRestartBanner();
-                }
-            }
+            if (data.updated > 0 && data.restart_required) showRestartBanner();
             updateInfo = {};
-            loadPlugins();
-            loadRecommended();
-            if (data.failed > 0) {
-                alert("Some plugins failed to update: " + data.failed);
-            }
+            refreshAll();
+            if (data.failed > 0) alert("Some plugins failed to update: " + data.failed);
         } catch (e) {
             alert("Update all error: " + e.message);
         } finally {
-            hideSpinner();
             hideGlobalStatus();
         }
     };
 
-    // ---- Plugin catalog ----
-
-    let catalogData = [];  // cached catalog data for filtering
-
-    function initCatalogFilter() {
-        const filterInput = document.getElementById("pm-catalog-filter");
-        if (!filterInput) return;
-        filterInput.addEventListener("input", () => {
-            renderRecommended(catalogData, filterInput.value.trim().toLowerCase());
-        });
-    }
-
-    function loadRecommended() {
-        apiFetch("/api/plugins/recommended").then(data => {
-            catalogData = data.plugins || [];
-            renderRecommended(catalogData, "");
-        }).catch(() => {});
-    }
-
-    function renderRecommended(list, filterText) {
-        const empty = document.getElementById("pm-recommended-empty");
-        const wrap = document.getElementById("pm-recommended-table-wrap");
-        const tbody = document.getElementById("pm-recommended-tbody");
-        if (!empty || !wrap || !tbody) return;
-
-        const filtered = filterText
-            ? list.filter(p => p.name.toLowerCase().includes(filterText) ||
-                               (p.description || "").toLowerCase().includes(filterText))
-            : list;
-
-        if (filtered.length === 0) {
-            empty.textContent = filterText ? "No plugins match the filter" : "No plugins in catalog";
-            empty.classList.remove("d-none");
-            wrap.classList.add("d-none");
-            return;
-        }
-        empty.classList.add("d-none");
-        wrap.classList.remove("d-none");
-        tbody.innerHTML = "";
-
-        for (const p of filtered) {
-            const tr = document.createElement("tr");
-            const pypi = p.source === "pypi";
-            let sourceLink;
-            if (pypi) {
-                const pypiUrl = `https://pypi.org/project/${encodeURIComponent(p.name)}/`;
-                sourceLink = `<a href="${escHtml(pypiUrl)}" target="_blank" rel="noopener"><i class="bi bi-box-seam me-1"></i>PyPI</a>`;
-            } else {
-                sourceLink = p.url
-                    ? `<a href="${escHtml(p.url)}" target="_blank" rel="noopener"><i class="bi bi-github me-1"></i>GitHub</a>`
-                    : escHtml(p.source);
-            }
-
-            let actionCell;
-            if (p.installed) {
-                actionCell = '<span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>Installed</span>';
-            } else {
-                const installSource = pypi ? escAttr(p.name) : escAttr(p.url);
-                const installVersion = escAttr(p.version || "");
-                actionCell = `<button class="btn btn-outline-success btn-sm py-0 px-2"
-                                      title="Quick install"
-                                      onclick="pmQuickInstall('${installSource}', '${installVersion}')">
-                                  <i class="bi bi-download me-1"></i>Install
-                              </button>`;
-            }
-
-            tr.innerHTML = `
-                <td><code>${escHtml(p.name)}</code></td>
-                <td>${escHtml(p.description)}</td>
-                <td>${sourceLink}</td>
-                <td class="text-nowrap">${actionCell}</td>`;
-            tbody.appendChild(tr);
-        }
-    }
+    // ---- Quick install (from catalog card) ----
 
     window.pmQuickInstall = async (source, version) => {
-        showSpinner("Installing…");
         showGlobalStatus("Installing plugin…");
         try {
             const data = await apiPost("/api/plugins/install", { repo_url: source, ref: version });
             if (data.ok) {
-                if (data.restart_required) {
-                    showRestartBanner();
-                }
-                loadPlugins();
-                loadRecommended();
+                if (data.restart_required) showRestartBanner();
+                refreshAll();
             } else {
-                showResultError((data.errors || []).join("; "));
+                alert("Install failed: " + (data.errors || []).join("; "));
             }
         } catch (e) {
-            showResultError(e.message);
+            alert("Install error: " + e.message);
         } finally {
-            hideSpinner();
             hideGlobalStatus();
         }
     };
+
+    // ---- Refresh ----
+
+    function refreshAll() {
+        loadPlugins();
+    }
 
     // ---- UI helpers ----
 
@@ -516,12 +520,10 @@
         const el = document.getElementById("pm-spinner");
         if (el) el.classList.add("d-none");
     }
-
     function showRestartBanner() {
         const el = document.getElementById("pm-restart-banner");
         if (el) el.classList.remove("d-none");
     }
-
     function showGlobalStatus(text) {
         const el = document.getElementById("pm-global-status");
         const txt = document.getElementById("pm-global-status-text");
@@ -532,7 +534,6 @@
         const el = document.getElementById("pm-global-status");
         if (el) el.classList.add("d-none");
     }
-
     function hideResult() {
         const el = document.getElementById("pm-validation-result");
         if (el) el.classList.add("d-none");
@@ -547,12 +548,9 @@
         if (!wrap || !status || !meta || !errEl || !warnEl) return;
 
         wrap.classList.remove("d-none");
-
-        if (data.ok) {
-            status.innerHTML = '<span class="badge bg-success">Valid</span>';
-        } else {
-            status.innerHTML = '<span class="badge bg-danger">Invalid</span>';
-        }
+        status.innerHTML = data.ok
+            ? '<span class="badge bg-success">Valid</span>'
+            : '<span class="badge bg-danger">Invalid</span>';
 
         const lines = [];
         if (data.distribution_name) lines.push("<strong>Distribution:</strong> " + escHtml(data.distribution_name));
@@ -564,7 +562,6 @@
                 Object.entries(data.entry_points).map(([k, v]) => escHtml(k) + " → " + escHtml(v)).join(", "));
         }
         meta.innerHTML = lines.join("<br>");
-
         renderList(errEl, data.errors, "danger");
         renderList(warnEl, data.warnings, "warning");
     }
@@ -588,10 +585,7 @@
 
     function renderList(el, items, variant) {
         if (!el) return;
-        if (!items || items.length === 0) {
-            el.classList.add("d-none");
-            return;
-        }
+        if (!items || items.length === 0) { el.classList.add("d-none"); return; }
         el.classList.remove("d-none");
         el.innerHTML = items.map(i =>
             '<div class="alert alert-' + variant + ' alert-sm py-1 px-2 mb-1" style="font-size:0.82rem;">' +
@@ -607,22 +601,5 @@
     function disableInstall() {
         const btn = document.getElementById("pm-install-btn");
         if (btn) btn.disabled = true;
-    }
-
-    function escHtml(s) {
-        const d = document.createElement("div");
-        d.textContent = String(s || "");
-        return d.innerHTML;
-    }
-
-    function escAttr(s) {
-        return String(s || "")
-            .replace(/\\/g, "\\\\")
-            .replace(/'/g, "\\'")
-            .replace(/\r/g, "\\r")
-            .replace(/\n/g, "\\n")
-            .replace(/\u2028/g, "\\u2028")
-            .replace(/\u2029/g, "\\u2029")
-            .replace(/"/g, "&quot;");
     }
 })();

--- a/src/az_scout/templates/index.html
+++ b/src/az_scout/templates/index.html
@@ -171,7 +171,7 @@
 
 <!-- ===== Plugin Manager Modal ===== -->
 <div class="modal fade" tabindex="-1" id="pluginModal" aria-labelledby="pluginModalLabel">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable" style="max-width:min(95vw, 1400px);">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="pluginModalLabel"><i class="bi bi-puzzle me-2"></i>Plugin Manager</h5>


### PR DESCRIPTION
## Description

Complete redesign of the Plugin Manager UI, replacing the old table-based views with a shared card-based catalog UI that can be reused across the Plugin Manager, docs site, and standalone catalog page.

### Key changes:

- **Shared `catalog.html` fragment** — self-contained HTML fragment that fetches `catalog.json` and renders plugin cards with filter, tags, authors, PyPI shields.io badges, long description truncation (3-line clamp + expand), disclaimer, plugin count, 3-tab install modal (Plugin Manager / uv / pip), copy-to-clipboard, and footer links. Zero awareness of the Plugin Manager — works standalone for docs.

- **Plugin Manager as progressive enhancement** — `plugins.js` loads `catalog.html` into the modal, then enhances each card with install/update/uninstall buttons based on the instance's plugin state. Built-in, external, dependency, and not-loaded plugins get appropriate cards appended to the grid.

- **Modal instead of offcanvas** — switched from side panel to a responsive modal (`modal-xl`, max 1400px) for better space utilisation.

- **Dependency plugin detection** — plugins installed into `_PACKAGES_DIR` as transitive dependencies (e.g. `az-scout-plugin-avs-sku` pulled in by `az-scout-plugin-avs-rvtools-analyser`) are now detected via `is_in_packages_dir()` and manageable from the UI instead of being labeled "external".

- **Native extension detection** — `snapshot_native_files()` / `has_new_native_extensions()` detect compiled extensions (`.so`, `.pyd`, `.dylib`) after install/update and return `restart_required: true` in the API response.

- **Built-in plugin metadata** — internal plugins now have `display_name` and `description` attributes, exposed in the `/api/plugins` response.

- **CSP update** — added `img.shields.io` to `img-src` for PyPI version badges.

## Related issue

<!-- No specific issue -->

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors