### PR TITLE
feat: shared SKU detail modal, expanded capabilities, planner migration

### DIFF
--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -19,7 +19,7 @@ Reusable renderers available to all plugins via the `window.azScout.components` 
 | Module | Functions |
 |---|---|
 | `sku-badges.js` | `scoreLabel()`, `renderConfidenceBadge()`, `renderSpotBadges()`, `renderSpotBadge()`, `renderZoneBadges()`, `renderQuotaBar()` |
-| `sku-detail-modal.js` | `renderVmProfile()`, `renderZoneAvailability()`, `renderQuotaPanel()`, `renderConfidenceBreakdown()`, `renderPricingPanel()` |
+| `sku-detail-modal.js` | `renderVmProfile()`, `renderZoneAvailability()`, `renderQuotaPanel()`, `renderConfidenceBreakdown()`, `renderPricingPanel()`, `showSkuDetailModal()` |
 | `data-filters.js` | `parseNumericFilter()`, `matchNumericFilter()`, `buildColumnFilters()`, `applyColumnFilters()` |
 
 ## CSS

--- a/.github/instructions/plugin-scaffold.instructions.md
+++ b/.github/instructions/plugin-scaffold.instructions.md
@@ -65,3 +65,13 @@ if is_ai_enabled():
 
 `apiFetch`, `apiPost`, `aiComplete`, `aiEnabled`, `renderMarkdown`,
 `tenantQS`, `escapeHtml`, `subscriptions`, `regions`
+
+## Create a new plugin
+
+If you need to create a new plugin, use the following command to scaffold a new plugin directory with template files:
+
+```bash
+az-scout create-plugin
+```
+
+Follow the prompts to enter the plugin name and description. This will create a new directory with a basic plugin structure and you can start implementing your plugin logic there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Added
+
+- **`showSkuDetailModal()`** – New shared JS component in `sku-detail-modal.js` that provides a full-flow SKU detail modal for all plugins. Shows loading state, fetches from `/api/sku-detail`, renders confidence breakdown (with signal tooltips, knockout reasons, disclaimers), VM profile, zone availability, quota, pricing (with currency selector), and supports plugin-specific extra sections and recalculate callbacks. Modal DOM is created lazily — no `index.html` changes needed.
+- **`parse_sku_series()`** – New utility in `azure_api.skus` that extracts the VM series prefix from ARM SKU names (e.g. `Standard_D2s_v5` → `D`, `Standard_NC24ads_A100_v4` → `NC`). Exported in `azure_api` public API.
+- **Expanded SKU capabilities** – `get_skus()` now extracts 15 capabilities (up from 4): added `AcceleratedNetworkingEnabled`, `EphemeralOSDiskSupported`, `HyperVGenerations`, `GPUs`, `CachedDiskBytes`, `MaxResourceVolumeMB`, `LowPriorityCapable`, `TrustedLaunchDisabled`, `EncryptionAtHostSupported`, `CpuArchitectureType`, `UltraSSDAvailable`. Enables workload eligibility filtering by plugins.
+
+### Changed
+
+- **Planner modal migration** – Planner now uses shared `showSkuDetailModal()` instead of its own custom modal. Removes ~200 lines of duplicate rendering code. Planner-specific features (recalculate with Spot, instance count) are injected via `onRecalculate` callback.
+- **`renderConfidenceBreakdown()`** – Upgraded shared component with signal description tooltips, knockout reasons alert, disclaimers with "Learn more" link, and dynamic title (blocked/basic+spot/basic).
+- **PLUGIN_API_VERSION** bumped to `1.3` (additive: new exports, expanded capabilities).
+
 ### Fixed
 
 - **XSS: `escapeHtml()` attribute-context escape** – Replaced the `div.textContent/innerHTML` approach with OWASP Rule #1 character replacement (`& < > " '`), fixing unescaped `"` and `'` in attribute contexts (e.g. `title="..."`, `data-*="..."`). Removed duplicate escape helpers from `plugins.js` and `catalog.html` in favour of the shared global.
@@ -15,6 +27,7 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 ### Removed
 
 - **Dead code** – Removed unused `showSignInScreen()` and `getActiveTabFromHash()` from `app.js`.
+- **Planner duplicate code** – Removed local `renderConfidenceBreakdown()`, `renderZoneAvailability()`, `renderPricingDetail()`, `fetchPricingDetail()`, `refreshPricingModal()` from planner.js (now handled by shared modal).
 
 ## [2026.4.0] - 2026-04-01
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -262,4 +262,4 @@ Every score result includes these disclaimers:
 ## References
 
 [protean]: https://www.usenix.org/conference/osdi20/presentation/hadary "Protean: VM Allocation Service at Scale (OSDI 2020)"
-[kerveros]: https://www.usenix.org/conference/osdi23/presentation/li-jiaqi "Kerveros: Efficient and Scalable Cloud Admission Control (OSDI 2023)"
+[kerveros]: https://www.usenix.org/conference/osdi23/presentation/sajal "Kerveros: Efficient and Scalable Cloud Admission Control (OSDI 2023)"

--- a/src/az_scout/azure_api/__init__.py
+++ b/src/az_scout/azure_api/__init__.py
@@ -104,6 +104,7 @@ from az_scout.azure_api.skus import (  # noqa: F401
     get_mappings,
     get_sku_profile,
     get_skus,
+    parse_sku_series,
 )
 
 # -- Spot --------------------------------------------------------------------
@@ -189,7 +190,7 @@ async def enrich_skus(
 # ---------------------------------------------------------------------------
 # API version – bump major for breaking changes, minor for additions.
 # ---------------------------------------------------------------------------
-PLUGIN_API_VERSION = "1.2"
+PLUGIN_API_VERSION = "1.3"
 """Semantic version of the plugin-facing API surface (``__all__``)."""
 
 # ---------------------------------------------------------------------------
@@ -224,6 +225,7 @@ __all__ = [
     # SKU catalogue
     "get_skus",
     "get_sku_profile",
+    "parse_sku_series",
     # Enrichment (mutate SKU dicts in-place)
     "enrich_skus_with_prices",
     "enrich_skus_with_quotas",

--- a/src/az_scout/azure_api/skus.py
+++ b/src/az_scout/azure_api/skus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import Any
 
@@ -21,6 +22,47 @@ _sku_profile_cache: dict[str, tuple[float, dict[str, Any] | None]] = {}
 # SKU list cache – keyed by (subscription, region, resource_type, tenant)
 _SKU_LIST_CACHE_TTL = 600  # 10 minutes
 _sku_list_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+
+# Capabilities extracted into every SKU dict returned by get_skus().
+# Kept intentionally lean – only fields that plugins commonly filter on.
+_LISTING_CAPABILITIES = frozenset(
+    {
+        "vCPUs",
+        "MemoryGB",
+        "MaxDataDiskCount",
+        "PremiumIO",
+        "AcceleratedNetworkingEnabled",
+        "EphemeralOSDiskSupported",
+        "HyperVGenerations",
+        "GPUs",
+        "CachedDiskBytes",
+        "MaxResourceVolumeMB",
+    }
+)
+
+# Regex to extract the VM series prefix from an ARM SKU name.
+# Examples:  Standard_D2s_v5 → D,  Standard_NC24ads_A100_v4 → NC,  Standard_B2s → B
+_SERIES_RE = re.compile(r"^(?:Standard|Basic)_([A-Z]+)", re.IGNORECASE)
+
+
+def parse_sku_series(sku_name: str) -> str:
+    """Extract the VM series prefix from an ARM SKU name.
+
+    Returns the uppercase series letter(s) (e.g. ``"D"``, ``"NC"``, ``"B"``,
+    ``"FX"``).  Returns ``""`` if the name doesn't match the expected pattern.
+
+    Examples::
+
+        >>> parse_sku_series("Standard_D2s_v5")
+        'D'
+        >>> parse_sku_series("Standard_NC24ads_A100_v4")
+        'NC'
+        >>> parse_sku_series("Standard_B2s")
+        'B'
+    """
+    m = _SERIES_RE.match(sku_name)
+    return m.group(1).upper() if m else ""
 
 
 def _sku_name_matches(filter_val: str, sku_name: str) -> bool:
@@ -146,7 +188,7 @@ def get_skus(
         for cap in sku.get("capabilities", []):
             cap_name = cap.get("name", "")
             cap_value = cap.get("value", "")
-            if cap_name in ("vCPUs", "MemoryGB", "MaxDataDiskCount", "PremiumIO"):
+            if cap_name in _LISTING_CAPABILITIES:
                 capabilities[cap_name] = cap_value
 
         # vCPU / memory range filters

--- a/src/az_scout/azure_api/skus.py
+++ b/src/az_scout/azure_api/skus.py
@@ -38,6 +38,11 @@ _LISTING_CAPABILITIES = frozenset(
         "GPUs",
         "CachedDiskBytes",
         "MaxResourceVolumeMB",
+        "LowPriorityCapable",
+        "TrustedLaunchDisabled",
+        "EncryptionAtHostSupported",
+        "CpuArchitectureType",
+        "UltraSSDAvailable",
     }
 )
 

--- a/src/az_scout/internal_plugins/planner/static/html/planner-tab.html
+++ b/src/az_scout/internal_plugins/planner/static/html/planner-tab.html
@@ -94,21 +94,4 @@
     </div>
 </div>
 
-<!-- ===== Pricing Detail Modal ===== -->
-<div class="modal fade" id="pricingModal" tabindex="-1" aria-labelledby="pricingModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-xl modal-fullscreen-md-down modal-dialog-centered modal-dialog-scrollable">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="pricingModalLabel">SKU Detail — <span id="pricing-modal-sku"></span></h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div id="pricing-modal-loading" class="text-center d-none">
-                    <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
-                    <span class="ms-2 small">Fetching prices…</span>
-                </div>
-                <div id="pricing-modal-content" class="d-none"></div>
-            </div>
-        </div>
-    </div>
-</div>
+<!-- SKU Detail Modal: now uses shared showSkuDetailModal() from sku-detail-modal.js -->

--- a/src/az_scout/internal_plugins/planner/static/js/planner.js
+++ b/src/az_scout/internal_plugins/planner/static/js/planner.js
@@ -270,138 +270,8 @@ function getPlannerPhysicalZoneMap() {
 }
 
 // ---------------------------------------------------------------------------
-// Include Spot in Deployment Confidence (called from confidence controls)
-// ---------------------------------------------------------------------------
-async function includeSpotInConfidence() {
-    const skuName = _pricingModalSku;
-    if (!skuName) return;
-    const region = document.getElementById("region-select").value;
-    const tenant = document.getElementById("tenant-select").value;
-    const subscriptionId = plannerSubscriptionId;
-    if (!subscriptionId || !region) return;
-
-    const btn = document.querySelector('.confidence-controls .btn-outline-primary');
-    const origHtml = btn?.innerHTML;
-    if (btn) {
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Calculating…';
-    }
-    const instanceCount = parseInt(document.getElementById("confidence-instance-count")?.value, 10) || 1;
-    const currency = document.getElementById("planner-currency")?.value || "USD";
-
-    try {
-        const payload = {
-            subscriptionId,
-            region,
-            currencyCode: currency,
-            preferSpot: true,
-            instanceCount,
-            skus: [skuName],
-            includeSignals: false,
-            includeProvenance: true,
-        };
-        if (tenant) payload.tenantId = tenant;
-
-        const result = await apiPost("/api/deployment-confidence", payload);
-
-        let spotIncluded = false;
-        if (result.results) {
-            for (const r of result.results) {
-                const sku = (lastSkuData || []).find(s => s.name === r.sku);
-                if (sku && r.deploymentConfidence) {
-                    sku.confidence = r.deploymentConfidence;
-                    if (r.deploymentConfidence.scoreType === "basic+spot") spotIncluded = true;
-                }
-            }
-        }
-
-        // Show feedback if spot could not be included
-        if (!spotIncluded) {
-            const reason = (result.warnings || []).join("; ") || "Spot Placement Scores unavailable or restricted for this SKU.";
-            showError("planner-error", reason);
-        }
-
-        // Re-render table and region summary
-        if (lastSkuData) {
-            renderRegionSummary(lastSkuData);
-            renderSkuTable(lastSkuData);
-        }
-
-        // Re-render modal in place, keeping open accordions
-        if (_lastPricingData) {
-            const content = document.getElementById("pricing-modal-content");
-            const openIds = [...content.querySelectorAll('.accordion-collapse.show')].map(el => el.id).filter(Boolean);
-            renderPricingDetail(_lastPricingData, openIds);
-        }
-    } catch (err) {
-        showError("planner-error", "Failed to include Spot in confidence: " + err.message);
-        if (btn) { btn.disabled = false; btn.innerHTML = origHtml; }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Reset to Basic confidence (exclude Spot)
-// ---------------------------------------------------------------------------
-async function resetToBasicConfidence() {
-    const skuName = _pricingModalSku;
-    if (!skuName) return;
-    const region = document.getElementById("region-select").value;
-    const tenant = document.getElementById("tenant-select").value;
-    const subscriptionId = plannerSubscriptionId;
-    if (!subscriptionId || !region) return;
-
-    const btn = document.querySelector('.confidence-controls .btn-outline-success');
-    const origHtml = btn?.innerHTML;
-    if (btn) {
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Recalculating…';
-    }
-    const currency = document.getElementById("planner-currency")?.value || "USD";
-    const instanceCount = parseInt(document.getElementById("confidence-instance-count")?.value, 10) || 1;
-
-    try {
-        const payload = {
-            subscriptionId,
-            region,
-            currencyCode: currency,
-            preferSpot: false,
-            instanceCount,
-            skus: [skuName],
-            includeSignals: false,
-            includeProvenance: true,
-        };
-        if (tenant) payload.tenantId = tenant;
-
-        const result = await apiPost("/api/deployment-confidence", payload);
-        if (result.results) {
-            for (const r of result.results) {
-                const sku = (lastSkuData || []).find(s => s.name === r.sku);
-                if (sku && r.deploymentConfidence) {
-                    sku.confidence = r.deploymentConfidence;
-                }
-            }
-        }
-
-        // Re-render table and region summary
-        if (lastSkuData) {
-            renderRegionSummary(lastSkuData);
-            renderSkuTable(lastSkuData);
-        }
-
-        // Re-render modal in place, keeping open accordions
-        if (_lastPricingData) {
-            const content = document.getElementById("pricing-modal-content");
-            const openIds = [...content.querySelectorAll('.accordion-collapse.show')].map(el => el.id).filter(Boolean);
-            renderPricingDetail(_lastPricingData, openIds);
-        }
-    } catch (err) {
-        showError("planner-error", "Failed to reset confidence: " + err.message);
-        if (btn) { btn.disabled = false; btn.innerHTML = origHtml; }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Fetch spot score from the Zone Availability panel button
+// Spot score fetching from Zone Availability panel (kept for the shared modal
+// zone panel's "Fetch Spot Scores" button which uses onclick="fetchSpotFromPanel()")
 // ---------------------------------------------------------------------------
 async function fetchSpotFromPanel() {
     const skuName = _pricingModalSku;
@@ -411,13 +281,6 @@ async function fetchSpotFromPanel() {
     const subscriptionId = plannerSubscriptionId;
     if (!subscriptionId || !region) return;
 
-    // Show spinner on button
-    const btn = document.querySelector('#zoneCollapsePanel .btn-outline-primary');
-    const origHtml = btn?.innerHTML;
-    if (btn) {
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Fetching…';
-    }
     const instanceCount = parseInt(document.getElementById("spot-panel-instances")?.value, 10) || 1;
 
     try {
@@ -430,29 +293,31 @@ async function fetchSpotFromPanel() {
                 lastSpotScores.scores[sku] = { ...(lastSpotScores.scores[sku] || {}), ...zoneScores };
             }
         }
-        if (result.errors?.length) lastSpotScores.errors.push(...result.errors);
 
-        // Refresh confidence from the backend (canonical source of truth)
+        // Refresh confidence + re-render table
         if (lastSkuData) {
             await refreshDeploymentConfidence([skuName]);
             renderRegionSummary(lastSkuData);
             renderSkuTable(lastSkuData);
         }
 
-        // Re-render modal in place with Zone Availability kept open
-        if (_lastPricingData) {
-            // Collect currently open accordion panels
-            const content = document.getElementById("pricing-modal-content");
-            const openIds = [...content.querySelectorAll('.accordion-collapse.show')].map(el => el.id).filter(Boolean);
-            // Ensure zone accordion stays open
-            if (!openIds.includes('zoneCollapsePanel')) openIds.push('zoneCollapsePanel');
-            renderPricingDetail(_lastPricingData, openIds);
-        }
+        // Re-open the shared modal with updated spot data
+        const enriched = (lastSkuData || []).find(s => s.name === skuName) || {};
+        _C.showSkuDetailModal(skuName, {
+            region,
+            subscriptionId: plannerSubscriptionId,
+            currency: _pricingModalCurrency,
+            enrichedSku: enriched,
+            physicalZoneMap: getPlannerPhysicalZoneMap(),
+            onRecalculate: _plannerRecalculate,
+            onAfterRecalculate: () => {
+                if (lastSkuData) { renderRegionSummary(lastSkuData); renderSkuTable(lastSkuData); }
+            },
+        });
 
         if (result.errors?.length) showError("planner-error", "Spot score error: " + result.errors.join("; "));
     } catch (err) {
         showError("planner-error", "Failed to fetch Spot Score: " + err.message);
-        if (btn) { btn.disabled = false; btn.innerHTML = origHtml; }
     }
 }
 
@@ -533,362 +398,88 @@ async function confirmSpotScore() {
 }
 
 // ---------------------------------------------------------------------------
-// SKU Detail Modal
+// SKU Detail Modal (delegates to shared showSkuDetailModal)
 // ---------------------------------------------------------------------------
 let _pricingModalSku = null;
-let _pricingModal = null;
 let _pricingModalCurrency = "USD";
-let _lastPricingData = null;
 
 function openPricingModal(skuName) {
     _pricingModalSku = skuName;
-    document.getElementById("pricing-modal-sku").textContent = skuName;
-    document.getElementById("pricing-modal-loading").classList.add("d-none");
-    document.getElementById("pricing-modal-content").classList.add("d-none");
-    if (!_pricingModal) _pricingModal = new bootstrap.Modal(document.getElementById("pricingModal"));
-    _pricingModal.show();
-    fetchPricingDetail();
+    const enriched = (lastSkuData || []).find(s => s.name === skuName) || {};
+    _pricingModalCurrency = document.getElementById("planner-currency")?.value || "USD";
+
+    _C.showSkuDetailModal(skuName, {
+        region: document.getElementById("region-select").value,
+        subscriptionId: plannerSubscriptionId,
+        currency: _pricingModalCurrency,
+        enrichedSku: enriched,
+        physicalZoneMap: getPlannerPhysicalZoneMap(),
+        onRecalculate: _plannerRecalculate,
+        onAfterRecalculate: (_conf) => {
+            // Re-render main table with updated confidence
+            if (lastSkuData) {
+                renderRegionSummary(lastSkuData);
+                renderSkuTable(lastSkuData);
+            }
+        },
+    });
 }
 
-function refreshPricingModal() {
-    const sel = document.getElementById("pricing-modal-currency-select");
-    if (sel) _pricingModalCurrency = sel.value;
-    if (_pricingModalSku) fetchPricingDetail();
-}
-
-async function fetchPricingDetail() {
-    const skuName = _pricingModalSku;
-    if (!skuName) return;
+/**
+ * Planner-specific recalculate callback.
+ * Calls POST /api/deployment-confidence (supports preferSpot + instanceCount).
+ */
+async function _plannerRecalculate(skuName, instanceCount, includeSpot) {
     const region = document.getElementById("region-select").value;
+    const tenant = document.getElementById("tenant-select").value;
+    const subscriptionId = plannerSubscriptionId;
+    if (!subscriptionId || !region) throw new Error("Missing subscription or region");
+
     const currency = _pricingModalCurrency;
-    if (!region) return;
-
-    document.getElementById("pricing-modal-loading").classList.remove("d-none");
-    document.getElementById("pricing-modal-content").classList.add("d-none");
-
-    try {
-        const params = new URLSearchParams({ region, sku: skuName, currencyCode: currency });
-        if (plannerSubscriptionId) params.set("subscriptionId", plannerSubscriptionId);
-        const tqs = tenantQS("&");
-        const data = await apiFetch(`/api/sku-detail?${params}${tqs}`);
-        renderPricingDetail(data);
-    } catch (err) {
-        const content = document.getElementById("pricing-modal-content");
-        content.innerHTML = `<p class="text-danger small">Failed to load pricing: ${escapeHtml(err.message)}</p>`;
-        content.classList.remove("d-none");
-    } finally {
-        document.getElementById("pricing-modal-loading").classList.add("d-none");
-    }
-}
-
-function renderPricingDetail(data, openAccordionIds) {
-    _lastPricingData = data;
-    const content = document.getElementById("pricing-modal-content");
-    const currency = data.currency || "USD";
-    const HOURS_PER_MONTH = 730;
-
-    const confSku = (lastSkuData || []).find(s => s.name === _pricingModalSku);
-
-    // Update local pricing data (for display) – confidence is NOT recomputed
-    // here; it comes from the backend (canonical source of truth).
-    if (confSku && (data.paygo != null || data.spot != null)) {
-        if (!confSku.pricing) confSku.pricing = {};
-        if (data.paygo != null) confSku.pricing.paygo = data.paygo;
-        if (data.spot != null) confSku.pricing.spot = data.spot;
-        confSku.pricing.currency = currency;
-    }
-
-    // Build sections in order: Confidence → VM Profile → Zone Availability → Quota → Pricing
-    let html = "";
-    if (confSku?.confidence) html += renderConfidenceBreakdown(confSku.confidence);
-    if (data.profile) html += renderVmProfile(data.profile);
-    if (data.profile) html += renderZoneAvailability(data.profile, confSku?.confidence);
-    const vcpus = parseInt(confSku?.capabilities?.vCPUs, 10) || 0;
-    if (confSku?.quota) html += renderQuotaPanel(confSku.quota, vcpus, confSku.confidence);
-
-    // Build pricing table
-    const spotDiscount = (data.paygo != null && data.spot != null && data.paygo > 0)
-        ? Math.round((1 - data.spot / data.paygo) * 100)
-        : null;
-    const spotLabel = spotDiscount != null
-        ? `Spot <span class="badge bg-success-subtle text-success-emphasis ms-1">\u2212${spotDiscount}%</span>`
-        : "Spot";
-    const rows = [
-        { label: "Pay-As-You-Go", hourly: data.paygo },
-        { label: spotLabel, raw: true, hourly: data.spot },
-        { label: "Reserved Instance 1Y", hourly: data.ri_1y },
-        { label: "Reserved Instance 3Y", hourly: data.ri_3y },
-        { label: "Savings Plan 1Y", hourly: data.sp_1y },
-        { label: "Savings Plan 3Y", hourly: data.sp_3y },
-    ];
-
-    let pricingHtml = '<table class="table table-sm pricing-detail-table mb-0">';
-    pricingHtml += `<thead><tr><th>Type</th><th>${escapeHtml(currency)}/hour</th><th>${escapeHtml(currency)}/month</th></tr></thead><tbody>`;
-    rows.forEach(r => {
-        const hourStr = r.hourly != null ? formatNum(r.hourly, 4) : "\u2014";
-        const monthStr = r.hourly != null ? formatNum(r.hourly * HOURS_PER_MONTH, 2) : "\u2014";
-        const labelHtml = r.raw ? r.label : escapeHtml(r.label);
-        pricingHtml += `<tr><td>${labelHtml}</td><td class="price-cell">${hourStr}</td><td class="price-cell">${monthStr}</td></tr>`;
-    });
-    pricingHtml += "</tbody></table>";
-
-    // Currency selector options
-    const currencies = ["USD", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "SEK", "BRL", "INR"];
-    const currencyOpts = currencies.map(c =>
-        `<option value="${c}"${c === currency ? " selected" : ""}>${c}</option>`
-    ).join("");
-
-    // Wrap pricing + currency in a collapsible accordion
-    html += '<div class="accordion mt-3" id="pricingAccordion">';
-    html += '<div class="accordion-item">';
-    html += '<h2 class="accordion-header">';
-    html += '<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#pricingCollapsePanel" aria-expanded="false" aria-controls="pricingCollapsePanel">';
-    html += '<i class="bi bi-currency-exchange me-2"></i>Pricing';
-    html += '</button></h2>';
-    html += '<div id="pricingCollapsePanel" class="accordion-collapse collapse" data-bs-parent="#pricingAccordion">';
-    html += '<div class="accordion-body p-2">';
-    html += '<div class="d-flex align-items-center gap-2 mb-2">';
-    html += '<label for="pricing-modal-currency-select" class="form-label small mb-0">Currency:</label>';
-    html += `<select class="form-select form-select-sm" id="pricing-modal-currency-select" onchange="refreshPricingModal()" style="width:100px;">${currencyOpts}</select>`;
-    html += '</div>';
-    html += pricingHtml;
-    html += '</div></div></div></div>';
-
-    content.innerHTML = html;
-    content.classList.remove("d-none");
-
-    // Restore open accordion panels
-    if (openAccordionIds?.length) {
-        openAccordionIds.forEach(id => {
-            const panel = content.querySelector(`#${id}`);
-            if (panel) panel.classList.add("show");
-            const btn = content.querySelector(`[data-bs-target="#${id}"]`);
-            if (btn) { btn.classList.remove("collapsed"); btn.setAttribute("aria-expanded", "true"); }
-        });
-    }
-
-    // Init Bootstrap tooltips for confidence info icons
-    content.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
-        new bootstrap.Tooltip(el, { delay: { show: 0, hide: 100 }, placement: "top" });
-    });
-}
-
-function renderVmProfile(profile) {
-    return _C.renderVmProfile ? _C.renderVmProfile(profile) : "";
-}
-
-function renderZoneAvailability(profile, confidence) {
-    const zones = profile.zones || [];
-    const restrictions = profile.restrictions || [];
-    const _components = confidence?.breakdown?.components || [];
-    const zoneSignal = _components.find(b => b.name === "zones");
-    const zoneScore = zoneSignal?.score100;
-    const spotSignal = _components.find(b => b.name === "spot");
-    const spotScore = spotSignal?.score100;
-    const physicalZoneMap = getPlannerPhysicalZoneMap();
-    const spotZoneScores = lastSpotScores?.scores?.[_pricingModalSku] || {};
-
-    function row(label, value) {
-        return `<div class="vm-profile-row"><span class="vm-profile-label">${escapeHtml(label)}</span><span>${value}</span></div>`;
-    }
-    function val(v) {
-        if (v == null) return '<span class="vm-badge vm-badge-unknown">\u2014</span>';
-        return escapeHtml(String(v));
-    }
-
-    const reasonLabels = {
-        NotAvailableForSubscription: "Not available for this subscription",
-        QuotaId: "Subscription offer type not eligible",
+    const payload = {
+        subscriptionId,
+        region,
+        currencyCode: currency,
+        preferSpot: includeSpot,
+        instanceCount,
+        skus: [skuName],
+        includeSignals: false,
+        includeProvenance: true,
     };
+    if (tenant) payload.tenantId = tenant;
 
-    const hasLocationRestriction = restrictions.some(r => r.type === "Location");
-    const zoneRestrictionZones = new Set(restrictions.filter(r => r.type === "Zone").flatMap(r => r.zones || []));
-    const allZoneIds = [...new Set([...["1", "2", "3"], ...zones])].sort();
-    const availableCount = zones.filter(z => !zoneRestrictionZones.has(z) && !hasLocationRestriction).length;
+    const result = await apiPost("/api/deployment-confidence", payload);
 
-    let bodyHtml = '<div class="vm-profile-grid">';
-
-    // Zone status card
-    bodyHtml += '<div class="vm-profile-card">';
-    bodyHtml += '<div class="vm-profile-card-title">Zones</div>';
-    if (hasLocationRestriction) {
-        bodyHtml += row("Region", '<span class="vm-badge vm-badge-no">Restricted</span>');
-    }
-    bodyHtml += row("Available", val(availableCount + " / 3"));
-    allZoneIds.forEach(z => {
-        const pz = physicalZoneMap[z];
-        const zLabel = `Zone ${z}`;
-        const pzTip = pz ? ` data-bs-toggle="tooltip" data-bs-title="${escapeHtml(pz)}"` : "";
-        const offered = zones.includes(z);
-        const restricted = zoneRestrictionZones.has(z) || hasLocationRestriction;
-        if (!offered && !restricted) {
-            bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label"${pzTip}>${escapeHtml(zLabel)}</span><span class="vm-badge vm-badge-unknown">Not offered</span></div>`;
-        } else if (restricted) {
-            bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label"${pzTip}>${escapeHtml(zLabel)}</span><span class="vm-badge vm-badge-no">Restricted</span></div>`;
-        } else {
-            bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label"${pzTip}>${escapeHtml(zLabel)}</span><span class="vm-badge vm-badge-yes">Available</span></div>`;
-        }
-    });
-    if (zoneScore != null) {
-        const lbl = _scoreLabel(zoneScore).toLowerCase().replace(/\s+/g, "-");
-        bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label">Breadth Score</span><span class="confidence-badge confidence-${lbl}" data-bs-toggle="tooltip" data-bs-title="Zone Breadth signal: ${availableCount}/3 zones available without restrictions. Score of 100 means all 3 zones are offered and unrestricted.">${zoneScore}/100</span></div>`;
-    }
-    bodyHtml += '</div>';
-
-    // Spot Placement card
-    const hasSpotData = Object.keys(spotZoneScores).length > 0;
-    const spotLabels = {
-        high: "High", medium: "Medium", low: "Low",
-        restrictedskunotavailable: "Restricted", unknown: "Unknown",
-        datanotfoundorstale: "No data",
-    };
-    function spotBadgeHtml(raw) {
-        const key = (raw || "").toLowerCase();
-        const friendly = spotLabels[key] || raw;
-        const knownClass = ["high", "medium", "low"].includes(key) ? `spot-badge spot-${key}` : "vm-badge vm-badge-unknown";
-        return `<span class="${knownClass}">${escapeHtml(friendly)}</span>`;
-    }
-    bodyHtml += '<div class="vm-profile-card">';
-    bodyHtml += '<div class="vm-profile-card-title">Spot Placement</div>';
-    const modalSku = (lastSkuData || []).find(s => s.name === _pricingModalSku);
-    const hasSpotPrice = modalSku?.pricing?.spot != null || (_lastPricingData?.spot != null);
-    if (!hasSpotData && !hasSpotPrice) {
-        bodyHtml += row("Status", '<span class="vm-badge vm-badge-unknown">No spot pricing</span>');
-    } else if (!hasSpotData) {
-        bodyHtml += row("Status", '<span class="vm-badge vm-badge-unknown">No data</span>');
-        bodyHtml += '<div class="vm-profile-row"><div class="d-flex align-items-center gap-2 w-100">';
-        bodyHtml += '<input type="number" id="spot-panel-instances" class="form-control form-control-sm" value="1" min="1" max="1000" style="width:70px;" title="Instance count">';
-        bodyHtml += '<button class="btn btn-sm btn-outline-primary flex-grow-1" onclick="fetchSpotFromPanel()"><i class="bi bi-lightning-charge me-1"></i>Fetch Spot Scores</button>';
-        bodyHtml += '</div></div>';
-    } else {
-        const bestLabel = _bestSpotLabel(spotZoneScores);
-        allZoneIds.forEach(z => {
-            const pz = physicalZoneMap[z];
-            const zLabel = `Zone ${z}`;
-            const pzTip = pz ? ` data-bs-toggle="tooltip" data-bs-title="${escapeHtml(pz)}"` : "";
-            const s = spotZoneScores[z];
-            if (s) {
-                const key = s.toLowerCase();
-                const isBest = key === (bestLabel || "").toLowerCase() && ["high", "medium", "low"].includes(key);
-                const star = isBest ? ' <i class="bi bi-star-fill text-warning" data-bs-toggle="tooltip" data-bs-title="Best eviction rate \u2014 used for confidence score"></i>' : "";
-                bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label"${pzTip}>${escapeHtml(zLabel)}</span><span>${spotBadgeHtml(s)}${star}</span></div>`;
-            } else {
-                bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label"${pzTip}>${escapeHtml(zLabel)}</span><span class="vm-badge vm-badge-unknown">\u2014</span></div>`;
+    let confidence = null;
+    if (result.results) {
+        for (const r of result.results) {
+            const sku = (lastSkuData || []).find(s => s.name === r.sku);
+            if (sku && r.deploymentConfidence) {
+                sku.confidence = r.deploymentConfidence;
+                confidence = r.deploymentConfidence;
             }
-        });
-        if (spotScore != null) {
-            const lbl = _scoreLabel(spotScore).toLowerCase().replace(/\s+/g, "-");
-            bodyHtml += `<div class="vm-profile-row"><span class="vm-profile-label">Spot Score</span><span class="confidence-badge confidence-${lbl}" data-bs-toggle="tooltip" data-bs-title="Average per-zone score across 3 zones (High\u2192100, Medium\u219260, Low\u219225, Restricted/Unknown\u21920).">${spotScore}/100</span></div>`;
         }
     }
-    bodyHtml += '</div>';
 
-    // Restrictions card
-    bodyHtml += '<div class="vm-profile-card">';
-    bodyHtml += '<div class="vm-profile-card-title">Restrictions</div>';
-    if (restrictions.length === 0) {
-        bodyHtml += row("Status", '<span class="vm-badge vm-badge-yes">None</span>');
-    } else {
-        restrictions.forEach(r => {
-            const reason = reasonLabels[r.reasonCode] || r.reasonCode || "Unknown reason";
-            let scope;
-            if (r.type === "Location") {
-                scope = "Entire region";
-            } else if (r.type === "Zone" && r.zones?.length) {
-                scope = `Zone${r.zones.length > 1 ? "s" : ""} ${r.zones.join(", ")}`;
-            } else {
-                scope = r.type || "Unknown";
-            }
-            bodyHtml += `<div class="vm-profile-row vm-profile-row-stacked"><span class="vm-profile-label">${escapeHtml(scope)}</span><span class="vm-badge vm-badge-limited vm-badge-block">${escapeHtml(reason)}</span></div>`;
-        });
+    // Check if spot was actually included when requested
+    if (includeSpot && confidence && confidence.scoreType !== "basic+spot") {
+        const reason = (result.warnings || []).join("; ") || "Spot Placement Scores unavailable or restricted for this SKU.";
+        showError("planner-error", reason);
     }
-    bodyHtml += '</div>';
 
-    bodyHtml += '</div>';
-
-    // Wrap in accordion
-    let html = '<div class="accordion mt-3" id="zoneAccordion">';
-    html += '<div class="accordion-item">';
-    html += '<h2 class="accordion-header">';
-    html += '<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#zoneCollapsePanel" aria-expanded="false" aria-controls="zoneCollapsePanel">';
-    html += '<i class="bi bi-pin-map me-2"></i>Zone Availability';
-    html += '</button></h2>';
-    html += '<div id="zoneCollapsePanel" class="accordion-collapse collapse" data-bs-parent="#zoneAccordion">';
-    html += '<div class="accordion-body p-2">';
-    html += bodyHtml;
-    html += '</div></div></div></div>';
-    return html;
+    return { confidence };
 }
 
-function renderQuotaPanel(quota, vcpus, confidence) {
-    return _C.renderQuotaPanel ? _C.renderQuotaPanel(quota, vcpus, confidence) : "";
-}
+// Old fetchPricingDetail / renderPricingDetail removed — now handled by shared showSkuDetailModal.
 
-function renderConfidenceBreakdown(conf) {
-    const lbl = (conf.label || "").toLowerCase().replace(/\s+/g, "-");
-    const isBlocked = conf.scoreType === "blocked";
-    const isBasicWithSpot = conf.scoreType === "basic+spot";
-    const titleText = isBlocked ? "Deployment Confidence (Blocked)"
-        : isBasicWithSpot ? "Deployment Confidence (with Spot)"
-        : "Basic Deployment Confidence";
-    const tooltipText = isBlocked
-        ? "Deployment is blocked due to hard constraints (quota or zone availability)."
-        : isBasicWithSpot
-        ? "Composite score (0\u2013100) including Spot Placement signal."
-        : "Composite score (0\u2013100) based on quota, zones, restrictions and price pressure. Spot excluded by default.";
-    let html = '<div class="confidence-section">';
-    html += `<h4 class="confidence-title">${escapeHtml(titleText)} <span class="confidence-badge confidence-${lbl}">${conf.score} ${escapeHtml(conf.label || "")}</span> <i class="bi bi-info-circle text-body-secondary confidence-info-icon" data-bs-toggle="tooltip" data-bs-title="${escapeHtml(tooltipText)}"></i></h4>`;
-    // Knockout reasons (hard blockers)
-    const knockoutReasons = conf.knockoutReasons || [];
-    if (knockoutReasons.length) {
-        html += '<div class="alert alert-danger py-1 px-2 mb-2 small"><i class="bi bi-x-octagon me-1"></i><strong>Blocked:</strong><ul class="mb-0 ps-3">';
-        knockoutReasons.forEach(r => { html += `<li>${escapeHtml(r)}</li>`; });
-        html += '</ul></div>';
-    }
-    const components = conf.breakdown?.components || conf.breakdown || [];
-    const usedComponents = components.filter(c => c.status === "used");
-    if (usedComponents.length) {
-        html += '<table class="table table-sm confidence-breakdown-table"><thead><tr><th>Signal</th><th>Score</th><th>Weight</th><th>Contribution</th></tr></thead><tbody>';
-        const signalLabels = { quotaPressure: "Quota Pressure", spot: "Spot Placement", zones: "Zone Breadth", restrictionDensity: "Restriction Density", pricePressure: "Price Pressure" };
-        const signalDescriptions = {
-            quotaPressure: "Non-linear quota usage pressure. Penalises heavily when family usage exceeds 80% or cannot fit a single VM.",
-            spot: "Best per-zone Spot Placement Score (Azure API). Higher means better spot allocation likelihood.",
-            zones: "Number of available (non-restricted) availability zones where the SKU is offered (out of 3).",
-            restrictionDensity: "Fraction of zones not restricted. Partial restrictions reduce the score proportionally.",
-            pricePressure: "Spot-to-PAYGO price ratio. A lower ratio indicates better spot savings."
-        };
-        usedComponents.forEach(b => {
-            const name = b.name || b.signal || "";
-            const desc = signalDescriptions[name] || "";
-            const score = b.score100 != null ? b.score100 : b.score;
-            const contribution = b.contribution != null ? (b.contribution * 100).toFixed(1) : "0.0";
-            html += `<tr><td>${escapeHtml(signalLabels[name] || name)} <i class="bi bi-info-circle text-body-secondary" data-bs-toggle="tooltip" data-bs-title="${escapeHtml(desc)}"></i></td><td>${score}</td><td>${(b.weight * 100).toFixed(1)}%</td><td>${contribution}</td></tr>`;
-        });
-        html += '</tbody></table>';
-    }
-    // Separate spot from other missing signals
-    const allMissing = conf.missingSignals || conf.missing || [];
-    const spotMissing = allMissing.includes("spot");
-    const otherMissing = allMissing.filter(m => m !== "spot");
-    if (otherMissing.length) {
-        const signalLabels = { quotaPressure: "Quota Pressure", zones: "Zone Breadth", restrictionDensity: "Restriction Density", pricePressure: "Price Pressure" };
-        const names = otherMissing.map(m => signalLabels[m] || m).join(", ");
-        html += `<p class="confidence-missing"><i class="bi bi-exclamation-circle"></i> Missing signals (excluded from score): ${escapeHtml(names)}</p>`;
-    }
-    // Scoring controls: recalculate basic or with spot
-    html += '<div class="confidence-controls mt-2 pt-2 border-top">';
-    html += '<div class="d-flex align-items-center gap-2 flex-wrap">';
-    html += '<label class="text-body-secondary small mb-0" for="confidence-instance-count">Instances:</label>';
-    html += '<input type="number" id="confidence-instance-count" class="form-control form-control-sm" value="1" min="1" max="1000" style="width:70px;" title="Number of instances to deploy (affects quota pressure)">';
-    html += '<button class="btn btn-sm btn-outline-success" onclick="resetToBasicConfidence()"><i class="bi bi-arrow-counterclockwise me-1"></i>Recalculate</button>';
-    html += '<button class="btn btn-sm btn-outline-primary" onclick="includeSpotInConfidence()"><i class="bi bi-lightning-charge me-1"></i>Recalculate with Spot</button>';
-    html += '</div></div>';
-    if (conf.disclaimers?.length) {
-        html += '<p class="confidence-disclaimer text-body-secondary small fst-italic mt-1 mb-0">' + escapeHtml(conf.disclaimers[0]) + ' <a href="https://github.com/az-scout/az-scout/blob/main/docs/SCORING.md" target="_blank" rel="noopener" class="text-body-secondary">Learn more</a> about scoring methodology.</p>';
-    }
-    html += '</div>';
-    return html;
-}
+// refreshPricingModal (kept as global for inline onclick references, but now no-op)
+function refreshPricingModal() {}
+
+// resetToBasicConfidence / includeSpotInConfidence are now handled by the
+// shared modal's onRecalculate callback (_plannerRecalculate above).
+// Keep as global no-ops for any stale onclick references.
+function resetToBasicConfidence() {}
+function includeSpotInConfidence() {}
 
 // ---------------------------------------------------------------------------
 // Render SKU table  (powered by Simple-DataTables)

--- a/src/az_scout/plugin_api.py
+++ b/src/az_scout/plugin_api.py
@@ -214,6 +214,8 @@ class SkuCapabilities(TypedDict, total=False):
     EphemeralOSDiskSupported: str
     GPUs: str
     HyperVGenerations: str
+    CachedDiskBytes: str
+    MaxResourceVolumeMB: str
 
 
 class SkuQuota(TypedDict, total=False):

--- a/src/az_scout/plugin_api.py
+++ b/src/az_scout/plugin_api.py
@@ -216,6 +216,11 @@ class SkuCapabilities(TypedDict, total=False):
     HyperVGenerations: str
     CachedDiskBytes: str
     MaxResourceVolumeMB: str
+    LowPriorityCapable: str
+    TrustedLaunchDisabled: str
+    EncryptionAtHostSupported: str
+    CpuArchitectureType: str
+    UltraSSDAvailable: str
 
 
 class SkuQuota(TypedDict, total=False):

--- a/src/az_scout/static/js/components/data-filters.js
+++ b/src/az_scout/static/js/components/data-filters.js
@@ -10,14 +10,14 @@
 window.azScout = window.azScout || {};
 window.azScout.components = window.azScout.components || {};
 
-(function (C) {
+((C) => {
     /**
      * Parse a numeric filter expression.
      * Supported syntax: >5, >=5, <32, <=32, =8, 5-16 (range), plain number (exact).
      * @param {string} val - Raw filter string.
      * @returns {object|null} Parsed filter or null.
      */
-    C.parseNumericFilter = function (val) {
+    C.parseNumericFilter = (val) => {
         const s = (val || "").trim();
         let m;
         // Range: 4-16, 4..16, 4–16
@@ -37,7 +37,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} filter - Parsed filter from parseNumericFilter.
      * @returns {boolean}
      */
-    C.matchNumericFilter = function (cellVal, filter) {
+    C.matchNumericFilter = (cellVal, filter) => {
         const n = parseFloat(cellVal);
         if (Number.isNaN(n)) return false;
         switch (filter.op) {
@@ -59,7 +59,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {Set<number>} [numericCols] - Column indices that are numeric.
      * @returns {HTMLElement} The filter row element.
      */
-    C.buildColumnFilters = function (tableEl, filterableCols, numericCols) {
+    C.buildColumnFilters = (tableEl, filterableCols, numericCols) => {
         const thead = tableEl.querySelector("thead");
         if (!thead) return null;
 
@@ -67,13 +67,13 @@ window.azScout.components = window.azScout.components || {};
         const filterRow = document.createElement("tr");
         filterRow.className = "datatable-filter-row";
 
-        headerCells.forEach(function (_, idx) {
+        headerCells.forEach((_, idx) => {
             const td = document.createElement("td");
             if (filterableCols.includes(idx)) {
                 const input = document.createElement("input");
                 input.type = "search";
                 input.className = "datatable-column-filter";
-                const isNumeric = numericCols && numericCols.has(idx);
+                const isNumeric = numericCols?.has(idx);
                 input.placeholder = isNumeric ? ">5, <32, 4-16\u2026" : "Filter\u2026";
                 if (isNumeric) input.dataset.numeric = "1";
                 input.dataset.col = String(idx);
@@ -85,9 +85,9 @@ window.azScout.components = window.azScout.components || {};
 
         // Debounced column filtering via row visibility
         let timeout;
-        filterRow.addEventListener("input", function () {
+        filterRow.addEventListener("input", () => {
             clearTimeout(timeout);
-            timeout = setTimeout(function () { C.applyColumnFilters(tableEl, filterRow); }, 200);
+            timeout = setTimeout(() => { C.applyColumnFilters(tableEl, filterRow); }, 200);
         });
 
         return filterRow;
@@ -98,10 +98,10 @@ window.azScout.components = window.azScout.components || {};
      * @param {HTMLElement} tableEl - The table element.
      * @param {HTMLElement} filterRow - The filter row with inputs.
      */
-    C.applyColumnFilters = function (tableEl, filterRow) {
+    C.applyColumnFilters = (tableEl, filterRow) => {
         const inputs = filterRow.querySelectorAll("input[data-col]");
         const filters = [];
-        inputs.forEach(function (inp) {
+        inputs.forEach((inp) => {
             const val = inp.value.trim();
             if (!val) return;
             const col = parseInt(inp.dataset.col, 10);
@@ -114,10 +114,10 @@ window.azScout.components = window.azScout.components || {};
         });
 
         const rows = tableEl.querySelectorAll("tbody tr");
-        rows.forEach(function (row) {
+        rows.forEach((row) => {
             if (filters.length === 0) { row.style.display = ""; return; }
             const cells = row.querySelectorAll("td");
-            const match = filters.every(function (f) {
+            const match = filters.every((f) => {
                 const cell = cells[f.col];
                 if (!cell) return false;
                 if (f.numeric) return C.matchNumericFilter(cell.textContent, f.numeric);

--- a/src/az_scout/static/js/components/sku-badges.js
+++ b/src/az_scout/static/js/components/sku-badges.js
@@ -7,7 +7,7 @@
 window.azScout = window.azScout || {};
 window.azScout.components = window.azScout.components || {};
 
-(function (C) {
+((C) => {
     const SCORE_LABELS = [[80, "High"], [60, "Medium"], [40, "Low"], [0, "Very Low"]];
 
     /**
@@ -15,7 +15,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {number} score - Score 0–100.
      * @returns {string} "High", "Medium", "Low", or "Very Low".
      */
-    C.scoreLabel = function (score) {
+    C.scoreLabel = (score) => {
         for (const [th, lbl] of SCORE_LABELS) {
             if (score >= th) return lbl;
         }
@@ -29,7 +29,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {boolean} [opts.tooltip=true] - Include Bootstrap tooltip.
      * @returns {string} Badge HTML or "—" if no score.
      */
-    C.renderConfidenceBadge = function (conf, opts) {
+    C.renderConfidenceBadge = (conf, opts) => {
         if (!conf || conf.score == null) return "\u2014";
         const o = opts || {};
         const lbl = (conf.label || "").toLowerCase().replace(/\s+/g, "-");
@@ -53,7 +53,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} zoneScores - {zone: scoreLabel} map.
      * @returns {string} HTML badges string.
      */
-    C.renderSpotBadges = function (zoneScores) {
+    C.renderSpotBadges = (zoneScores) => {
         if (!zoneScores || !Object.keys(zoneScores).length) return "";
         return Object.entries(zoneScores)
             .sort(([a], [b]) => a.localeCompare(b))
@@ -71,7 +71,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {string[]} allZones - All logical zones to display.
      * @returns {string} HTML string with zone indicator icons.
      */
-    C.renderZoneBadges = function (zones, restrictions, allZones) {
+    C.renderZoneBadges = (zones, restrictions, allZones) => {
         const zoneList = allZones || ["1", "2", "3"];
         return zoneList.map(lz => {
             const restricted = (restrictions || []).includes(lz);
@@ -89,7 +89,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {number} [opts.vcpus] - vCPUs per instance for deployable count.
      * @returns {string} HTML string with progress bar.
      */
-    C.renderQuotaBar = function (quota, opts) {
+    C.renderQuotaBar = (quota, opts) => {
         if (!quota || quota.limit == null) return "\u2014";
         const o = opts || {};
         const pct = quota.limit > 0 ? Math.round((quota.used / quota.limit) * 100) : 0;
@@ -113,7 +113,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {string} label - "High", "Medium", "Low", etc.
      * @returns {string} Badge HTML.
      */
-    C.renderSpotBadge = function (label) {
+    C.renderSpotBadge = (label) => {
         const key = (label || "").toLowerCase();
         const friendly = { high: "High", medium: "Medium", low: "Low", restrictedskunotavailable: "Restricted", unknown: "Unknown", datanotfoundorstale: "No data" };
         const display = friendly[key] || label;

--- a/src/az_scout/static/js/components/sku-detail-modal.js
+++ b/src/az_scout/static/js/components/sku-detail-modal.js
@@ -11,7 +11,7 @@
 window.azScout = window.azScout || {};
 window.azScout.components = window.azScout.components || {};
 
-(function (C) {
+((C) => {
     // --- shared inner helpers ---
     function _row(label, value) {
         return '<div class="vm-profile-row"><span class="vm-profile-label">' + escapeHtml(label) + '</span><span>' + value + '</span></div>';
@@ -54,7 +54,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} profile - SKU profile with capabilities dict.
      * @returns {string} HTML string.
      */
-    C.renderVmProfile = function (profile) {
+    C.renderVmProfile = (profile) => {
         const caps = profile.capabilities || {};
         let html = '<div class="vm-profile-section">';
         html += '<h4 class="vm-profile-title">VM Profile</h4>';
@@ -102,14 +102,14 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} [opts.spotZoneScores] - {zone: scoreLabel} map.
      * @returns {string} HTML accordion string.
      */
-    C.renderZoneAvailability = function (profile, confidence, opts) {
+    C.renderZoneAvailability = (profile, confidence, opts) => {
         const o = opts || {};
         const zones = profile.zones || [];
         const restrictions = profile.restrictions || [];
         const components = confidence?.breakdown?.components || [];
-        const zoneSignal = components.find(function (b) { return b.name === "zones"; });
+        const zoneSignal = components.find((b) => b.name === "zones");
         const zoneScore = zoneSignal?.score100;
-        const spotSignal = components.find(function (b) { return b.name === "spot"; });
+        const spotSignal = components.find((b) => b.name === "spot");
         const spotScore = spotSignal?.score100;
         const physicalZoneMap = o.physicalZoneMap || {};
         const spotZoneScores = o.spotZoneScores || {};
@@ -119,10 +119,10 @@ window.azScout.components = window.azScout.components || {};
             QuotaId: "Subscription offer type not eligible",
         };
 
-        const hasLocationRestriction = restrictions.some(function (r) { return r.type === "Location"; });
-        const zoneRestrictionZones = new Set(restrictions.filter(function (r) { return r.type === "Zone"; }).flatMap(function (r) { return r.zones || []; }));
+        const hasLocationRestriction = restrictions.some((r) => r.type === "Location");
+        const zoneRestrictionZones = new Set(restrictions.filter((r) => r.type === "Zone").flatMap((r) => r.zones || []));
         const allZoneIds = [...new Set(["1", "2", "3", ...zones])].sort();
-        const availableCount = zones.filter(function (z) { return !zoneRestrictionZones.has(z) && !hasLocationRestriction; }).length;
+        const availableCount = zones.filter((z) => !zoneRestrictionZones.has(z) && !hasLocationRestriction).length;
 
         let body = '<div class="vm-profile-grid">';
 
@@ -130,7 +130,7 @@ window.azScout.components = window.azScout.components || {};
         body += '<div class="vm-profile-card"><div class="vm-profile-card-title">Zones</div>';
         if (hasLocationRestriction) body += _row("Region", '<span class="vm-badge vm-badge-no">Restricted</span>');
         body += _row("Available", _val(availableCount + " / 3"));
-        allZoneIds.forEach(function (z) {
+        allZoneIds.forEach((z) => {
             const pz = physicalZoneMap[z];
             const pzTip = pz ? ' data-bs-toggle="tooltip" data-bs-title="' + escapeHtml(pz) + '"' : "";
             const offered = zones.includes(z);
@@ -151,7 +151,7 @@ window.azScout.components = window.azScout.components || {};
         if (!hasSpotData) {
             body += _row("Status", '<span class="vm-badge vm-badge-unknown">No data</span>');
         } else {
-            allZoneIds.forEach(function (z) {
+            allZoneIds.forEach((z) => {
                 const pz = physicalZoneMap[z];
                 const pzTip = pz ? ' data-bs-toggle="tooltip" data-bs-title="' + escapeHtml(pz) + '"' : "";
                 const s = spotZoneScores[z];
@@ -170,7 +170,7 @@ window.azScout.components = window.azScout.components || {};
         if (restrictions.length === 0) {
             body += _row("Status", '<span class="vm-badge vm-badge-yes">None</span>');
         } else {
-            restrictions.forEach(function (r) {
+            restrictions.forEach((r) => {
                 const reason = reasonLabels[r.reasonCode] || r.reasonCode || "Unknown reason";
                 const scope = r.type === "Location" ? "Entire region" : r.type === "Zone" && r.zones?.length ? "Zone" + (r.zones.length > 1 ? "s" : "") + " " + r.zones.join(", ") : r.type || "Unknown";
                 body += '<div class="vm-profile-row vm-profile-row-stacked"><span class="vm-profile-label">' + escapeHtml(scope) + '</span><span class="vm-badge vm-badge-limited vm-badge-block">' + escapeHtml(reason) + '</span></div>';
@@ -188,7 +188,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} [confidence] - Confidence object with breakdown.
      * @returns {string} HTML accordion string.
      */
-    C.renderQuotaPanel = function (quota, vcpus, confidence) {
+    C.renderQuotaPanel = (quota, vcpus, confidence) => {
         const limit = quota.limit;
         const used = quota.used;
         const remaining = quota.remaining;
@@ -196,7 +196,7 @@ window.azScout.components = window.azScout.components || {};
         const deployable = (remaining != null && vcpus > 0) ? Math.floor(remaining / vcpus) : null;
 
         const components = confidence?.breakdown?.components || [];
-        const quotaSignal = components.find(function (b) { return b.name === "quota"; });
+        const quotaSignal = components.find((b) => b.name === "quota");
         const quotaScore = quotaSignal?.score100;
 
         let barClass = "bg-success";
@@ -236,42 +236,60 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} conf - Confidence object with breakdown, knockout reasons, etc.
      * @returns {string} HTML string (NOT wrapped in accordion — rendered as top-level section).
      */
-    C.renderConfidenceBreakdown = function (conf) {
+    C.renderConfidenceBreakdown = (conf) => {
         const lbl = (conf.label || "").toLowerCase().replace(/\s+/g, "-");
         const isBlocked = conf.scoreType === "blocked";
         const isBasicWithSpot = conf.scoreType === "basic+spot";
         const titleText = isBlocked ? "Deployment Confidence (Blocked)" : isBasicWithSpot ? "Deployment Confidence (with Spot)" : "Basic Deployment Confidence";
+        const tooltipText = isBlocked
+            ? "Deployment is blocked due to hard constraints (quota or zone availability)."
+            : isBasicWithSpot
+            ? "Composite score (0\u2013100) including Spot Placement signal."
+            : "Composite score (0\u2013100) based on quota, zones, restrictions and price pressure. Spot excluded by default.";
 
         let html = '<div class="confidence-section">';
-        html += '<h4 class="confidence-title">' + escapeHtml(titleText) + ' <span class="confidence-badge confidence-' + lbl + '">' + conf.score + ' ' + escapeHtml(conf.label || '') + '</span></h4>';
+        html += '<h4 class="confidence-title">' + escapeHtml(titleText) + ' <span class="confidence-badge confidence-' + lbl + '">' + conf.score + ' ' + escapeHtml(conf.label || '') + '</span> <i class="bi bi-info-circle text-body-secondary confidence-info-icon" data-bs-toggle="tooltip" data-bs-title="' + escapeHtml(tooltipText) + '"></i></h4>';
 
         const knockoutReasons = conf.knockoutReasons || [];
         if (knockoutReasons.length) {
             html += '<div class="alert alert-danger py-1 px-2 mb-2 small"><i class="bi bi-x-octagon me-1"></i><strong>Blocked:</strong><ul class="mb-0 ps-3">';
-            knockoutReasons.forEach(function (r) { html += '<li>' + escapeHtml(r) + '</li>'; });
+            knockoutReasons.forEach((r) => { html += '<li>' + escapeHtml(r) + '</li>'; });
             html += '</ul></div>';
         }
 
+        const signalLabels = { quotaPressure: "Quota Pressure", spot: "Spot Placement", zones: "Zone Breadth", restrictionDensity: "Restriction Density", pricePressure: "Price Pressure" };
+        const signalDescriptions = {
+            quotaPressure: "Non-linear quota usage pressure. Penalises heavily when family usage exceeds 80% or cannot fit a single VM.",
+            spot: "Best per-zone Spot Placement Score (Azure API). Higher means better spot allocation likelihood.",
+            zones: "Number of available (non-restricted) availability zones where the SKU is offered (out of 3).",
+            restrictionDensity: "Fraction of zones not restricted. Partial restrictions reduce the score proportionally.",
+            pricePressure: "Spot-to-PAYGO price ratio. A lower ratio indicates better spot savings."
+        };
+
         const components = conf.breakdown?.components || conf.breakdown || [];
-        const usedComponents = components.filter(function (c) { return c.status === "used"; });
+        const usedComponents = components.filter((c) => c.status === "used");
         if (usedComponents.length) {
-            const signalLabels = { quotaPressure: "Quota Pressure", spot: "Spot Placement", zones: "Zone Breadth", restrictionDensity: "Restriction Density", pricePressure: "Price Pressure" };
             html += '<table class="table table-sm confidence-breakdown-table"><thead><tr><th>Signal</th><th>Score</th><th>Weight</th><th>Contribution</th></tr></thead><tbody>';
-            usedComponents.forEach(function (b) {
+            usedComponents.forEach((b) => {
                 const name = b.name || b.signal || "";
+                const desc = signalDescriptions[name] || "";
                 const score = b.score100 != null ? b.score100 : b.score;
                 const contribution = b.contribution != null ? (b.contribution * 100).toFixed(1) : "0.0";
-                html += '<tr><td>' + escapeHtml(signalLabels[name] || name) + '</td><td>' + score + '</td><td>' + (b.weight * 100).toFixed(1) + '%</td><td>' + contribution + '</td></tr>';
+                const infoIcon = desc ? ' <i class="bi bi-info-circle text-body-secondary" data-bs-toggle="tooltip" data-bs-title="' + escapeHtml(desc) + '"></i>' : '';
+                html += '<tr><td>' + escapeHtml(signalLabels[name] || name) + infoIcon + '</td><td>' + score + '</td><td>' + (b.weight * 100).toFixed(1) + '%</td><td>' + contribution + '</td></tr>';
             });
             html += '</tbody></table>';
         }
 
         const allMissing = conf.missingSignals || conf.missing || [];
-        const otherMissing = allMissing.filter(function (m) { return m !== "spot"; });
+        const otherMissing = allMissing.filter((m) => m !== "spot");
         if (otherMissing.length) {
-            const signalLabels = { quotaPressure: "Quota Pressure", zones: "Zone Breadth", restrictionDensity: "Restriction Density", pricePressure: "Price Pressure" };
-            const names = otherMissing.map(function (m) { return signalLabels[m] || m; }).join(", ");
-            html += '<p class="confidence-missing"><i class="bi bi-exclamation-circle"></i> Missing signals: ' + escapeHtml(names) + '</p>';
+            const names = otherMissing.map((m) => signalLabels[m] || m).join(", ");
+            html += '<p class="confidence-missing"><i class="bi bi-exclamation-circle"></i> Missing signals (excluded from score): ' + escapeHtml(names) + '</p>';
+        }
+
+        if (conf.disclaimers?.length) {
+            html += '<p class="confidence-disclaimer text-body-secondary small fst-italic mt-1 mb-0">' + escapeHtml(conf.disclaimers[0]) + ' <a href="https://github.com/az-scout/az-scout/blob/main/docs/SCORING.md" target="_blank" rel="noopener" class="text-body-secondary">Learn more</a> about scoring methodology.</p>';
         }
 
         html += '</div>';
@@ -285,7 +303,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {function} [opts.onCurrencyChange] - Callback when currency selector changes.
      * @returns {string} HTML accordion string.
      */
-    C.renderPricingPanel = function (data, opts) {
+    C.renderPricingPanel = (data, opts) => {
         const o = opts || {};
         const currency = data.currency || "USD";
         const HOURS_PER_MONTH = 730;
@@ -304,7 +322,7 @@ window.azScout.components = window.azScout.components || {};
 
         let table = '<table class="table table-sm pricing-detail-table mb-0">';
         table += '<thead><tr><th>Type</th><th>' + escapeHtml(currency) + '/hour</th><th>' + escapeHtml(currency) + '/month</th></tr></thead><tbody>';
-        rows.forEach(function (r) {
+        rows.forEach((r) => {
             const hourStr = r.hourly != null ? formatNum(r.hourly, 4) : "\u2014";
             const monthStr = r.hourly != null ? formatNum(r.hourly * HOURS_PER_MONTH, 2) : "\u2014";
             const labelHtml = r.raw ? r.label : escapeHtml(r.label);
@@ -314,7 +332,7 @@ window.azScout.components = window.azScout.components || {};
 
         // Currency selector
         const currencies = ["USD", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "SEK", "BRL", "INR"];
-        const currencyOpts = currencies.map(function (c) { return '<option value="' + c + '"' + (c === currency ? " selected" : "") + '>' + c + '</option>'; }).join("");
+        const currencyOpts = currencies.map((c) => '<option value="' + c + '"' + (c === currency ? " selected" : "") + '>' + c + '</option>').join("");
         const changeAttr = o.onCurrencyChange ? ' onchange="' + o.onCurrencyChange + '"' : "";
 
         let body = '<div class="d-flex align-items-center gap-2 mb-2">';
@@ -325,4 +343,229 @@ window.azScout.components = window.azScout.components || {};
 
         return _accordion("pricing", "bi-currency-exchange", "Pricing", body);
     };
+
+    // -------------------------------------------------------------------
+    // showSkuDetailModal – full-flow modal callable from any plugin
+    // -------------------------------------------------------------------
+
+    let _sharedModal = null;
+    let _sharedModalContext = {};
+    let _sharedModalData = null;   // last API response for re-render
+
+    function _ensureModalElement() {
+        if (document.getElementById("sharedSkuDetailModal")) return;
+        const style = document.createElement("style");
+        style.textContent =
+            "@media (min-width: 1200px) { #sharedSkuDetailModal .modal-dialog { max-width: 900px; } } " +
+            "#sharedSkuDetailModal .accordion-button { font-size: 0.88rem; padding: 0.5rem 0.75rem; } " +
+            "#sharedSkuDetailModal .accordion-body { font-size: 0.85rem; }";
+        document.head.appendChild(style);
+        const div = document.createElement("div");
+        div.innerHTML =
+            '<div class="modal fade" id="sharedSkuDetailModal" tabindex="-1" aria-labelledby="sharedSkuDetailModalLabel" aria-hidden="true">' +
+                '<div class="modal-dialog modal-xl modal-fullscreen-md-down modal-dialog-centered modal-dialog-scrollable">' +
+                    '<div class="modal-content">' +
+                        '<div class="modal-header">' +
+                            '<h5 class="modal-title" id="sharedSkuDetailModalLabel">SKU Detail \u2014 <span id="shared-sku-detail-name"></span></h5>' +
+                            '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>' +
+                        '</div>' +
+                        '<div class="modal-body">' +
+                            '<div id="shared-sku-detail-loading" class="text-center d-none">' +
+                                '<div class="spinner-border spinner-border-sm text-primary" role="status"></div>' +
+                                '<span class="ms-2 small">Fetching SKU detail\u2026</span>' +
+                            '</div>' +
+                            '<div id="shared-sku-detail-content" class="d-none"></div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>' +
+            '</div>';
+        document.body.appendChild(div.firstChild);
+    }
+
+    /**
+     * Open, fetch data, and render the shared SKU detail modal.
+     *
+     * @param {string} skuName - ARM SKU name.
+     * @param {object} opts
+     * @param {string} opts.region - Azure region.
+     * @param {string} [opts.subscriptionId] - Subscription ID.
+     * @param {string} [opts.tenantId] - Tenant ID.
+     * @param {string} [opts.currency] - Initial currency code (default "USD").
+     * @param {object} [opts.enrichedSku] - Enriched SKU from plugin cache (quota, confidence, spot_zones).
+     * @param {object} [opts.physicalZoneMap] - {logicalZone: physicalName} for zone tooltips.
+     * @param {function} [opts.extraSections] - function(data, enrichedSku) → HTML.
+     * @param {function} [opts.onRecalculate] - function(skuName, instanceCount, includeSpot) → Promise<{confidence}>.
+     *     If provided, replaces the default recalculation (re-fetch /api/sku-detail).
+     *     Must return an object with at least {confidence} to merge into the display.
+     * @param {function} [opts.onAfterRecalculate] - function(confidence) called after recalculation completes.
+     */
+    C.showSkuDetailModal = (skuName, opts) => {
+        const o = opts || {};
+        _ensureModalElement();
+        _sharedModalContext = { skuName: skuName, opts: o, currency: o.currency || "USD" };
+        _sharedModalData = null;
+
+        document.getElementById("shared-sku-detail-name").textContent = skuName;
+        document.getElementById("shared-sku-detail-loading").classList.remove("d-none");
+        document.getElementById("shared-sku-detail-content").classList.add("d-none");
+        if (!_sharedModal) _sharedModal = new bootstrap.Modal(document.getElementById("sharedSkuDetailModal"));
+        _sharedModal.show();
+
+        _fetchAndRender();
+    };
+
+    function _fetchAndRender(openAccordionIds) {
+        var ctx = _sharedModalContext;
+        var o = ctx.opts || {};
+        var params = new URLSearchParams({ region: o.region || "", sku: ctx.skuName, currencyCode: ctx.currency || "USD" });
+        if (o.subscriptionId) params.set("subscriptionId", o.subscriptionId);
+        var tqs = typeof tenantQS === "function" ? tenantQS("&") : "";
+
+        document.getElementById("shared-sku-detail-loading").classList.remove("d-none");
+        document.getElementById("shared-sku-detail-content").classList.add("d-none");
+
+        apiFetch("/api/sku-detail?" + params + tqs)
+            .then((data) => {
+                _sharedModalData = data;
+                _renderSharedDetail(data, ctx.skuName, o, openAccordionIds);
+            })
+            .catch((err) => {
+                var content = document.getElementById("shared-sku-detail-content");
+                content.innerHTML = '<p class="text-danger small">Failed to load: ' + escapeHtml(err.message) + '</p>';
+                content.classList.remove("d-none");
+                document.getElementById("shared-sku-detail-loading").classList.add("d-none");
+            });
+    }
+
+    function _getOpenAccordionIds() {
+        var content = document.getElementById("shared-sku-detail-content");
+        if (!content) return [];
+        return Array.from(content.querySelectorAll('.accordion-collapse.show'))
+            .map((el) => el.id)
+            .filter(Boolean);
+    }
+
+    function _restoreAccordionState(content, openIds) {
+        if (!openIds || !openIds.length) return;
+        openIds.forEach((id) => {
+            var panel = content.querySelector('#' + id);
+            if (panel) panel.classList.add("show");
+            var btn = content.querySelector('[data-bs-target="#' + id + '"]');
+            if (btn) { btn.classList.remove("collapsed"); btn.setAttribute("aria-expanded", "true"); }
+        });
+    }
+
+    function _renderSharedDetail(data, _skuName, opts, openAccordionIds) {
+        var enriched = opts.enrichedSku || {};
+        var html = "";
+
+        // 1. Confidence breakdown
+        var conf = enriched.confidence || data.confidence;
+        if (conf) {
+            html += C.renderConfidenceBreakdown(conf);
+            // Recalculate controls
+            html += '<div class="confidence-controls mt-2 pt-2 border-top">';
+            html += '<div class="d-flex align-items-center gap-2 flex-wrap">';
+            html += '<label class="text-body-secondary small mb-0" for="shared-confidence-instance-count">Instances:</label>';
+            html += '<input type="number" id="shared-confidence-instance-count" class="form-control form-control-sm" value="1" min="1" max="1000" style="width:70px;" title="Number of instances to deploy (affects quota pressure)">';
+            html += '<button class="btn btn-sm btn-outline-success" id="shared-recalc-basic"><i class="bi bi-arrow-counterclockwise me-1"></i>Recalculate</button>';
+            html += '<button class="btn btn-sm btn-outline-primary" id="shared-recalc-spot"><i class="bi bi-lightning-charge me-1"></i>Recalculate with Spot</button>';
+            html += '</div></div>';
+        }
+
+        // 2. VM Profile
+        if (data.profile) html += C.renderVmProfile(data.profile);
+
+        // 3. Zone Availability
+        if (data.profile) {
+            const zoneOpts = {};
+            if (opts.physicalZoneMap) zoneOpts.physicalZoneMap = opts.physicalZoneMap;
+            if (enriched.spot_zones) zoneOpts.spotZoneScores = enriched.spot_zones;
+            html += C.renderZoneAvailability(data.profile, conf, zoneOpts);
+        }
+
+        // 4. Quota
+        var quota = enriched.quota;
+        if (quota && quota.limit != null) {
+            const vcpus = parseInt(data.profile?.capabilities?.vCPUs || enriched.capabilities?.vCPUs || "0", 10);
+            html += C.renderQuotaPanel(quota, vcpus, conf);
+        }
+
+        // 5. Pricing (with currency change wired to re-fetch)
+        html += C.renderPricingPanel(data);
+
+        // 6. Plugin-specific extra sections
+        if (typeof opts.extraSections === "function") {
+            html += opts.extraSections(data, enriched);
+        }
+
+        var content = document.getElementById("shared-sku-detail-content");
+        content.innerHTML = html;
+        content.classList.remove("d-none");
+        document.getElementById("shared-sku-detail-loading").classList.add("d-none");
+
+        // Restore accordion state
+        _restoreAccordionState(content, openAccordionIds);
+
+        // Init tooltips
+        content.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((t) => {
+            new bootstrap.Tooltip(t, { delay: { show: 0, hide: 100 }, placement: "top" });
+        });
+
+        // Wire recalculate buttons
+        var recalcBasic = document.getElementById("shared-recalc-basic");
+        var recalcSpot = document.getElementById("shared-recalc-spot");
+        if (recalcBasic) recalcBasic.addEventListener("click", () => { _handleRecalc(false); });
+        if (recalcSpot) recalcSpot.addEventListener("click", () => { _handleRecalc(true); });
+
+        // Wire currency selector
+        var currSel = document.getElementById("pricing-modal-currency-select");
+        if (currSel) {
+            currSel.addEventListener("change", () => {
+                _sharedModalContext.currency = currSel.value;
+                var openIds = _getOpenAccordionIds();
+                _fetchAndRender(openIds);
+            });
+        }
+    }
+
+    function _handleRecalc(includeSpot) {
+        var ctx = _sharedModalContext;
+        if (!ctx.skuName) return;
+        var o = ctx.opts || {};
+        var instanceCount = parseInt(document.getElementById("shared-confidence-instance-count")?.value, 10) || 1;
+        var openIds = _getOpenAccordionIds();
+
+        // Spinner on button
+        var btnId = includeSpot ? "shared-recalc-spot" : "shared-recalc-basic";
+        var btn = document.getElementById(btnId);
+        var origHtml = btn ? btn.innerHTML : "";
+        if (btn) {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Calculating\u2026';
+        }
+
+        // If plugin provides custom recalculate handler, use it
+        if (typeof o.onRecalculate === "function") {
+            Promise.resolve(o.onRecalculate(ctx.skuName, instanceCount, includeSpot))
+                .then((result) => {
+                    // Merge updated confidence into enriched SKU
+                    if (result?.confidence && o.enrichedSku) {
+                        o.enrichedSku.confidence = result.confidence;
+                    }
+                    if (typeof o.onAfterRecalculate === "function") {
+                        o.onAfterRecalculate(result ? result.confidence : null);
+                    }
+                    // Re-render with preserved accordion state
+                    if (_sharedModalData) _renderSharedDetail(_sharedModalData, ctx.skuName, o, openIds);
+                })
+                .catch((err) => {
+                    if (btn) { btn.disabled = false; btn.innerHTML = origHtml; }
+                    alert("Recalculation failed: " + err.message);
+                });
+        } else {
+            // Default: re-fetch /api/sku-detail with instanceCount
+            _fetchAndRender(openIds);
+        }
+    }
 })(window.azScout.components);

--- a/src/az_scout/static/js/plugins.js
+++ b/src/az_scout/static/js/plugins.js
@@ -42,7 +42,7 @@
             "Loading…</div>";
 
         // Set up the callback BEFORE injecting catalog.html so the inline script can call it
-        window.onCatalogRendered = function(plugins) {
+        window.onCatalogRendered = (plugins) => {
             catalogPlugins = plugins;
             // Now that cards are rendered, fetch instance data and enhance
             loadPlugins();
@@ -156,8 +156,8 @@
                 const ver = escHtml(record.ref || '');
                 let btnsHtml = '';
 
-                if ((info && info.update_available) || record.update_available === true) {
-                    const latest = escHtml((info && info.latest_ref) || record.latest_ref || '');
+                if ((info?.update_available) || record.update_available === true) {
+                    const latest = escHtml((info?.latest_ref) || record.latest_ref || '');
                     const label = latest ? ver + ' \u2192 ' + latest : 'Update';
                     btnsHtml += '<button class="btn btn-outline-info btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Update plugin to latest version" onclick="pmUpdate(\'' + escAttr(name) + '\')"><i class="bi bi-cloud-download me-1"></i>' + label + '</button>';
                     anyUpdate = true;
@@ -166,7 +166,7 @@
 
                 actionsEl.innerHTML = btnsHtml;
                 injectVersion(col, ver);
-            } else if (isInstalled && loadedPlugin && loadedPlugin.in_packages_dir) {
+            } else if (isInstalled && loadedPlugin?.in_packages_dir) {
                 // Installed as a dependency via PM — manageable
                 actionsEl.innerHTML =
                     '<button class="btn btn-outline-danger btn-sm" onclick="pmUninstall(\'' + escAttr(name) + '\')"><i class="bi bi-trash me-1"></i>Uninstall</button>';
@@ -197,14 +197,14 @@
             const record = installedByDist[distName];
             grid.insertAdjacentHTML("beforeend", buildExtraCard(p, record));
 
-            if (record && ((updateInfo[distName] || {}).update_available || record.update_available === true)) {
+            if (record && (updateInfo[distName]?.update_available || record.update_available === true)) {
                 anyUpdate = true;
             }
         }
 
         // 2b. Single card for all built-in plugins
         if (builtins.length > 0) {
-            const items = builtins.map(function(p) {
+            const items = builtins.map((p) => {
                 const label = p.display_name || p.name;
                 return '<li><strong>' + escHtml(label) + '</strong>' +
                     (p.description ? ' — ' + escHtml(p.description) : '') + '</li>';
@@ -228,7 +228,7 @@
             if (seenDists.has(r.distribution_name)) continue;
             seenDists.add(r.distribution_name);
             grid.insertAdjacentHTML("beforeend", buildNotLoadedCard(r));
-            if ((updateInfo[r.distribution_name] || {}).update_available || r.update_available === true) {
+            if (updateInfo[r.distribution_name]?.update_available || r.update_available === true) {
                 anyUpdate = true;
             }
         }
@@ -279,8 +279,8 @@
             const info = updateInfo[record.distribution_name];
             const ver = escHtml(record.ref || '');
             let btnsHtml = '';
-            if ((info && info.update_available) || record.update_available === true) {
-                const latest = escHtml((info && info.latest_ref) || record.latest_ref || '');
+            if ((info?.update_available) || record.update_available === true) {
+                const latest = escHtml((info?.latest_ref) || record.latest_ref || '');
                 const label = latest ? ver + ' \u2192 ' + latest : 'Update';
                 btnsHtml += '<button class="btn btn-outline-info btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Update plugin to latest version" onclick="pmUpdate(\'' + escAttr(record.distribution_name) + '\')"><i class="bi bi-cloud-download me-1"></i>' + label + '</button>';
             }
@@ -317,8 +317,8 @@
     /** Build a card for a plugin in installed.json but not loaded. */
     function buildNotLoadedCard(r) {
         let btnsLine = "";
-        if ((updateInfo[r.distribution_name] || {}).update_available || r.update_available === true) {
-            const latest = escHtml((updateInfo[r.distribution_name] || {}).latest_ref || r.latest_ref || '');
+        if (updateInfo[r.distribution_name]?.update_available || r.update_available === true) {
+            const latest = escHtml(updateInfo[r.distribution_name]?.latest_ref || r.latest_ref || '');
             const ver = escHtml(r.ref || '');
             const label = latest ? ver + ' \u2192 ' + latest : 'Update';
             btnsLine += '<button class="btn btn-outline-info btn-sm" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Update plugin to latest version" onclick="pmUpdate(\'' + escAttr(r.distribution_name) + '\')"><i class="bi bi-cloud-download me-1"></i>' + label + '</button> ';

--- a/tests/test_azure_api.py
+++ b/tests/test_azure_api.py
@@ -14,6 +14,7 @@ from az_scout.azure_api._arm import (
     arm_post,
     get_headers,
 )
+from az_scout.azure_api.skus import parse_sku_series
 
 
 class TestSkuNameMatches:
@@ -52,6 +53,34 @@ class TestSkuNameMatches:
     def test_no_false_positive_partial_overlap(self) -> None:
         # "d48-v3" should not match "standard_d4s_v3" (d4 != d48)
         assert not _sku_name_matches("d48-v3", "standard_d4s_v3")
+
+
+class TestParseSkuSeries:
+    """Tests for parse_sku_series()."""
+
+    def test_d_series(self) -> None:
+        assert parse_sku_series("Standard_D2s_v5") == "D"
+
+    def test_nc_series(self) -> None:
+        assert parse_sku_series("Standard_NC24ads_A100_v4") == "NC"
+
+    def test_b_series(self) -> None:
+        assert parse_sku_series("Standard_B2s") == "B"
+
+    def test_fx_series(self) -> None:
+        assert parse_sku_series("Standard_FX48mds_v2") == "FX"
+
+    def test_e_series(self) -> None:
+        assert parse_sku_series("Standard_E4s_v5") == "E"
+
+    def test_basic_a_series(self) -> None:
+        assert parse_sku_series("Basic_A0") == "A"
+
+    def test_empty_string(self) -> None:
+        assert parse_sku_series("") == ""
+
+    def test_no_prefix(self) -> None:
+        assert parse_sku_series("SomeRandomName") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Introduces `showSkuDetailModal()` — a shared full-flow SKU detail modal that any plugin can use — and migrates the planner to use it. Also expands the SKU capabilities extracted by `get_skus()` and adds `parse_sku_series()` for workload-specific filtering.

### Core infrastructure

- **`showSkuDetailModal(skuName, opts)`** in `sku-detail-modal.js`: lazily creates modal DOM, shows loading state, fetches `/api/sku-detail`, renders all standard sections (confidence → VM profile → zones → quota → pricing), supports `extraSections` callback for plugin-specific content, `onRecalculate` callback for custom confidence recalculation, currency change with re-fetch, and accordion state preservation.
- **`renderConfidenceBreakdown()`** upgraded with signal description tooltips, knockout reasons alert, disclaimers with "Learn more" link, dynamic title (blocked/basic+spot/basic).
- **`parse_sku_series()`** — extracts VM series prefix from ARM SKU names (e.g. `Standard_D2s_v5` → `D`).

### SKU capabilities expansion

`get_skus()` now extracts 15 capabilities (was 4): `AcceleratedNetworkingEnabled`, `EphemeralOSDiskSupported`, `HyperVGenerations`, `GPUs`, `CachedDiskBytes`, `MaxResourceVolumeMB`, `LowPriorityCapable`, `TrustedLaunchDisabled`, `EncryptionAtHostSupported`, `CpuArchitectureType`, `UltraSSDAvailable`.

### Planner migration

Planner now delegates to `showSkuDetailModal()` with an `onRecalculate` callback for `POST /api/deployment-confidence`. Removes ~200 lines of duplicate modal rendering code.

## Related issue

Enables the AKS Placement Advisor plugin ([az-scout-plugin-aks-placement-advisor#1](https://github.com/az-scout/az-scout-plugin-aks-placement-advisor/pull/1)).

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [x] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
- [x] All 409 tests pass (40 fixture errors are pre-existing Python 3.14 recursion bug)
- [x] ruff lint, ruff format, mypy all pass
- [x] PLUGIN_API_VERSION bumped to 1.3
