### PR TITLE
feat(shared-modal): add prependSections callback to showSkuDetailModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ### Added
 
-- **`showSkuDetailModal()`** – New shared JS component in `sku-detail-modal.js` that provides a full-flow SKU detail modal for all plugins. Shows loading state, fetches from `/api/sku-detail`, renders confidence breakdown (with signal tooltips, knockout reasons, disclaimers), VM profile, zone availability, quota, pricing (with currency selector), and supports plugin-specific extra sections and recalculate callbacks. Modal DOM is created lazily — no `index.html` changes needed.
+- **`showSkuDetailModal()`** – New shared JS component in `sku-detail-modal.js` that provides a full-flow SKU detail modal for all plugins. Shows loading state, fetches from `/api/sku-detail`, renders confidence breakdown (with signal tooltips, knockout reasons, disclaimers), VM profile, zone availability, quota, pricing (with currency selector), and supports plugin-specific extra sections (`extraSections`, `prependSections`) and recalculate callbacks. Modal DOM is created lazily — no `index.html` changes needed.
 - **`parse_sku_series()`** – New utility in `azure_api.skus` that extracts the VM series prefix from ARM SKU names (e.g. `Standard_D2s_v5` → `D`, `Standard_NC24ads_A100_v4` → `NC`). Exported in `azure_api` public API.
 - **Expanded SKU capabilities** – `get_skus()` now extracts 15 capabilities (up from 4): added `AcceleratedNetworkingEnabled`, `EphemeralOSDiskSupported`, `HyperVGenerations`, `GPUs`, `CachedDiskBytes`, `MaxResourceVolumeMB`, `LowPriorityCapable`, `TrustedLaunchDisabled`, `EncryptionAtHostSupported`, `CpuArchitectureType`, `UltraSSDAvailable`. Enables workload eligibility filtering by plugins.
 

--- a/src/az_scout/static/js/components/sku-detail-modal.js
+++ b/src/az_scout/static/js/components/sku-detail-modal.js
@@ -394,6 +394,7 @@ window.azScout.components = window.azScout.components || {};
      * @param {object} [opts.enrichedSku] - Enriched SKU from plugin cache (quota, confidence, spot_zones).
      * @param {object} [opts.physicalZoneMap] - {logicalZone: physicalName} for zone tooltips.
      * @param {function} [opts.extraSections] - function(data, enrichedSku) → HTML.
+     * @param {function} [opts.prependSections] - function(data, enrichedSku) → HTML inserted before confidence.
      * @param {function} [opts.onRecalculate] - function(skuName, instanceCount, includeSpot) → Promise<{confidence}>.
      *     If provided, replaces the default recalculation (re-fetch /api/sku-detail).
      *     Must return an object with at least {confidence} to merge into the display.
@@ -458,6 +459,12 @@ window.azScout.components = window.azScout.components || {};
     function _renderSharedDetail(data, _skuName, opts, openAccordionIds) {
         var enriched = opts.enrichedSku || {};
         var html = "";
+
+        // 0. Plugin-specific prepend sections (before confidence)
+        if (typeof opts.prependSections === "function") {
+            html += opts.prependSections(data, enriched);
+            html += '<hr class="my-3 opacity-25">';
+        }
 
         // 1. Confidence breakdown
         var conf = enriched.confidence || data.confidence;


### PR DESCRIPTION
## Description

Adds `prependSections` callback to `showSkuDetailModal()`, allowing plugins to insert content **before** the confidence breakdown section. This complements the existing `extraSections` callback (which appends after pricing).

Use case: AKS Placement Advisor plugin displays an eligibility summary at the top of the modal, before the standard sections.

```js
C.showSkuDetailModal(skuName, {
    prependSections: (data, enriched) => renderEligibilitySummary(enriched),
    extraSections: (data, enriched) => renderAksDetails(enriched),
});
```

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors
