### PR TITLE
fix(frontend): escape quotes in escapeHtml for attribute-context XSS

### DIFF
--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -44,7 +44,7 @@ Reusable renderers available to all plugins via the `window.azScout.components` 
 | `aiEnabled` | `true` if AI chat/completion is configured |
 | `renderMarkdown(md)` | Render Markdown to HTML via marked.js |
 | `tenantQS(prefix)` | Returns `?tenantId=…` or `""` |
-| `escapeHtml(str)` | Escape HTML entities |
+| `escapeHtml(str)` | OWASP Rule #1 entity encoding (`& < > " '`). **Must** be used on every value interpolated into `innerHTML` or attribute contexts. Handles both body and attribute (including `title="..."`, `data-*="..."`) safely. |
 | `subscriptions` | `[{id, name}]` array |
 | `regions` | `[{name, displayName}]` array |
 
@@ -60,3 +60,11 @@ Reusable renderers available to all plugins via the `window.azScout.components` 
 ## Context changes
 
 Plugins react to tenant/region changes via DOM events or MutationObserver on `#region-select`.
+
+## XSS prevention
+
+- **Every** value from Azure APIs or user input interpolated into `innerHTML` **must** be escaped with `escapeHtml()`.
+- This applies to both element body (`<span>${escapeHtml(name)}</span>`) and attribute contexts (`title="${escapeHtml(tip)}"`).
+- `escapeHtml()` encodes the 5 OWASP-mandated characters: `& < > " '`.
+- Do **not** define local escape helpers in plugin JS — reuse the global `escapeHtml()` from `app.js`.
+- For standalone HTML fragments loaded outside `app.js` (e.g. `catalog.html`), use a local fallback that applies the same 5 replacements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Fixed
+
+- **XSS: `escapeHtml()` attribute-context escape** – Replaced the `div.textContent/innerHTML` approach with OWASP Rule #1 character replacement (`& < > " '`), fixing unescaped `"` and `'` in attribute contexts (e.g. `title="..."`, `data-*="..."`). Removed duplicate escape helpers from `plugins.js` and `catalog.html` in favour of the shared global.
+
+### Removed
+
+- **Dead code** – Removed unused `showSignInScreen()` and `getActiveTabFromHash()` from `app.js`.
+
 ## [2026.4.0] - 2026-04-01
 
 ### Added

--- a/src/az_scout/static/html/catalog.html
+++ b/src/az_scout/static/html/catalog.html
@@ -73,12 +73,16 @@
   const filterInput = document.getElementById("catalog-filter");
   let plugins = [];
 
-  function esc(s) {
-    if (!s) return "";
-    const d = document.createElement("div");
-    d.textContent = s;
-    return d.innerHTML.replace(/'/g, "&#39;");
-  }
+  // Use global escapeHtml() from app.js when available, standalone fallback otherwise.
+  const esc = typeof escapeHtml === "function" ? escapeHtml : function(s) {
+    if (s == null) return "";
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  };
 
   function renderCard(p) {
     const isWip = (p.tags || []).some(function(t) { return t.toLowerCase() === "wip"; });

--- a/src/az_scout/static/js/app.js
+++ b/src/az_scout/static/js/app.js
@@ -105,48 +105,6 @@ async function init() {
 }
 
 // ---------------------------------------------------------------------------
-// OBO sign-in screen (shown when OBO is enabled but user is not signed in)
-// ---------------------------------------------------------------------------
-function showSignInScreen() {
-    // Hide main content
-    const main = document.getElementById("main-content");
-    if (main) main.style.display = "none";
-
-    // Create sign-in screen
-    let screen = document.getElementById("obo-signin-screen");
-    if (!screen) {
-        screen = document.createElement("div");
-        screen.id = "obo-signin-screen";
-        screen.className = "d-flex flex-column align-items-center justify-content-center";
-        screen.style.cssText = "min-height: 60vh; text-align: center;";
-        screen.innerHTML = `
-            <div style="max-width: 420px;">
-                <img src="/static/img/favicon.svg" width="64" height="64" alt="" class="mb-3 opacity-75">
-                <h3 class="mb-2">Welcome to Azure Scout</h3>
-                <p class="text-body-secondary mb-4">
-                    Sign in with your Microsoft account to explore Azure resources
-                    using your own permissions.
-                </p>
-                <a href="/auth/login" class="btn btn-primary btn-lg">
-                    <i class="bi bi-microsoft"></i> Sign in with Microsoft
-                </a>
-                <p class="text-body-secondary small mt-3">
-                    Your Azure RBAC permissions determine what you can access.
-                </p>
-            </div>`;
-        document.querySelector(".container-fluid.mt-3")?.prepend(screen);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// URL hash helper  (only stores active tab, no query params)
-// ---------------------------------------------------------------------------
-function getActiveTabFromHash() {
-    const h = window.location.hash.replace(/^#/, '');
-    return h || "topology";
-}
-
-// ---------------------------------------------------------------------------
 // API helpers
 // Cookies are sent automatically — no client-side token injection needed.
 // ---------------------------------------------------------------------------
@@ -223,10 +181,20 @@ function tenantQS(prefix) {
     return (prefix || "&") + "tenantId=" + encodeURIComponent(tid);
 }
 
+/**
+ * Escape a value for safe interpolation into innerHTML / attribute contexts.
+ * Covers OWASP XSS Prevention Rule #1: encode & < > " '
+ * @param {*} str - value to escape (null/undefined become "").
+ * @returns {string}
+ */
 function escapeHtml(str) {
-    const div = document.createElement("div");
-    div.textContent = str;
-    return div.innerHTML;
+    if (str == null) return "";
+    return String(str)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
 }
 
 /**

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -80,11 +80,8 @@
 
     // ---- Card enhancement (progressive enhancement of catalog.html) ----
 
-    function escHtml(s) {
-        const d = document.createElement("div");
-        d.textContent = String(s || "");
-        return d.innerHTML;
-    }
+    // Use global escapeHtml() from app.js for HTML entity escaping.
+    const escHtml = escapeHtml;
 
     function escAttr(s) {
         return String(s || "")


### PR DESCRIPTION
## Description

Fix attribute-context XSS vulnerability in the core `escapeHtml()` function. The previous `div.textContent/innerHTML` approach did not escape `"` or `'`, allowing attribute breakout in `title="..."`, `data-*="..."`, and similar contexts.

Replaced with OWASP XSS Prevention Rule #1 character replacement encoding all 5 mandated characters: `& < > " '`.

Also removes duplicate escape helpers from `plugins.js` and `catalog.html`, and adds an **XSS prevention** section to the frontend instructions for plugin authors.

Dead code cleanup: removed unused `showSignInScreen()` and `getActiveTabFromHash()`.

## Related issue

<!-- No specific issue — discovered during ODCR plugin XSS review -->

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

