### PR TITLE
fix: add HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,8 @@ USER scout
 
 EXPOSE 8000
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
+
 # Container listens on 0.0.0.0:8000, no browser auto-open
 ENTRYPOINT ["az-scout", "web", "--host", "0.0.0.0", "--port", "8000", "--no-open", "--proxy-headers"]


### PR DESCRIPTION
## Summary
Adds a `HEALTHCHECK` instruction to the Dockerfile to satisfy **CKV_DOCKER_2** (code scanning alert #90).

## Changes
- Added `HEALTHCHECK` before `ENTRYPOINT` that probes the root endpoint on port 8000 every 30s.

## Notes
- In Azure Container Apps, the infrastructure-level health probes (configured in Bicep) take precedence over Docker HEALTHCHECK.
- This is primarily for Docker standalone / docker-compose usage.

## Code scanning alerts fixed
- #90 — CKV_DOCKER_2: Ensure HEALTHCHECK instructions have been added to container images