### PR TITLE
fix(release): inject version into container build (#159)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,9 @@ venv/
 .vscode/
 .idea/
 
-# Git (we need .git for hatch-vcs, but exclude heavy objects selectively)
+# Git — version is injected via SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AZ_SCOUT
+# at build time, so the build context does not need git history (see #159).
+.git/
 .github/
 
 # Docs & config not needed at runtime

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,7 @@ venv/
 .vscode/
 .idea/
 
-# Git — version is injected via SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AZ_SCOUT
+# Git — version is injected via SETUPTOOLS_SCM_PRETEND_VERSION
 # at build time, so the build context does not need git history (see #159).
 .git/
 .github/

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -48,6 +48,19 @@ jobs:
             type=sha,prefix=dev-
             type=ref,event=branch,prefix=dev-
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      # Compute the version on the host (full git history available) so the
+      # Dockerfile doesn't need .git/ inside the build context (see #159).
+      - name: Compute version
+        id: version
+        run: |
+          uv tool install --quiet hatch
+          version=$(hatch version)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Building with version: ${version}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -59,6 +72,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            AZ_SCOUT_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -93,6 +108,19 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      # Compute the version on the host (full git history available) so the
+      # Dockerfile doesn't need .git/ inside the build context (see #159).
+      - name: Compute version
+        id: version
+        run: |
+          uv tool install --quiet hatch
+          version=$(hatch version)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Building with version: ${version}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -104,5 +132,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            AZ_SCOUT_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Fixed
+
+- **Container image version (#159)** – the GHCR container image now reports the correct version in the UI footer, MCP banner, and `_version.py`. The Dockerfile previously copied a partial worktree alongside the full `.git/` directory, which made `git describe` return `v<tag>-dirty` and caused `hatch-vcs` to emit the next-dev version (e.g. tag `v2026.4.1` was reported as `2026.4.2.dev0` inside the container). The version is now computed on the CI host and injected into the build via the `AZ_SCOUT_VERSION` build-arg / `SETUPTOOLS_SCM_PRETEND_VERSION`, making container builds deterministic and removing `.git/` from the build context.
+
+### Changed
+
+- **Dockerfile** – removed `git` from the builder stage's apt install (no longer needed) and dropped `COPY .git/`. The build context is now smaller and the wheel build is bit-for-bit reproducible from the same source + version arg.
+- **`container.yml`** – both `dev-image` and `release-image` jobs now run `hatch version` on the host (after `astral-sh/setup-uv@v5`) and pass the result as `AZ_SCOUT_VERSION` to `docker/build-push-action`.
+
 ## [2026.5.0] - 2026-05-01
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,24 @@
 # ---------- build stage ----------
 FROM python:3.13-slim AS builder
 
-# Install build tools (git needed for hatch-vcs version)
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /build
+
+# Version is injected by CI (computed from the git tag / branch SHA on the
+# host) instead of being derived from `.git/` inside the container.  Doing the
+# latter caused issue #159: the selective `COPY` below makes git see most of
+# the worktree as deleted ("dirty"), which made setuptools-scm fall back to
+# the next-dev version (e.g. tag v2026.4.1 was reported as 2026.4.2.dev0 in
+# the running container).  Pretending the version makes the build bit-for-bit
+# deterministic, drops the `git` apt dependency from the builder stage, and
+# avoids shipping `.git/` into the build context.
+ARG AZ_SCOUT_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${AZ_SCOUT_VERSION}
 
 # Copy source and build metadata
 COPY pyproject.toml README.md ./
 COPY src/ src/
-COPY .git/ .git/
 
-# Build the wheel (hatch-vcs reads git tags for the version)
+# Build the wheel
 RUN pip install --no-cache-dir build hatchling hatch-vcs && \
     python -m build --wheel --outdir /build/dist
 


### PR DESCRIPTION
## Summary

Fixes #159 — the GHCR container image was reporting the wrong version in the UI footer (e.g. tag `v2026.4.1` showed as `v2026.4.2.dev0`).

## Root cause

The Dockerfile selectively copied only `pyproject.toml`, `README.md` and `src/` but copied the **entire** `.git/` directory. Inside the build container, git therefore saw ~95 files as **deleted** (`.github/`, `tests/`, `docs/`, `Dockerfile`, `LICENSE.txt`, `CHANGELOG.md`, `mkdocs.yml`, `uv.lock`, …). `git describe --dirty` returned `v<tag>-dirty`, which made `setuptools-scm` set `version.exact = False` and fall back to the next-dev version.

Reproduced locally on the v2026.4.1 tag commit:

```
git describe --tags --dirty            → v2026.4.1-dirty
hatch version (Docker COPY pattern)    → 2026.4.2.dev0   ← matches the bug
hatch version (full tree)              → 2026.4.1        ← correct
```

This only affected the **container** build because direct PyPI installs ship the wheel pre-built by the `publish.yml` workflow (which uses `actions/checkout@v4` with `fetch-depth: 0` and the full tree).

## Fix

Compute the version on the CI host (where the full git history is available) and inject it into the Docker build via a build-arg. The Dockerfile maps it to `SETUPTOOLS_SCM_PRETEND_VERSION`, so `hatch-vcs` no longer needs `.git/` at all.

- `Dockerfile` — added `ARG AZ_SCOUT_VERSION` + `ENV SETUPTOOLS_SCM_PRETEND_VERSION`. Removed `git` from the builder stage's apt install (no longer needed) and dropped `COPY .git/ .git/`.
- `.github/workflows/container.yml` — both `dev-image` and `release-image` jobs now run `hatch version` after `astral-sh/setup-uv@v5` and pass the result as `AZ_SCOUT_VERSION` to `docker/build-push-action`.
- `.dockerignore` — added `.git/` (the build context no longer needs it).
- `CHANGELOG.md` — entry under `Unreleased / Fixed`.

The per-package `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AZ_SCOUT` variable is documented by setuptools-scm but is **not** honoured by `hatch-vcs` in practice — verified via local Docker build with `env | grep SETUPTOOLS` showing the var was set but the build still failed. The simpler global `SETUPTOOLS_SCM_PRETEND_VERSION` works.

## Validation

- ✅ `docker build --build-arg AZ_SCOUT_VERSION=2026.5.1.dev0 --target builder` succeeds.
- ✅ Inside the resulting image, `_version.py` contains `__version__ = '2026.5.1.dev0'` and `__commit_id__ = None` (confirms hatch-vcs no longer touches git).
- ✅ Wheel filename: `az_scout-2026.5.1.dev0-py3-none-any.whl`.
- ✅ Quality gate green: `ruff check`, `ruff format --check`, `mypy --strict`, `pytest` (449 passed).
- ✅ pre-commit hooks pass on changed files.

## Side effects

- Smaller build context (no more `.git/`).
- Faster builder stage (no apt install of git).
- Bit-for-bit reproducible builds for the same `(source, version)` pair.

## Releasing

This will ship in the next CalVer release after v2026.5.0 — no need to backport into PR #158.

Closes #159
