### PR TITLE
fix(plugin-manager): prevent core version conflict during plugin install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 - **Auto update check** – Plugin Manager silently checks for updates when opened, showing results immediately.
 - **CSP: shields.io** – Added `img.shields.io` to the Content-Security-Policy `img-src` directive for PyPI version badges.
 
+### Fixed
+
+- **Plugin core version guard** – Plugin Manager now validates that a plugin's `az-scout` version requirement is compatible with the running instance before install. Incompatible plugins are blocked with a clear error. A pip constraint file also prevents pip from installing a different core version into the packages directory.
+
 ### Changed
 
 - **Plugin Manager layout** – Replaced table-based views with a card grid layout matching the catalog style. All plugins (catalog, installed, built-in, external) shown in a unified card grid with a filter, action bar, and manual install card.

--- a/src/az_scout/plugin_manager/_compat.py
+++ b/src/az_scout/plugin_manager/_compat.py
@@ -1,0 +1,74 @@
+"""Core version compatibility check for plugin dependencies."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def get_core_version() -> str:
+    """Return the running az-scout version string."""
+    from az_scout import __version__
+
+    return __version__
+
+
+def check_core_version_compat(
+    dependencies: list[str],
+) -> tuple[bool, str]:
+    """Check if a plugin's dependencies are compatible with the running core version.
+
+    Parses the ``az-scout`` version specifier from *dependencies* and checks it
+    against the running version.
+
+    Returns ``(ok, message)`` — *ok* is ``True`` if compatible or if no version
+    constraint is specified.  *message* is empty on success or describes the
+    incompatibility.
+    """
+    core_version = get_core_version()
+
+    # Dev versions (e.g. "0.0.0-dev", "2026.3.9.dev4") skip the check
+    if "dev" in core_version or core_version == "0.0.0":
+        return True, ""
+
+    # Find the az-scout dependency with its version specifier
+    for dep in dependencies:
+        dep_lower = dep.strip().lower()
+        # Extract the package name (before any version specifier)
+        name_match = re.match(r"^([a-z0-9_-]+)", dep_lower.replace("_", "-"))
+        if not name_match:
+            continue
+        name = name_match.group(1)
+        if name != "az-scout":
+            continue
+
+        # Extract the version specifier part (everything after the name)
+        specifier_str = dep.strip()[len(name_match.group(0)) :].strip()
+        if not specifier_str:
+            return True, ""  # No version constraint — always compatible
+
+        try:
+            from packaging.specifiers import InvalidSpecifier, SpecifierSet
+            from packaging.version import Version
+
+            spec = SpecifierSet(specifier_str)
+            if Version(core_version) not in spec:
+                return False, (
+                    f"Plugin requires az-scout{specifier_str} but this instance "
+                    f"runs v{core_version}. Upgrade az-scout first."
+                )
+        except (InvalidSpecifier, Exception) as exc:
+            logger.warning(
+                "Could not parse az-scout version specifier '%s': %s",
+                specifier_str,
+                exc,
+            )
+            # Can't parse — don't block, just warn
+            return True, ""
+
+        return True, ""
+
+    # az-scout not in dependencies — no constraint to check
+    return True, ""

--- a/src/az_scout/plugin_manager/_github.py
+++ b/src/az_scout/plugin_manager/_github.py
@@ -183,12 +183,18 @@ def validate_plugin_repo(repo_url: str, ref: str = "") -> PluginValidationResult
             else:
                 result.entry_points[str(key)] = val
 
-    deps = [str(d).lower() for d in project.get("dependencies", [])]
-    dep_names = [re.split(r"[<>=!~\[;@ ]", d)[0].strip() for d in deps]
+    deps = [str(d) for d in project.get("dependencies", [])]
+    dep_names = [re.split(r"[<>=!~\[;@ ]", d.lower())[0].strip() for d in deps]
     if "az-scout" not in dep_names:
         result.warnings.append(
             "project.dependencies does not include 'az-scout' – plugin may fail at runtime"
         )
+    else:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        compat_ok, compat_msg = check_core_version_compat(deps)
+        if not compat_ok:
+            result.errors.append(compat_msg)
 
     req_python = project.get("requires-python", "")
     if req_python:

--- a/src/az_scout/plugin_manager/_installer.py
+++ b/src/az_scout/plugin_manager/_installer.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import az_scout.plugin_manager._storage as _storage
@@ -39,11 +41,23 @@ def run_pip(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a ``pip`` command that installs/uninstalls into the plugin packages dir.
 
     Uses ``uv pip`` when available, otherwise falls back to ``python -m pip``.
+
+    For install operations, a constraints file is generated to pin ``az-scout``
+    to the running version, preventing pip from installing a different core
+    version into the target directory.
     """
     _storage._PACKAGES_DIR.mkdir(parents=True, exist_ok=True)
     env = _pip_env()
     uv = _find_uv()
     sub_args = list(args[1:])  # drop leading "pip"
+    is_install = sub_args and sub_args[0] == "install"
+
+    # Generate a constraints file to prevent core package installation
+    constraint_file = None
+    if is_install:
+        constraint_file = _write_core_constraint()
+        if constraint_file:
+            sub_args.insert(1, f"--constraint={constraint_file}")
 
     if uv:
         cmd: list[str] = [uv, "pip", *sub_args, "--target", str(_storage._PACKAGES_DIR)]
@@ -57,13 +71,39 @@ def run_pip(args: list[str]) -> subprocess.CompletedProcess[str]:
         cmd = [sys.executable, "-m", "pip", *sub_args, "--target", str(_storage._PACKAGES_DIR)]
 
     logger.info("Running plugin pip: %s", " ".join(cmd))
-    return subprocess.run(  # noqa: S603
+    result = subprocess.run(  # noqa: S603
         cmd,
         capture_output=True,
         text=True,
         env=env,
         check=False,
     )
+
+    # Clean up the temporary constraints file
+    if constraint_file:
+        with contextlib.suppress(Exception):
+            Path(constraint_file).unlink(missing_ok=True)
+
+    return result
+
+
+def _write_core_constraint() -> str | None:
+    """Write a temporary constraints file pinning ``az-scout`` to the running version.
+
+    Returns the file path, or ``None`` if the version cannot be determined.
+    """
+    try:
+        from az_scout import __version__
+
+        if not __version__ or __version__ == "0.0.0-dev" or "dev" in __version__:
+            return None
+        fd, path = tempfile.mkstemp(prefix="azscout-constraint-", suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write(f"az-scout=={__version__}\n")
+        logger.debug("Core constraint file: %s (az-scout==%s)", path, __version__)
+        return path
+    except Exception:
+        return None
 
 
 def snapshot_native_files(packages_dir: Path | None = None) -> set[Path]:

--- a/src/az_scout/plugin_manager/_pypi.py
+++ b/src/az_scout/plugin_manager/_pypi.py
@@ -86,6 +86,12 @@ def validate_pypi_plugin(package_name: str, version: str = "") -> PluginValidati
         result.warnings.append(
             "Package dependencies do not include 'az-scout' — plugin may fail at runtime"
         )
+    else:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        compat_ok, compat_msg = check_core_version_compat(requires_dist)
+        if not compat_ok:
+            result.errors.append(compat_msg)
 
     project_urls: dict[str, str] = info.get("project_urls") or {}
     if project_urls:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2033,3 +2033,94 @@ class TestInstallRestartRequired:
         data = resp.json()
         assert data["ok"] is True
         assert data["restart_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Core version compatibility check
+# ---------------------------------------------------------------------------
+
+
+class TestCoreVersionCompat:
+    """Tests for check_core_version_compat."""
+
+    def test_compatible_version(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.8"):
+            ok, msg = check_core_version_compat(["az-scout>=2026.3.7"])
+        assert ok is True
+        assert msg == ""
+
+    def test_incompatible_version(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.7"):
+            ok, msg = check_core_version_compat(["az-scout>=2026.3.8"])
+        assert ok is False
+        assert "2026.3.7" in msg
+        assert "2026.3.8" in msg
+
+    def test_no_version_constraint(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.7"):
+            ok, msg = check_core_version_compat(["az-scout"])
+        assert ok is True
+
+    def test_az_scout_not_in_deps(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.7"):
+            ok, msg = check_core_version_compat(["fastapi>=0.100"])
+        assert ok is True
+
+    def test_dev_version_skips_check(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch(
+            "az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.9.dev4"
+        ):
+            ok, msg = check_core_version_compat(["az-scout>=2099.1.0"])
+        assert ok is True
+
+    def test_complex_specifier(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.7"):
+            ok, msg = check_core_version_compat(["az-scout>=2026.3.5,<2027.0.0"])
+        assert ok is True
+
+    def test_complex_specifier_fail(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2027.1.0"):
+            ok, msg = check_core_version_compat(["az-scout>=2026.3.5,<2027.0.0"])
+        assert ok is False
+
+    def test_case_insensitive(self) -> None:
+        from az_scout.plugin_manager._compat import check_core_version_compat
+
+        with patch("az_scout.plugin_manager._compat.get_core_version", return_value="2026.3.7"):
+            ok, msg = check_core_version_compat(["Az-Scout>=2026.3.7"])
+        assert ok is True
+
+
+class TestCoreConstraintFile:
+    """Tests for _write_core_constraint."""
+
+    def test_writes_constraint(self) -> None:
+        from az_scout.plugin_manager._installer import _write_core_constraint
+
+        with patch("az_scout.__version__", "2026.3.8"):
+            path = _write_core_constraint()
+        assert path is not None
+        content = Path(path).read_text()
+        assert "az-scout==2026.3.8" in content
+        Path(path).unlink()
+
+    def test_skips_dev_version(self) -> None:
+        from az_scout.plugin_manager._installer import _write_core_constraint
+
+        with patch("az_scout.__version__", "2026.3.9.dev4"):
+            path = _write_core_constraint()
+        assert path is None


### PR DESCRIPTION
## Description

Prevents plugins from silently upgrading or conflicting with the running az-scout core version during install/update via the Plugin Manager.

### Problem

When a plugin declares `az-scout>=2026.3.8` as a dependency and the running instance is `2026.3.7`, pip would attempt to install `az-scout 2026.3.8` into the `--target` packages directory. This creates two co-existing core versions with undefined import behavior — modules loaded at startup run from `2026.3.7` while newly imported ones resolve to `2026.3.8`.

### Solution: Two safeguards

**1. Pre-install version compatibility check** (`_compat.py`)

During plugin validation (both GitHub and PyPI paths), the plugin's `az-scout` version specifier is parsed using `packaging.specifiers.SpecifierSet` and checked against the running `az_scout.__version__`. Incompatible plugins are blocked with a clear error:

> *"Plugin requires az-scout>=2026.3.8 but this instance runs v2026.3.7. Upgrade az-scout first."*

**2. Pip constraint file** (`_installer.py`)

For all install operations, `run_pip()` generates a temporary constraints file pinning `az-scout=={current_version}`. This is passed via `--constraint=` so pip/uv never resolves a different core version, even for transitive dependencies.

Both checks are skipped for dev versions (e.g. `2026.3.9.dev4`) to avoid blocking development workflows.

### Files changed

- **New:** `src/az_scout/plugin_manager/_compat.py` — `check_core_version_compat()` helper
- **Modified:** `_github.py`, `_pypi.py` — wired compat check into validators
- **Modified:** `_installer.py` — constraint file generation + cleanup
- **Tests:** 10 new tests (version compat + constraint file)
- **Changelog:** updated

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors