### PR TITLE
release: v2026.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+## [2026.5.0] - 2026-05-01
+
 ### Added
 
 - **AGENTS.md** – Top-level pointer for non-Copilot AI agents (Claude, Codex, Aider, Cursor) summarising where the rules live, the quality gate, branch protection, and hard constraints.


### PR DESCRIPTION
## Description

Cut release **v2026.5.0** — finalises the `## Unreleased` section in `CHANGELOG.md` for the .github reorganization shipped in #157.

This is a **changelog-only commit**. No code, schema, or behaviour changes.

After merge, the `v2026.5.0` tag will be created on `main` to trigger the **Publish** workflow (CI → CalVer validation → GitHub Release → PyPI publish via OIDC trusted publishing).

## Related issue

_None — release prep._

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update (CHANGELOG)
- [x] 🔧 Refactor / chore (release)

## Checklist

- [x] I have tested my changes locally — full quality gate green on Python 3.13:
  - `uv run ruff check src/ tests/` — clean
  - `uv run ruff format --check src/ tests/` — 72 files already formatted
  - `uv run mypy src/` — no issues in 56 source files
  - `uv run pytest` — **449 passed**, 18 deselected
- [x] I have updated the documentation / README if needed — `CHANGELOG.md` updated.
- [x] My changes do not introduce new warnings or errors

## Release contents (from `## Unreleased`)

### Added
- `AGENTS.md` (root pointer for non-Copilot agents)
- `.github/CODEOWNERS`
- `.github/copilot-review-instructions.md`
- Chat modes: `backend-engineer`, `frontend-engineer`, `plugin-reviewer`
- Slash prompts: `/review-dependabot-pr`, `/add-mcp-tool`, `/add-route`, `/bump-plugin-api`
- Scoped instructions: `tests`, `scoring`, `mcp-tools`, `cli`, `docs`, `commit`

### Changed
- Renamed `plugin-dev` → `plugin-api` and `plugin-scaffold` → `plugin-author` instruction files (`applyTo` extended to `internal_plugins/**`)
- Refreshed root `copilot-instructions.md` with full contextual table + Workflows section

## Post-merge

After this PR merges, tag `v2026.5.0` will be pushed from the new `main` HEAD:

```bash
git fetch origin
git tag v2026.5.0 origin/main
git push origin v2026.5.0
```
