### PR TITLE
fix(frontend): restore page reload after plugin install/uninstall/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 ### Fixed
 
 - **XSS: `escapeHtml()` attribute-context escape** – Replaced the `div.textContent/innerHTML` approach with OWASP Rule #1 character replacement (`& < > " '`), fixing unescaped `"` and `'` in attribute contexts (e.g. `title="..."`, `data-*="..."`). Removed duplicate escape helpers from `plugins.js` and `catalog.html` in favour of the shared global.
+- **Plugin Manager reload** – Restored full page reload after plugin install/uninstall/update so new or removed tabs, routes, and JS are picked up.
 
 ### Removed
 

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -502,8 +502,9 @@
 
     // ---- Refresh ----
 
+    /** Reload the page to pick up new/removed plugin tabs, routes, and JS. */
     function refreshAll() {
-        loadPlugins();
+        window.location.reload();
     }
 
     // ---- UI helpers ----


### PR DESCRIPTION
## Description

Restore full page reload after plugin install/uninstall/update operations. The `refreshAll()` function was only calling `loadPlugins()` which refreshes plugin cards inside the modal, but does not reload the page to pick up new/removed plugin tabs, routes, and JS files injected server-side.

## Related issue

Regression from #144 (escapeHtml XSS fix branch also touched plugins.js).

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
