### PR TITLE
feat(ui): add tab drag-and-drop reordering with localStorage persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Added
+
+- **Tab reordering** – Main tabs can be reordered via drag-and-drop. The custom order is persisted in `localStorage` and restored on page load. A grip icon (⠿) appears on hover to indicate draggability. New plugin tabs are appended at the end; stale tabs from uninstalled plugins are silently dropped.
+
 ## [2026.3.8] - 2026-03-28
 
 ### Added

--- a/src/az_scout/static/css/style.css
+++ b/src/az_scout/static/css/style.css
@@ -672,3 +672,35 @@ body.chat-pinned > footer {
         background: radial-gradient(circle, rgba(0, 120, 212, 0.25) 0%, transparent 70%);
     }
 }
+
+/* ── Tab drag-and-drop reordering ── */
+#mainTabs > .nav-item[draggable="true"] {
+    cursor: grab;
+}
+
+#mainTabs > .nav-item[draggable="true"] > .nav-link::before {
+    content: "\u2800";
+    display: inline-block;
+    width: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: width 0.15s ease, opacity 0.15s ease;
+    vertical-align: middle;
+    font-size: 0.7rem;
+    color: var(--bs-secondary-color, #6c757d);
+}
+
+#mainTabs > .nav-item[draggable="true"]:hover > .nav-link::before {
+    content: "⠿";
+    width: 1rem;
+    opacity: 0.6;
+}
+
+#mainTabs > .nav-item.tab-dragging {
+    opacity: 0.4;
+    cursor: grabbing;
+}
+
+#mainTabs > .nav-item.tab-drag-over {
+    border-left: 3px solid var(--bs-primary, #0d6efd);
+}

--- a/src/az_scout/static/js/app.js
+++ b/src/az_scout/static/js/app.js
@@ -72,6 +72,10 @@ async function init() {
     // Init shared region combobox
     initRegionCombobox();
 
+    // Restore saved tab order, then set up drag-and-drop reordering
+    _restoreTabOrder();
+    _initTabDragReorder();
+
     // Hash-based tab routing (supports built-in + plugin tabs)
     const tabEl = document.querySelector('#mainTabs');
     if (tabEl) {
@@ -605,6 +609,120 @@ function _copyConsentUrl(btn, url) {
             btn.innerHTML = '<i class="bi bi-clipboard me-1"></i> Copy link for admin';
         }, 2000);
     });
+}
+
+// ---------------------------------------------------------------------------
+// Tab drag-and-drop reordering  (order persisted in localStorage)
+// ---------------------------------------------------------------------------
+const _TAB_ORDER_KEY = "azscout_tabOrder";
+
+/** Read tab IDs from the DOM in their current visual order. */
+function _readTabIds() {
+    return [...document.querySelectorAll("#mainTabs > .nav-item > [role='tab']")
+    ].map(btn => btn.id.replace(/-tab$/, ""));
+}
+
+/** Persist current tab order to localStorage. */
+function _saveTabOrder() {
+    localStorage.setItem(_TAB_ORDER_KEY, JSON.stringify(_readTabIds()));
+}
+
+/**
+ * Restore previously saved tab order.
+ * New tabs (from freshly installed plugins) are appended at the end.
+ * Stale IDs (from uninstalled plugins) are silently dropped.
+ */
+function _restoreTabOrder() {
+    const saved = JSON.parse(localStorage.getItem(_TAB_ORDER_KEY) || "[]");
+    if (!saved.length) return;
+
+    const tabBar = document.getElementById("mainTabs");
+    const tabContent = document.getElementById("mainTabContent");
+    if (!tabBar || !tabContent) return;
+
+    // Build a lookup of current items
+    const liById = {};
+    const paneById = {};
+    for (const li of [...tabBar.querySelectorAll(".nav-item")]) {
+        const btn = li.querySelector("[role='tab']");
+        if (btn) liById[btn.id.replace(/-tab$/, "")] = li;
+    }
+    for (const pane of [...tabContent.querySelectorAll(".tab-pane")]) {
+        paneById[pane.id.replace(/^tab-/, "")] = pane;
+    }
+
+    // Append in saved order (moves existing DOM nodes)
+    for (const id of saved) {
+        if (liById[id]) tabBar.appendChild(liById[id]);
+        if (paneById[id]) tabContent.appendChild(paneById[id]);
+    }
+    // Any new tabs not in the saved list stay at the end (already there)
+}
+
+/** Enable HTML5 drag-and-drop on main tab bar items. */
+function _initTabDragReorder() {
+    const tabBar = document.getElementById("mainTabs");
+    if (!tabBar) return;
+
+    let dragItem = null;
+
+    for (const li of tabBar.querySelectorAll(".nav-item")) {
+        li.setAttribute("draggable", "true");
+
+        li.addEventListener("dragstart", (e) => {
+            dragItem = li;
+            li.classList.add("tab-dragging");
+            e.dataTransfer.effectAllowed = "move";
+            // Firefox requires setData to fire drag events
+            e.dataTransfer.setData("text/plain", "");
+        });
+
+        li.addEventListener("dragend", () => {
+            if (dragItem) dragItem.classList.remove("tab-dragging");
+            dragItem = null;
+            for (const i of tabBar.querySelectorAll(".nav-item")) {
+                i.classList.remove("tab-drag-over");
+            }
+        });
+
+        li.addEventListener("dragover", (e) => {
+            if (!dragItem || dragItem === li) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "move";
+            li.classList.add("tab-drag-over");
+        });
+
+        li.addEventListener("dragleave", () => {
+            li.classList.remove("tab-drag-over");
+        });
+
+        li.addEventListener("drop", (e) => {
+            e.preventDefault();
+            li.classList.remove("tab-drag-over");
+            if (!dragItem || dragItem === li) return;
+
+            // Determine drop position (before or after)
+            const rect = li.getBoundingClientRect();
+            const midX = rect.left + rect.width / 2;
+            if (e.clientX < midX) {
+                tabBar.insertBefore(dragItem, li);
+            } else {
+                tabBar.insertBefore(dragItem, li.nextSibling);
+            }
+
+            // Sync tab-content pane order to match
+            const tabContent = document.getElementById("mainTabContent");
+            if (tabContent) {
+                const newOrder = _readTabIds();
+                for (const id of newOrder) {
+                    const pane = document.getElementById("tab-" + id);
+                    if (pane) tabContent.appendChild(pane);
+                }
+            }
+
+            _saveTabOrder();
+        });
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Add drag-and-drop reordering for main tabs with order persistence in the browser's `localStorage`.

Users can drag tabs to rearrange them. The order is remembered across page reloads. A grip icon (⠿) appears on hover to indicate draggability. New plugin tabs (from freshly installed plugins) are appended at the end; stale IDs from uninstalled plugins are silently dropped.

### Implementation details

- **JS (`app.js`):** HTML5 Drag & Drop API on `#mainTabs .nav-item` elements. Drop position determined by cursor relative to target midpoint. Tab-content panes are synced after each reorder. Order saved to `localStorage` key `azscout_tabOrder`.
- **CSS (`style.css`):** `cursor: grab/grabbing`, grip icon via `::before` pseudo-element with smooth width/opacity transition, `.tab-dragging` opacity reduction, `.tab-drag-over` blue left-border indicator.

## Related issue

N/A

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors