### PR TITLE
feat(plugin): VM v6/v7 Migration dashboard

### DIFF
--- a/src/az_scout/internal_plugins/__init__.py
+++ b/src/az_scout/internal_plugins/__init__.py
@@ -33,4 +33,13 @@ def discover_internal_plugins() -> list[AzScoutPlugin]:
         logger.info("Loaded internal plugin: %s v%s", planner_plugin.name, planner_plugin.version)
     except Exception:
         logger.exception("Failed to load internal plugin: planner")
+    try:
+        from az_scout.internal_plugins.vm_migration import plugin as vm_migration_plugin
+
+        plugins.append(vm_migration_plugin)
+        logger.info(
+            "Loaded internal plugin: %s v%s", vm_migration_plugin.name, vm_migration_plugin.version
+        )
+    except Exception:
+        logger.exception("Failed to load internal plugin: vm-migration")
     return plugins

--- a/src/az_scout/internal_plugins/vm_migration/__init__.py
+++ b/src/az_scout/internal_plugins/vm_migration/__init__.py
@@ -1,7 +1,7 @@
-"""VM v6/v7 Migration – internal plugin.
+"""VM v6/v7 SKU Migration Scope – internal plugin.
 
-Provides a dashboard of VMs that are candidates for migration from v2–v5
-series to the v6/v7 Azure VM series, with enriched metadata per VM.
+Provides an inventory of legacy SKU VMs (v2-v5) that are in scope for
+v6/v7 SKU-family migration planning, with enriched metadata per VM.
 """
 
 from __future__ import annotations
@@ -19,13 +19,15 @@ _STATIC_DIR = Path(__file__).parent / "static"
 
 
 class VmMigrationPlugin:
-    """Internal plugin: VM v6/v7 Migration dashboard."""
+    """Internal plugin: VM v6/v7 SKU Migration Scope dashboard."""
 
     name = "vm-migration"
-    display_name = "VM Migration"
+    display_name = "SKU Migration Scope"
     version = __version__
     internal = True
-    description = "Dashboard of VMs impacted by the Azure v2–v5 → v6/v7 series migration."
+    description = (
+        "Inventory of legacy SKU VMs (v2-v5) in scope for v6/v7 SKU-family migration planning."
+    )
 
     def get_router(self) -> APIRouter | None:
         from az_scout.internal_plugins.vm_migration.routes import router
@@ -44,7 +46,7 @@ class VmMigrationPlugin:
         return [
             TabDefinition(
                 id="vm-migration",
-                label="VM Migration",
+                label="SKU Migration Scope",
                 icon="bi bi-arrow-up-circle",
                 js_entry="js/vm-migration-tab.js",
                 css_entry="css/vm-migration-tab.css",

--- a/src/az_scout/internal_plugins/vm_migration/__init__.py
+++ b/src/az_scout/internal_plugins/vm_migration/__init__.py
@@ -1,0 +1,61 @@
+"""VM v6/v7 Migration – internal plugin.
+
+Provides a dashboard of VMs that are candidates for migration from v2–v5
+series to the v6/v7 Azure VM series, with enriched metadata per VM.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+from az_scout import __version__
+from az_scout.plugin_api import AzScoutPlugin, TabDefinition
+
+_STATIC_DIR = Path(__file__).parent / "static"
+
+
+class VmMigrationPlugin:
+    """Internal plugin: VM v6/v7 Migration dashboard."""
+
+    name = "vm-migration"
+    display_name = "VM Migration"
+    version = __version__
+    internal = True
+    description = "Dashboard of VMs impacted by the Azure v2–v5 → v6/v7 series migration."
+
+    def get_router(self) -> APIRouter | None:
+        from az_scout.internal_plugins.vm_migration.routes import router
+
+        return router
+
+    def get_mcp_tools(self) -> list[Callable[..., Any]] | None:
+        from az_scout.internal_plugins.vm_migration.tools import list_migration_candidate_vms
+
+        return [list_migration_candidate_vms]
+
+    def get_static_dir(self) -> Path | None:
+        return _STATIC_DIR
+
+    def get_tabs(self) -> list[TabDefinition] | None:
+        return [
+            TabDefinition(
+                id="vm-migration",
+                label="VM Migration",
+                icon="bi bi-arrow-up-circle",
+                js_entry="js/vm-migration-tab.js",
+                css_entry="css/vm-migration-tab.css",
+            )
+        ]
+
+    def get_chat_modes(self) -> None:
+        return None
+
+    def get_navbar_actions(self) -> None:
+        return None
+
+
+plugin: AzScoutPlugin = VmMigrationPlugin()

--- a/src/az_scout/internal_plugins/vm_migration/__init__.py
+++ b/src/az_scout/internal_plugins/vm_migration/__init__.py
@@ -13,7 +13,7 @@ from typing import Any
 from fastapi import APIRouter
 
 from az_scout import __version__
-from az_scout.plugin_api import AzScoutPlugin, TabDefinition
+from az_scout.plugin_api import AzScoutPlugin, ChatMode, NavbarAction, TabDefinition
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
@@ -51,10 +51,10 @@ class VmMigrationPlugin:
             )
         ]
 
-    def get_chat_modes(self) -> None:
+    def get_chat_modes(self) -> list[ChatMode] | None:
         return None
 
-    def get_navbar_actions(self) -> None:
+    def get_navbar_actions(self) -> list[NavbarAction] | None:
         return None
 
 

--- a/src/az_scout/internal_plugins/vm_migration/routes.py
+++ b/src/az_scout/internal_plugins/vm_migration/routes.py
@@ -129,14 +129,14 @@ def _fetch_vms_for_subscription(
 
 @router.get(
     "/vms",
-    summary="List VMs impacted by the v6/v7 migration",
+    summary="List legacy-SKU VMs in migration scope for v6/v7 planning",
     responses={400: {"model": dict}},
 )
 async def get_migration_vms(
     subscriptions: str | None = Query(None, description="Comma-separated subscription IDs."),
     tenantId: str | None = Query(None, description="Optional tenant ID."),  # noqa: N803
 ) -> JSONResponse:
-    """Return all VMs using v2–v5 SKUs, enriched with migration-relevant metadata."""
+    """Return legacy-SKU VM inventory (v2-v5) for v6/v7 migration planning scope."""
     if not subscriptions:
         return JSONResponse(
             {"error": "'subscriptions' query parameter is required"},

--- a/src/az_scout/internal_plugins/vm_migration/routes.py
+++ b/src/az_scout/internal_plugins/vm_migration/routes.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Plugin: vm-migration"])
 
 # VM SKU families v2–v5 are migration candidates.
-# Matches Standard_D4s_v3, Standard_E8ds_v4, Standard_B2ms_v2, etc.
-_V2_TO_V5_RE = re.compile(r"_v[2-5]([a-z]*)?$", re.IGNORECASE)
+# Matches Standard_D4s_v3, Standard_E8ds_v4, Standard_B2ms_v2,
+# and Promo variants like Standard_D4_v3_Promo.
+_V2_TO_V5_RE = re.compile(r"_v[2-5][a-z]*(_promo)?$", re.IGNORECASE)
 
 # Marker strings in image SKU names that indicate Generation 2
 _GEN2_IMAGE_MARKERS = ("gen2", "-g2", "2gen")

--- a/src/az_scout/internal_plugins/vm_migration/routes.py
+++ b/src/az_scout/internal_plugins/vm_migration/routes.py
@@ -1,0 +1,165 @@
+"""API routes for the VM v6/v7 Migration internal plugin."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+from fastapi import APIRouter, Query
+from starlette.responses import JSONResponse
+
+from az_scout import azure_api
+from az_scout.azure_api._arm import ArmAuthorizationError, ArmRequestError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Plugin: vm-migration"])
+
+# VM SKU families v2–v5 are migration candidates.
+# Matches Standard_D4s_v3, Standard_E8ds_v4, Standard_B2ms_v2, etc.
+_V2_TO_V5_RE = re.compile(r"_v[2-5]([a-z]*)?$", re.IGNORECASE)
+
+# Marker strings in image SKU names that indicate Generation 2
+_GEN2_IMAGE_MARKERS = ("gen2", "-g2", "2gen")
+
+_ARM_API_VERSION = "2024-07-01"
+
+
+def _parse_resource_group(resource_id: str) -> str:
+    """Extract the resource group name from an ARM resource ID."""
+    parts = resource_id.split("/")
+    try:
+        idx = [p.lower() for p in parts].index("resourcegroups")
+        return parts[idx + 1]
+    except (ValueError, IndexError):
+        return ""
+
+
+def _detect_generation(vm: dict[str, Any]) -> str:
+    """Derive the HyperV generation from available VM fields.
+
+    Priority:
+    1. securityProfile.securityType (TrustedLaunch / ConfidentialVM → V2)
+    2. imageReference.sku containing a Gen 2 marker (gen2, -g2)
+    3. SKU family: v4/v5 → V2 likely; v2/v3 → V1 likely
+    """
+    props = vm.get("properties", {})
+
+    security_type = props.get("securityProfile", {}).get("securityType", "")
+    if security_type in ("TrustedLaunch", "ConfidentialVM"):
+        return "V2"
+
+    img_sku = props.get("storageProfile", {}).get("imageReference", {}).get("sku", "").lower()
+    if any(m in img_sku for m in _GEN2_IMAGE_MARKERS):
+        return "V2"
+
+    vm_size = props.get("hardwareProfile", {}).get("vmSize", "")
+    match = re.search(r"_v([2-5])", vm_size, re.IGNORECASE)
+    if match:
+        gen_num = int(match.group(1))
+        return "V2 (inferred)" if gen_num >= 4 else "V1 (inferred)"
+
+    return "Unknown"
+
+
+def _is_migration_candidate(vm_size: str) -> bool:
+    """Return True when the SKU belongs to a v2–v5 family."""
+    return bool(_V2_TO_V5_RE.search(vm_size))
+
+
+def _build_vm_record(
+    vm: dict[str, Any],
+    sub_id: str,
+    sub_name: str,
+) -> dict[str, Any]:
+    """Transform an ARM VM object into the dashboard record shape."""
+    props = vm.get("properties", {})
+    storage = props.get("storageProfile", {})
+    image_ref = storage.get("imageReference", {})
+    os_disk = storage.get("osDisk", {})
+
+    return {
+        "name": vm.get("name", ""),
+        "resource_group": _parse_resource_group(vm.get("id", "")),
+        "subscription_id": sub_id,
+        "subscription_name": sub_name,
+        "region": vm.get("location", ""),
+        "sku": props.get("hardwareProfile", {}).get("vmSize", ""),
+        "generation": _detect_generation(vm),
+        "os_type": os_disk.get("osType", ""),
+        "image_publisher": image_ref.get("publisher", ""),
+        "disk_controller_type": os_disk.get("diskControllerType", "SCSI"),
+        "zones": vm.get("zones", []),
+    }
+
+
+def _fetch_vms_for_subscription(
+    sub_id: str,
+    sub_name: str,
+    tenant_id: str | None,
+) -> list[dict[str, Any]]:
+    """List migration-candidate VMs for one subscription (blocking)."""
+    url = (
+        f"https://management.azure.com/subscriptions/{sub_id}"
+        "/providers/Microsoft.Compute/virtualMachines"
+    )
+    try:
+        vms = azure_api.arm_paginate(
+            url,
+            params={"api-version": _ARM_API_VERSION},
+            tenant_id=tenant_id,
+        )
+    except ArmAuthorizationError:
+        logger.warning("No access to subscription %s — skipping", sub_id)
+        return []
+    except ArmRequestError as exc:
+        logger.warning("ARM error for subscription %s: %s — skipping", sub_id, exc)
+        return []
+
+    records: list[dict[str, Any]] = []
+    for vm in vms:
+        vm_size = vm.get("properties", {}).get("hardwareProfile", {}).get("vmSize", "")
+        if _is_migration_candidate(vm_size):
+            records.append(_build_vm_record(vm, sub_id, sub_name))
+    return records
+
+
+@router.get(
+    "/vms",
+    summary="List VMs impacted by the v6/v7 migration",
+    responses={400: {"model": dict}},
+)
+async def get_migration_vms(
+    subscriptions: str | None = Query(None, description="Comma-separated subscription IDs."),
+    tenantId: str | None = Query(None, description="Optional tenant ID."),  # noqa: N803
+) -> JSONResponse:
+    """Return all VMs using v2–v5 SKUs, enriched with migration-relevant metadata."""
+    if not subscriptions:
+        return JSONResponse(
+            {"error": "'subscriptions' query parameter is required"},
+            status_code=400,
+        )
+    sub_ids = [s.strip() for s in subscriptions.split(",") if s.strip()]
+    if not sub_ids:
+        return JSONResponse(
+            {"error": "'subscriptions' query parameter is required"},
+            status_code=400,
+        )
+
+    # Resolve subscription names from ARM discovery
+    known_subs: dict[str, str] = {}
+    try:
+        all_subs = await asyncio.to_thread(azure_api.list_subscriptions, tenantId)
+        known_subs = {s["id"]: s.get("name", s["id"]) for s in all_subs}
+    except Exception:
+        logger.debug("Could not resolve subscription names — using IDs as names")
+
+    results: list[dict[str, Any]] = []
+    for sub_id in sub_ids:
+        sub_name = known_subs.get(sub_id, sub_id)
+        items = await asyncio.to_thread(_fetch_vms_for_subscription, sub_id, sub_name, tenantId)
+        results.extend(items)
+
+    return JSONResponse(results)

--- a/src/az_scout/internal_plugins/vm_migration/routes.py
+++ b/src/az_scout/internal_plugins/vm_migration/routes.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Query
 from starlette.responses import JSONResponse
 
 from az_scout import azure_api
-from az_scout.azure_api._arm import ArmAuthorizationError, ArmRequestError
+from az_scout.azure_api import ArmAuthorizationError, ArmRequestError
 
 logger = logging.getLogger(__name__)
 

--- a/src/az_scout/internal_plugins/vm_migration/static/css/vm-migration-tab.css
+++ b/src/az_scout/internal_plugins/vm_migration/static/css/vm-migration-tab.css
@@ -58,7 +58,303 @@
     vertical-align: middle;
 }
 
+.vmm-vm-row {
+    cursor: pointer;
+}
+
+.vmm-vm-row:hover,
+.vmm-vm-row:focus {
+    background-color: var(--bs-secondary-bg);
+}
+
+/* ---- VM detail modal ---- */
+.vmm-vm-context {
+    background: var(--bs-tertiary-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    padding: 0.65rem 0.8rem;
+}
+
+.vmm-reco-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 0.75rem;
+}
+
+.vmm-reco-step {
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    background: var(--bs-body-bg);
+    padding: 0.75rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    border-left: 5px solid var(--bs-primary);
+}
+
+.vmm-reco-step-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+
+.vmm-reco-step-index {
+    min-width: 1.45rem;
+    height: 1.45rem;
+    border-radius: 999px;
+    background: var(--bs-primary);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.73rem;
+    font-weight: 700;
+}
+
+.vmm-reco-why {
+    font-size: 0.83rem;
+    color: var(--bs-body-color);
+    line-height: 1.35;
+}
+
+.vmm-reco-title {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    color: var(--bs-heading-color);
+}
+
+.vmm-reco-actions {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 0;
+}
+
+.vmm-reco-actions li {
+    display: flex;
+    gap: 0.45rem;
+    align-items: flex-start;
+    margin-bottom: 0.25rem;
+}
+
+.vmm-reco-actions li i {
+    color: var(--bs-success);
+    margin-top: 0.15rem;
+}
+
+.vmm-tone-blue {
+    background: linear-gradient(180deg, rgba(13, 110, 253, 0.08) 0%, var(--bs-body-bg) 58%);
+    border-left-color: #0d6efd;
+}
+
+.vmm-tone-green {
+    background: linear-gradient(180deg, rgba(25, 135, 84, 0.08) 0%, var(--bs-body-bg) 58%);
+    border-left-color: #198754;
+}
+
+.vmm-tone-purple {
+    background: linear-gradient(180deg, rgba(111, 66, 193, 0.1) 0%, var(--bs-body-bg) 58%);
+    border-left-color: #6f42c1;
+}
+
+.vmm-tone-orange {
+    background: linear-gradient(180deg, rgba(253, 126, 20, 0.1) 0%, var(--bs-body-bg) 58%);
+    border-left-color: #fd7e14;
+}
+
+.vmm-target-sku-card {
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    background: var(--bs-body-bg);
+    padding: 0.85rem;
+    margin-bottom: 0.85rem;
+}
+
+.vmm-target-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 0.7rem;
+}
+
+.vmm-target-block {
+    border: 1px solid var(--bs-border-color-translucent);
+    border-radius: var(--bs-border-radius);
+    background: var(--bs-tertiary-bg);
+    padding: 0.6rem;
+}
+
+.vmm-target-block h6 {
+    font-size: 0.82rem;
+    margin-bottom: 0.45rem;
+    color: var(--bs-secondary-color);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.vmm-target-block-wide {
+    grid-column: 1 / -1;
+}
+
+.vmm-pricing-table {
+    font-size: 0.8rem;
+}
+
+.vmm-pricing-table th,
+.vmm-pricing-table td {
+    padding-top: 0.3rem;
+    padding-bottom: 0.3rem;
+}
+
+.vmm-target-sku-card .accordion-button {
+    font-size: 0.88rem;
+    padding: 0.5rem 0.75rem;
+}
+
+.vmm-target-sku-card .accordion-body {
+    font-size: 0.85rem;
+}
+
+.vmm-zone-icons .zone-available {
+    color: var(--bs-success) !important;
+}
+
+.vmm-zone-icons .zone-restricted {
+    color: var(--bs-warning) !important;
+}
+
+.vmm-zone-icons .zone-unavailable {
+    color: var(--bs-secondary) !important;
+    opacity: 0.6;
+}
+
+/* Compatibility with shared confidence badge renderer */
+.confidence-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.76rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.confidence-high { background: #d4edda; color: #155724; border: 1px solid #b1dfbb; }
+.confidence-medium { background: #fff3cd; color: #856404; border: 1px solid #ffeeba; }
+.confidence-low { background: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+.confidence-very-low { background: #f5c6cb; color: #721c24; border: 1px solid #f1b0b7; }
+.confidence-blocked { background: #f8d7da; color: #58151c; border: 1px solid #f1aeb5; }
+
+.confidence-section {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.confidence-title {
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+}
+
+.confidence-breakdown-table {
+    font-size: 0.82rem;
+}
+
+.confidence-missing {
+    font-size: 0.78rem;
+    color: var(--bs-secondary-color);
+    margin-top: 0.25rem;
+    margin-bottom: 0;
+}
+
+.vm-profile-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+}
+
+.vm-profile-card {
+    background: var(--bs-tertiary-bg);
+    border-radius: var(--bs-border-radius);
+    padding: 0.75rem;
+}
+
+.vm-profile-card-title {
+    font-weight: 600;
+    font-size: 0.82rem;
+    margin-bottom: 0.4rem;
+    color: var(--az-blue);
+}
+
+.vm-profile-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.15rem 0;
+    font-size: 0.8rem;
+    border-bottom: 1px solid var(--bs-border-color-translucent);
+}
+
+.vm-profile-label {
+    color: var(--bs-secondary-color);
+}
+
+.vm-badge {
+    display: inline-block;
+    padding: 0 0.35rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.vm-badge-yes { background: #d4edda; color: #155724; }
+.vm-badge-no { background: #f8d7da; color: #721c24; }
+.vm-badge-unknown { background: var(--bs-secondary-bg); color: var(--bs-body-color); }
+.vm-badge-limited { background: #fff3cd; color: #856404; }
+
+.pricing-detail-table {
+    font-size: 0.85rem;
+}
+
+.price-cell {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.spot-zone-label {
+    font-size: 0.7rem;
+    opacity: 0.7;
+    margin-right: 0.15rem;
+}
+
+.spot-badge {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.spot-high { background: #d4edda; color: #155724; }
+.spot-medium { background: #fff3cd; color: #856404; }
+.spot-low { background: #f8d7da; color: #721c24; }
+
 /* ---- Dark theme overrides ---- */
 [data-bs-theme="dark"] .vmm-stat-card {
     background: var(--bs-tertiary-bg);
+}
+
+[data-bs-theme="dark"] .vmm-tone-blue {
+    background: linear-gradient(180deg, rgba(13, 110, 253, 0.28) 0%, var(--bs-body-bg) 62%);
+}
+
+[data-bs-theme="dark"] .vmm-tone-green {
+    background: linear-gradient(180deg, rgba(25, 135, 84, 0.28) 0%, var(--bs-body-bg) 62%);
+}
+
+[data-bs-theme="dark"] .vmm-tone-purple {
+    background: linear-gradient(180deg, rgba(111, 66, 193, 0.33) 0%, var(--bs-body-bg) 62%);
+}
+
+[data-bs-theme="dark"] .vmm-tone-orange {
+    background: linear-gradient(180deg, rgba(253, 126, 20, 0.33) 0%, var(--bs-body-bg) 62%);
 }

--- a/src/az_scout/internal_plugins/vm_migration/static/css/vm-migration-tab.css
+++ b/src/az_scout/internal_plugins/vm_migration/static/css/vm-migration-tab.css
@@ -1,0 +1,64 @@
+/* ===================================================================
+   Azure Scout – VM v6/v7 Migration Plugin Styles
+   =================================================================== */
+
+/* ---- Sidebar ---- */
+.vmm-sidebar {
+    position: sticky;
+    top: 1rem;
+}
+
+/* ---- Subscription checklist (reuse topology pattern) ---- */
+#vmm-sub-list.subscription-checklist {
+    max-height: 40vh;
+    overflow-y: auto;
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    padding: 0.35rem 0.5rem;
+}
+
+#vmm-sub-list label {
+    display: block;
+    padding: 0.15rem 0;
+    cursor: pointer;
+    font-size: 0.82rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ---- Stat cards ---- */
+.vmm-stat-card {
+    border: 1px solid var(--bs-border-color);
+    background: var(--bs-tertiary-bg);
+}
+
+/* ---- Migration table ---- */
+.vmm-table thead th {
+    font-size: 0.78rem;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.vmm-table thead th.sortable {
+    cursor: pointer;
+}
+
+.vmm-table thead th.sortable:hover {
+    background-color: var(--bs-secondary-bg);
+}
+
+.vmm-table .sort-icon {
+    opacity: 0.4;
+    font-size: 0.7rem;
+}
+
+.vmm-table tbody td {
+    font-size: 0.83rem;
+    vertical-align: middle;
+}
+
+/* ---- Dark theme overrides ---- */
+[data-bs-theme="dark"] .vmm-stat-card {
+    background: var(--bs-tertiary-bg);
+}

--- a/src/az_scout/internal_plugins/vm_migration/static/html/vm-migration-tab.html
+++ b/src/az_scout/internal_plugins/vm_migration/static/html/vm-migration-tab.html
@@ -104,15 +104,15 @@
                         <table class="table table-sm table-hover vmm-table mb-0" id="vmm-table">
                             <thead class="table-dark">
                                 <tr>
-                                    <th onclick="vmmSort('name')" class="sortable">VM Name <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('resource_group')" class="sortable">Resource Group <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('subscription_name')" class="sortable">Subscription <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('region')" class="sortable">Region <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('sku')" class="sortable">SKU <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('generation')" class="sortable">Generation <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('os_type')" class="sortable">OS <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('image_publisher')" class="sortable">Image Publisher <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('disk_controller_type')" class="sortable">Disk Controller <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('name')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('name');}" class="sortable" tabindex="0">VM Name <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('resource_group')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('resource_group');}" class="sortable" tabindex="0">Resource Group <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('subscription_name')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('subscription_name');}" class="sortable" tabindex="0">Subscription <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('region')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('region');}" class="sortable" tabindex="0">Region <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('sku')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('sku');}" class="sortable" tabindex="0">SKU <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('generation')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('generation');}" class="sortable" tabindex="0">Generation <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('os_type')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('os_type');}" class="sortable" tabindex="0">OS <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('image_publisher')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('image_publisher');}" class="sortable" tabindex="0">Image Publisher <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('disk_controller_type')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('disk_controller_type');}" class="sortable" tabindex="0">Disk Controller <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th>Zones</th>
                                     <th>Effort</th>
                                 </tr>

--- a/src/az_scout/internal_plugins/vm_migration/static/html/vm-migration-tab.html
+++ b/src/az_scout/internal_plugins/vm_migration/static/html/vm-migration-tab.html
@@ -60,14 +60,20 @@
 
     <!-- Right content -->
     <div class="col-md-9 col-xl-10">
+        <!-- Scope definition -->
+        <div class="alert alert-info py-2 mb-3 small" role="note">
+            <strong>Scope definition:</strong> This list is a legacy SKU VM inventory for v6/v7 migration
+            planning scope. It is not a direct execution checklist for in-place migration.
+        </div>
+
         <!-- Error -->
         <div id="vmm-error" data-testid="vmm-error" class="alert alert-danger alert-sm d-none" role="alert"></div>
 
         <!-- Empty state -->
         <div id="vmm-empty" data-testid="vmm-empty" class="text-center text-body-secondary py-5">
             <i class="bi bi-arrow-up-circle fs-1 d-block mb-2"></i>
-            <p>Select subscriptions and click <strong>Load</strong> to find VMs that need to migrate to the v6/v7 series.</p>
-            <p class="small">Scans for VMs using v2–v5 SKU families.</p>
+            <p>Select subscriptions and click <strong>Load</strong> to discover legacy SKU VMs in migration scope.</p>
+            <p class="small">This inventory targets VMs currently on v2-v5 SKU families.</p>
         </div>
 
         <!-- Loading -->
@@ -79,8 +85,8 @@
         <!-- No results (after load) -->
         <div id="vmm-no-results" data-testid="vmm-no-results" class="text-center text-body-secondary py-5 d-none">
             <i class="bi bi-check-circle fs-1 d-block mb-2 text-success"></i>
-            <p>No v2–v5 VMs found in the selected subscriptions.</p>
-            <p class="small">All VMs are already on v6/v7 series or newer.</p>
+            <p>No legacy SKU (v2-v5) VMs found in the selected subscriptions.</p>
+            <p class="small">No VM is currently in this migration planning scope.</p>
         </div>
 
         <!-- Results -->
@@ -92,8 +98,11 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <span>
-                        <i class="bi bi-table"></i> Migration Candidates
+                        <i class="bi bi-table"></i> Legacy SKU VM Inventory
                         <span id="vmm-table-count" class="badge bg-secondary ms-2">0</span>
+                        <span class="ms-2 text-body-secondary small">
+                            Click a row to open VM planning recommendations
+                        </span>
                     </span>
                     <button type="button" class="btn btn-sm btn-outline-secondary" onclick="vmmExportCSV()" title="Export as CSV">
                         <i class="bi bi-download"></i> CSV
@@ -109,18 +118,39 @@
                                     <th onclick="vmmSort('subscription_name')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('subscription_name');}" class="sortable" tabindex="0">Subscription <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th onclick="vmmSort('region')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('region');}" class="sortable" tabindex="0">Region <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th onclick="vmmSort('sku')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('sku');}" class="sortable" tabindex="0">SKU <i class="bi bi-arrow-down-up sort-icon"></i></th>
-                                    <th onclick="vmmSort('generation')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('generation');}" class="sortable" tabindex="0">Generation <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('generation')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('generation');}" class="sortable" tabindex="0">Hyper-V Generation <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th onclick="vmmSort('os_type')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('os_type');}" class="sortable" tabindex="0">OS <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th onclick="vmmSort('image_publisher')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('image_publisher');}" class="sortable" tabindex="0">Image Publisher <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th onclick="vmmSort('disk_controller_type')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmSort('disk_controller_type');}" class="sortable" tabindex="0">Disk Controller <i class="bi bi-arrow-down-up sort-icon"></i></th>
                                     <th>Zones</th>
-                                    <th>Effort</th>
+                                    <th>Migration Readiness (inferred)</th>
                                 </tr>
                             </thead>
                             <tbody id="vmm-tbody"></tbody>
                         </table>
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- VM Detail Modal (VM Migration plugin specific) -->
+<div class="modal fade" id="vmmDetailModal" tabindex="-1" aria-labelledby="vmmDetailModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-fullscreen-md-down modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="vmmDetailModalLabel">
+                    VM Migration Scope Detail - <span id="vmm-detail-name"></span>
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div id="vmm-detail-loading" class="text-center d-none">
+                    <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                    <span class="ms-2 small">Building recommendations...</span>
+                </div>
+                <div id="vmm-detail-content" class="d-none"></div>
             </div>
         </div>
     </div>

--- a/src/az_scout/internal_plugins/vm_migration/static/html/vm-migration-tab.html
+++ b/src/az_scout/internal_plugins/vm_migration/static/html/vm-migration-tab.html
@@ -1,0 +1,127 @@
+<div class="row g-3">
+    <!-- Left sidebar: subscription selector + filters -->
+    <div class="col-md-3 col-xl-2">
+        <div class="vmm-sidebar">
+            <label class="form-label form-label-sm mb-1">
+                <i class="bi bi-collection"></i> Subscriptions
+            </label>
+            <div class="input-group input-group-sm mb-1">
+                <input type="search" class="form-control" id="vmm-sub-filter"
+                       placeholder="Filter…" autocomplete="off" spellcheck="false">
+                <button type="button" class="btn btn-outline-secondary" onclick="vmmSelectAllVisible()" title="Select all visible">
+                    <i class="bi bi-check-all"></i>
+                </button>
+                <button type="button" class="btn btn-outline-secondary" onclick="vmmDeselectAll()" title="Clear all">
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            </div>
+            <div id="vmm-sub-list" data-testid="vmm-sub-list" class="subscription-checklist"></div>
+            <div class="d-flex justify-content-between align-items-center mt-2">
+                <small class="text-body-secondary" id="vmm-sub-count">0 selected</small>
+                <button type="button" class="btn btn-primary btn-sm" id="vmm-load-btn"
+                        data-testid="vmm-load-btn" onclick="vmmLoad()" disabled>
+                    <i class="bi bi-arrow-repeat"></i> Load
+                </button>
+            </div>
+
+            <!-- Column filters -->
+            <hr class="my-3">
+            <label class="form-label form-label-sm mb-1">
+                <i class="bi bi-funnel"></i> Filters
+            </label>
+            <div class="mb-2">
+                <input type="search" class="form-control form-control-sm" id="vmm-filter-name"
+                       placeholder="VM name…" autocomplete="off" oninput="vmmApplyFilters()">
+            </div>
+            <div class="mb-2">
+                <select class="form-select form-select-sm" id="vmm-filter-region" onchange="vmmApplyFilters()">
+                    <option value="">All regions</option>
+                </select>
+            </div>
+            <div class="mb-2">
+                <select class="form-select form-select-sm" id="vmm-filter-os" onchange="vmmApplyFilters()">
+                    <option value="">All OS types</option>
+                    <option value="Windows">Windows</option>
+                    <option value="Linux">Linux</option>
+                </select>
+            </div>
+            <div class="mb-2">
+                <select class="form-select form-select-sm" id="vmm-filter-gen" onchange="vmmApplyFilters()">
+                    <option value="">All generations</option>
+                    <option value="V1">V1</option>
+                    <option value="V2">V2</option>
+                </select>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline-secondary w-100 mt-1" onclick="vmmResetFilters()">
+                <i class="bi bi-x-circle"></i> Reset filters
+            </button>
+        </div>
+    </div>
+
+    <!-- Right content -->
+    <div class="col-md-9 col-xl-10">
+        <!-- Error -->
+        <div id="vmm-error" data-testid="vmm-error" class="alert alert-danger alert-sm d-none" role="alert"></div>
+
+        <!-- Empty state -->
+        <div id="vmm-empty" data-testid="vmm-empty" class="text-center text-body-secondary py-5">
+            <i class="bi bi-arrow-up-circle fs-1 d-block mb-2"></i>
+            <p>Select subscriptions and click <strong>Load</strong> to find VMs that need to migrate to the v6/v7 series.</p>
+            <p class="small">Scans for VMs using v2–v5 SKU families.</p>
+        </div>
+
+        <!-- Loading -->
+        <div id="vmm-loading" data-testid="vmm-loading" class="text-center py-5 d-none">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="mt-2 text-body-secondary">Scanning VMs across subscriptions…</p>
+        </div>
+
+        <!-- No results (after load) -->
+        <div id="vmm-no-results" data-testid="vmm-no-results" class="text-center text-body-secondary py-5 d-none">
+            <i class="bi bi-check-circle fs-1 d-block mb-2 text-success"></i>
+            <p>No v2–v5 VMs found in the selected subscriptions.</p>
+            <p class="small">All VMs are already on v6/v7 series or newer.</p>
+        </div>
+
+        <!-- Results -->
+        <div id="vmm-results" data-testid="vmm-results" class="d-none">
+            <!-- Summary cards -->
+            <div id="vmm-stats" class="row g-2 mb-3"></div>
+
+            <!-- Table card -->
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>
+                        <i class="bi bi-table"></i> Migration Candidates
+                        <span id="vmm-table-count" class="badge bg-secondary ms-2">0</span>
+                    </span>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="vmmExportCSV()" title="Export as CSV">
+                        <i class="bi bi-download"></i> CSV
+                    </button>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-sm table-hover vmm-table mb-0" id="vmm-table">
+                            <thead class="table-dark">
+                                <tr>
+                                    <th onclick="vmmSort('name')" class="sortable">VM Name <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('resource_group')" class="sortable">Resource Group <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('subscription_name')" class="sortable">Subscription <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('region')" class="sortable">Region <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('sku')" class="sortable">SKU <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('generation')" class="sortable">Generation <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('os_type')" class="sortable">OS <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('image_publisher')" class="sortable">Image Publisher <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th onclick="vmmSort('disk_controller_type')" class="sortable">Disk Controller <i class="bi bi-arrow-down-up sort-icon"></i></th>
+                                    <th>Zones</th>
+                                    <th>Effort</th>
+                                </tr>
+                            </thead>
+                            <tbody id="vmm-tbody"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/az_scout/internal_plugins/vm_migration/static/js/vm-migration-tab.js
+++ b/src/az_scout/internal_plugins/vm_migration/static/js/vm-migration-tab.js
@@ -1,6 +1,6 @@
 /* eslint-disable @microsoft/sdl/no-inner-html -- All dynamic values sanitized via escapeHtml(). HTML fragments loaded from own server. */
 /* ===================================================================
-   Azure Scout – VM v6/v7 Migration Tab  (internal plugin)
+   Azure Scout – VM v6/v7 SKU Migration Scope Tab  (internal plugin)
    Requires: app.js globals: subscriptions, apiFetch, tenantQS,
              escapeHtml, showError, hideError, downloadCSV
    =================================================================== */
@@ -33,8 +33,22 @@
 const vmmSelectedSubs = new Set();
 let vmmAllVms = [];          // raw API results
 let vmmFilteredVms = [];     // after filter application
+let vmmDisplayedVms = [];    // current table ordering
 let vmmSortField = "name";
 let vmmSortAsc = true;
+let vmmDetailModal = null;
+const vmmSkuRecommendationCache = new Map();
+const vmmComponents = window.azScout?.components || {};
+
+const vmmKnownMarketplacePublishers = new Set([
+    "canonical",
+    "microsoftwindowsserver",
+    "microsoft-aks",
+    "redhat",
+    "suse",
+    "debian",
+    "oracle",
+]);
 
 // ---------------------------------------------------------------------------
 // Subscription checklist
@@ -183,6 +197,480 @@ function vmmSortedVms() {
     });
 }
 
+function vmmOpenVmDetailByIndex(index) {
+    const vm = vmmDisplayedVms[index];
+    if (!vm) return;
+    vmmOpenVmDetail(vm);
+}
+
+function vmmEnsureDetailModal() {
+    const modalEl = document.getElementById("vmmDetailModal");
+    if (!modalEl || typeof bootstrap === "undefined") return null;
+    if (!vmmDetailModal) vmmDetailModal = new bootstrap.Modal(modalEl);
+    return vmmDetailModal;
+}
+
+function vmmIsDSuffixedSku(sku) {
+    return /_d[a-z0-9]*_v/i.test(sku || "");
+}
+
+function vmmHasThirdPartyPublisher(publisher) {
+    const normalized = String(publisher || "").trim().toLowerCase();
+    if (!normalized) return true;
+    return !vmmKnownMarketplacePublishers.has(normalized);
+}
+
+function vmmBuildRecommendations(vm) {
+    const recs = [];
+    const generation = String(vm.generation || "");
+    const diskController = String(vm.disk_controller_type || "SCSI");
+    const osType = String(vm.os_type || "Unknown");
+    const publisher = String(vm.image_publisher || "Unknown");
+    const sku = String(vm.sku || "");
+    const hasZones = Array.isArray(vm.zones) && vm.zones.length > 0;
+
+    if (generation.startsWith("V1")) {
+        recs.push({
+            title: "Generation 2 and Trusted Launch",
+            why: "This VM appears to be Generation 1 or not yet confirmed as Generation 2.",
+            actions: [
+                "Plan a Generation 2 path before sizing into v6/v7.",
+                "Validate Secure Boot compatibility for low-level guest agents.",
+            ],
+        });
+    } else {
+        recs.push({
+            title: "Generation 2 and Trusted Launch",
+            why: "This VM is Generation 2 or likely Generation 2.",
+            actions: [
+                "Keep Trusted Launch enabled during redeploy.",
+                "Validate signed security, backup, and monitoring drivers.",
+            ],
+        });
+    }
+
+    if (diskController.toUpperCase() === "NVME") {
+        recs.push({
+            title: "NVMe storage interface",
+            why: "Disk controller is already NVMe-aware.",
+            actions: [
+                "Validate disk discovery and mount expectations in pilot.",
+                "Confirm no legacy SCSI path assumptions remain in scripts.",
+            ],
+        });
+    } else {
+        recs.push({
+            title: "NVMe storage interface",
+            why: "Current disk controller indicates SCSI-based lineage.",
+            actions: [
+                "Treat migration as redeploy-from-image, not in-place resize.",
+                "Replace hard-coded SCSI paths with stable identifiers (UUID/labels).",
+            ],
+        });
+    }
+
+    recs.push({
+        title: "Image prerequisites",
+        why: `Current publisher is ${publisher}.`,
+        actions: [
+            "Use a current Generation 2, NVMe-ready, MANA-ready image baseline.",
+            "Test boot diagnostics and extension health in pilot before wider rollout.",
+        ],
+    });
+
+    recs.push({
+        title: "MANA networking",
+        why: `Workload OS is ${osType}.`,
+        actions: [
+            osType === "Linux"
+                ? "Confirm Linux kernel and MANA driver readiness in the image."
+                : "Confirm Windows image patch level and in-box network driver readiness.",
+            "Capture before/after network checks during pilot.",
+        ],
+    });
+
+    recs.push({
+        title: "OS-disk data",
+        why: "Cross-generation migration starts from a fresh OS disk.",
+        actions: [
+            "Inventory app state persisted on OS disk before cutover.",
+            "Add explicit backup and restore steps for OS-disk data.",
+        ],
+    });
+
+    recs.push({
+        title: "Local (temporary) disk strategy",
+        why: vmmIsDSuffixedSku(sku)
+            ? "Current SKU likely includes a temporary/local disk profile."
+            : "Current SKU does not clearly indicate a d-suffixed local disk profile.",
+        actions: [
+            "Decide if target must use d-suffixed size for local NVMe scratch.",
+            "Keep persistent data on managed disks, not temporary local disks.",
+        ],
+    });
+
+    recs.push({
+        title: "Region, zone, and capacity",
+        why: hasZones
+            ? `VM is zonal (${vm.zones.join(", ")}).`
+            : "VM has no explicit zone pinning in current inventory.",
+        actions: [
+            "Confirm v6/v7 size availability and quota in target region/zone.",
+            "Request quota early and reserve capacity for wave windows.",
+        ],
+    });
+
+    recs.push({
+        title: "Commercial continuity",
+        why: "Reservations and savings plans are family-scoped.",
+        actions: [
+            "Replan reservation or savings-plan coverage for target v6/v7 family.",
+            "Rightsize based on observed usage, not one-to-one vCPU parity.",
+        ],
+    });
+
+    if (vmmHasThirdPartyPublisher(publisher)) {
+        recs.push({
+            title: "ISV appliance and vendor support",
+            why: "Image publisher may represent a third-party or custom appliance path.",
+            actions: [
+                "Confirm vendor certification for NVMe and MANA on target family.",
+                "Validate data-plane and failover behavior in pilot.",
+            ],
+        });
+    }
+
+    recs.push({
+        title: "Sequencing and automation",
+        why: "Large estate migration should execute in controlled waves.",
+        actions: [
+            "Group rollout by workload dependency and start with pilot ring.",
+            "Automate repeatable pre-flight and validation checks per wave.",
+        ],
+    });
+
+    return recs;
+}
+
+function vmmRecommendationIcon(title) {
+    if (title.includes("Generation 2")) return "bi-shield-check";
+    if (title.includes("NVMe")) return "bi-device-hdd";
+    if (title.includes("MANA")) return "bi-diagram-3";
+    if (title.includes("Region") || title.includes("capacity")) return "bi-geo-alt";
+    if (title.includes("Commercial")) return "bi-cash-coin";
+    if (title.includes("ISV")) return "bi-box";
+    if (title.includes("automation")) return "bi-diagram-2";
+    return "bi-lightbulb";
+}
+
+function vmmBuildRecommendationSectionHtml(vm) {
+    const vmName = escapeHtml(vm.name || "VM");
+    const sku = escapeHtml(vm.sku || "Unknown");
+    const region = escapeHtml(vm.region || "Unknown");
+    const generation = escapeHtml(vm.generation || "Unknown");
+    const diskController = escapeHtml(vm.disk_controller_type || "SCSI");
+    const publisher = escapeHtml(vm.image_publisher || "Unknown");
+    const recs = vmmBuildRecommendations(vm);
+
+    const toneClasses = ["vmm-tone-blue", "vmm-tone-green", "vmm-tone-purple", "vmm-tone-orange"];
+    const rows = recs
+        .map((r, idx) => {
+            const actions = r.actions
+                .map((a) => `<li><i class="bi bi-check2-circle"></i><span>${escapeHtml(a)}</span></li>`)
+                .join("");
+            const icon = vmmRecommendationIcon(r.title);
+            const toneClass = toneClasses[idx % toneClasses.length];
+            return `
+                <article class="vmm-reco-step ${toneClass}">
+                    <div class="vmm-reco-step-head">
+                        <span class="vmm-reco-step-index">${idx + 1}</span>
+                        <div class="vmm-reco-title">
+                            <i class="bi ${icon}"></i>
+                            <span>${escapeHtml(r.title)}</span>
+                        </div>
+                    </div>
+                    <div class="vmm-reco-why mb-2">${escapeHtml(r.why)}</div>
+                    <ul class="vmm-reco-actions small mb-0">${actions}</ul>
+                </article>
+            `;
+        })
+        .join("");
+
+    return `
+        <div class="accordion mt-3" id="vmmRecoAccordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#vmmRecoPanel" aria-expanded="true">
+                        <i class="bi bi-lightbulb me-2"></i>VM Migration Planning Recommendations
+                    </button>
+                </h2>
+                <div id="vmmRecoPanel" class="accordion-collapse collapse show">
+                    <div class="accordion-body p-3">
+                        <div class="vmm-vm-context mb-3">
+                            <div class="small text-body-secondary mb-1">
+                                <strong>${vmName}</strong> · SKU <code>${sku}</code>
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <span class="badge rounded-pill text-bg-primary">Region: ${region}</span>
+                                <span class="badge rounded-pill text-bg-info">Hyper-V Gen: ${generation}</span>
+                                <span class="badge rounded-pill text-bg-success">Disk: ${diskController}</span>
+                                <span class="badge rounded-pill text-bg-secondary">Publisher: ${publisher}</span>
+                            </div>
+                        </div>
+                        <div class="vmm-reco-grid">
+                            ${rows}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+function vmmBuildCandidateTargetSkus(currentSku) {
+    const base = String(currentSku || "");
+    if (!base) return [];
+    const stem = base.replace(/_v[2-5][a-z]*(?:_promo)?$/i, "");
+    if (stem === base) return [];
+    return [`${stem}_v7`, `${stem}_v6`];
+}
+
+function vmmGetConfidenceDisplay(confidence) {
+    if (vmmComponents.renderConfidenceBadge) {
+        return vmmComponents.renderConfidenceBadge(confidence, { tooltip: false });
+    }
+    if (!confidence || typeof confidence.score !== "number") {
+        return '<span class="badge bg-secondary">Unknown</span>';
+    }
+    const score = Math.round(confidence.score);
+    const label = String(confidence.label || "Unknown");
+    let cls = "bg-secondary";
+    if (score >= 80) cls = "bg-success";
+    else if (score >= 60) cls = "bg-primary";
+    else if (score >= 40) cls = "bg-warning text-dark";
+    else cls = "bg-danger";
+    return `<span class="badge ${cls}">${escapeHtml(label)} (${score})</span>`;
+}
+
+function vmmGetZonesDisplay(sku) {
+    const zones = Array.isArray(sku?.zones) ? sku.zones : [];
+    const restrictions = Array.isArray(sku?.restrictions)
+        ? sku.restrictions.filter((r) => r?.type === "Zone").flatMap((r) => r?.zones || [])
+        : [];
+    if (vmmComponents.renderZoneBadges) {
+        return `
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+                <span class="vmm-zone-icons">${vmmComponents.renderZoneBadges(zones, restrictions, ["1", "2", "3"])}</span>
+                <span class="small text-body-secondary">${zones.length ? `Available zones: ${escapeHtml(zones.join(", "))}` : "Regional / no explicit zones"}</span>
+            </div>
+        `;
+    }
+    if (!zones.length) return '<span class="text-body-secondary">Regional / no explicit zones</span>';
+    return zones.map((z) => `<span class="badge bg-secondary me-1">${escapeHtml(String(z))}</span>`).join("");
+}
+
+function vmmGetPriceDisplay(value) {
+    if (typeof value !== "number") return "—";
+    return escapeHtml(value.toFixed(4));
+}
+
+function vmmBuildPricingTable(sku) {
+    const pricing = sku?.pricing || {};
+    const currency = pricing.currency || "USD";
+    const rows = [
+        ["Pay-As-You-Go", pricing.paygo],
+        ["Spot", pricing.spot],
+        ["Reserved Instance 1Y", pricing.ri_1y],
+        ["Reserved Instance 3Y", pricing.ri_3y],
+        ["Savings Plan 1Y", pricing.sp_1y],
+        ["Savings Plan 3Y", pricing.sp_3y],
+    ];
+    return `
+        <table class="table table-sm pricing-detail-table vmm-pricing-table mb-0">
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th class="text-end">${escapeHtml(currency)}/hour</th>
+                </tr>
+            </thead>
+            <tbody>
+                ${rows.map(([label, value]) => `
+                    <tr>
+                        <td>${escapeHtml(label)}</td>
+                        <td class="text-end">${vmmGetPriceDisplay(value)}</td>
+                    </tr>
+                `).join("")}
+            </tbody>
+        </table>
+    `;
+}
+
+async function vmmFetchTargetSkuRecommendations(vm) {
+    const cacheKey = `${vm.subscription_id}|${vm.region}|${vm.sku}`;
+    const cached = vmmSkuRecommendationCache.get(cacheKey);
+    if (cached) return cached;
+
+    const candidates = vmmBuildCandidateTargetSkus(vm.sku);
+    if (!candidates.length) {
+        vmmSkuRecommendationCache.set(cacheKey, []);
+        return [];
+    }
+
+    const results = [];
+    for (const candidate of candidates) {
+        const params = new URLSearchParams({
+            region: vm.region,
+            subscriptionId: vm.subscription_id,
+            name: candidate,
+            includePrices: "true",
+            currencyCode: "USD",
+        });
+        const data = await apiFetch(`/api/skus?${params}${tenantQS("&")}`);
+        if (data?.error || !Array.isArray(data)) continue;
+        const exact = data.find((s) => String(s.name || "").toLowerCase() === candidate.toLowerCase());
+        if (exact) results.push(exact);
+    }
+
+    results.sort((a, b) => {
+        const as = a?.confidence?.score ?? -1;
+        const bs = b?.confidence?.score ?? -1;
+        if (bs !== as) return bs - as;
+        const av = String(a?.name || "").toLowerCase().includes("_v7") ? 7 : 6;
+        const bv = String(b?.name || "").toLowerCase().includes("_v7") ? 7 : 6;
+        return bv - av;
+    });
+    const top = results.slice(0, 2);
+    vmmSkuRecommendationCache.set(cacheKey, top);
+    return top;
+}
+
+function vmmBuildTargetRecommendationSection(vm, targetSkus) {
+    if (!targetSkus.length) {
+        return `
+            <div class="alert alert-secondary py-2 mb-0 mt-3">
+                No direct v6/v7 SKU recommendation was auto-matched for this VM.
+                Use Deployment Planner to choose a target family manually for this workload.
+            </div>
+        `;
+    }
+
+    const primarySku = targetSkus[0];
+    const alternateSkus = targetSkus.slice(1);
+    const primaryConfidence = vmmGetConfidenceDisplay(primarySku.confidence);
+    const primaryProfile = {
+        zones: Array.isArray(primarySku.zones) ? primarySku.zones : [],
+        restrictions: Array.isArray(primarySku.restrictions) ? primarySku.restrictions : [],
+        capabilities: primarySku.capabilities || {},
+    };
+
+    const sharedConfidenceSection = primarySku.confidence && vmmComponents.renderConfidenceBreakdown
+        ? vmmComponents.renderConfidenceBreakdown(primarySku.confidence)
+        : `
+            <div class="vmm-target-block mb-3">
+                <h6><i class="bi bi-graph-up-arrow me-1"></i>Confidence</h6>
+                <div class="small">${primaryConfidence}</div>
+            </div>
+        `;
+
+    const sharedZoneSection = vmmComponents.renderZoneAvailability
+        ? vmmComponents.renderZoneAvailability(primaryProfile, primarySku.confidence, {})
+        : `
+            <div class="vmm-target-block mb-3">
+                <h6><i class="bi bi-pin-map me-1"></i>Zone availability</h6>
+                ${vmmGetZonesDisplay(primarySku)}
+            </div>
+        `;
+
+    const sharedPricingSection = primarySku.pricing && vmmComponents.renderPricingPanel
+        ? vmmComponents.renderPricingPanel(primarySku.pricing)
+        : `
+            <div class="vmm-target-block">
+                <h6><i class="bi bi-cash-coin me-1"></i>Pricing</h6>
+                ${vmmBuildPricingTable(primarySku)}
+            </div>
+        `;
+
+    const alternateSection = alternateSkus.length
+        ? `
+            <div class="mt-3 pt-2 border-top">
+                <div class="small text-body-secondary mb-2">Alternate candidates</div>
+                <div class="d-flex flex-wrap gap-2">
+                    ${alternateSkus.map((sku) => `
+                        <span class="px-2 py-1 border rounded bg-body-tertiary small d-inline-flex align-items-center gap-2">
+                            <code>${escapeHtml(sku.name || "")}</code>
+                            ${vmmGetConfidenceDisplay(sku.confidence)}
+                        </span>
+                    `).join("")}
+                </div>
+            </div>
+        `
+        : "";
+
+    const rows = `
+        <article class="vmm-target-sku-card">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-2">
+                <div class="d-flex align-items-center gap-2">
+                    <span class="badge rounded-pill text-bg-primary">Recommended target SKU</span>
+                    <code class="fs-6">${escapeHtml(primarySku.name || "")}</code>
+                </div>
+                <div>${primaryConfidence}</div>
+            </div>
+            <div class="small text-body-secondary mb-3">
+                Target region <strong>${escapeHtml(vm.region || "")}</strong> · Source SKU <code>${escapeHtml(vm.sku || "")}</code>
+            </div>
+            ${sharedConfidenceSection}
+            ${sharedZoneSection}
+            ${sharedPricingSection}
+            ${alternateSection}
+        </article>
+    `;
+
+    return `
+        <div class="accordion mt-3" id="vmmTargetRecoAccordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#vmmTargetRecoPanel" aria-expanded="true">
+                        <i class="bi bi-bullseye me-2"></i>Recommended v6/v7 target SKU
+                    </button>
+                </h2>
+                <div id="vmmTargetRecoPanel" class="accordion-collapse collapse show">
+                    <div class="accordion-body p-3">${rows}</div>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+async function vmmOpenVmDetail(vm) {
+    if (!vm?.sku || !vm?.region) return;
+    const modal = vmmEnsureDetailModal();
+    if (!modal) return;
+
+    const nameEl = document.getElementById("vmm-detail-name");
+    const loadingEl = document.getElementById("vmm-detail-loading");
+    const contentEl = document.getElementById("vmm-detail-content");
+    if (!nameEl || !loadingEl || !contentEl) return;
+
+    nameEl.textContent = vm.name || "VM";
+    loadingEl.classList.remove("d-none");
+    contentEl.classList.add("d-none");
+    modal.show();
+
+    try {
+        const targetSkus = await vmmFetchTargetSkuRecommendations(vm);
+        let html = "";
+        html += vmmBuildRecommendationSectionHtml(vm);
+        html += vmmBuildTargetRecommendationSection(vm, targetSkus);
+        contentEl.innerHTML = html;
+        contentEl.classList.remove("d-none");
+    } catch (err) {
+        contentEl.innerHTML = `<div class="text-danger small">Failed to build recommendations: ${escapeHtml(String(err))}</div>`;
+        contentEl.classList.remove("d-none");
+    } finally {
+        loadingEl.classList.add("d-none");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
@@ -208,6 +696,7 @@ function vmmZonesBadge(zones) {
 
 function vmmRenderTable() {
     const sorted = vmmSortedVms();
+    vmmDisplayedVms = sorted;
     const tbody = document.getElementById("vmm-tbody");
     if (!tbody) return;
 
@@ -221,7 +710,9 @@ function vmmRenderTable() {
     const countEl = document.getElementById("vmm-table-count");
     if (countEl) countEl.textContent = sorted.length;
 
-    tbody.innerHTML = sorted.map(v => `<tr>
+    tbody.innerHTML = sorted.map((v, i) => `<tr class="vmm-vm-row" tabindex="0"
+        onclick="vmmOpenVmDetailByIndex(${i})"
+        onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();vmmOpenVmDetailByIndex(${i});}">
         <td class="text-nowrap">${escapeHtml(v.name)}</td>
         <td class="text-nowrap small">${escapeHtml(v.resource_group)}</td>
         <td class="text-nowrap small">${escapeHtml(v.subscription_name)}</td>
@@ -259,8 +750,8 @@ function vmmRenderStats(vms) {
 
     statsEl.innerHTML = [
         { label: "Total VMs", value: vms.length, icon: "bi-server", color: "primary" },
-        { label: "V1 Generation", value: byGen.V1 || 0, icon: "bi-exclamation-triangle", color: "warning" },
-        { label: "V2 Generation", value: byGen.V2 || 0, icon: "bi-check-circle", color: "info" },
+        { label: "V1 Hyper-V Gen", value: byGen.V1 || 0, icon: "bi-exclamation-triangle", color: "warning" },
+        { label: "V2 Hyper-V Gen", value: byGen.V2 || 0, icon: "bi-check-circle", color: "info" },
         { label: "Windows VMs", value: byOs.Windows || 0, icon: "bi-windows", color: "secondary" },
         { label: "Linux VMs", value: byOs.Linux || 0, icon: "bi-ubuntu", color: "secondary" },
         { label: "Regions", value: regions, icon: "bi-geo-alt", color: "secondary" },
@@ -297,7 +788,7 @@ function vmmSetView(state) {
     if (state === "no-filter-results") {
         const tbody = document.getElementById("vmm-tbody");
         if (tbody) tbody.innerHTML = `<tr><td colspan="11" class="text-center text-body-secondary py-3">
-            No VMs match the current filters.</td></tr>`;
+            No legacy SKU VMs in migration scope match the current filters.</td></tr>`;
         const countEl = document.getElementById("vmm-table-count");
         if (countEl) countEl.textContent = "0";
     }
@@ -309,8 +800,8 @@ function vmmSetView(state) {
 function vmmExportCSV() {
     const headers = [
         "VM Name", "Resource Group", "Subscription", "Subscription ID",
-        "Region", "SKU", "Generation", "OS Type", "Image Publisher",
-        "Disk Controller", "Zones", "Migration Effort",
+        "Region", "SKU", "Hyper-V Generation", "OS Type", "Image Publisher",
+        "Disk Controller", "Zones", "Migration Readiness (inferred)",
     ];
     const rows = vmmSortedVms().map(v => [
         v.name,
@@ -326,7 +817,7 @@ function vmmExportCSV() {
         (v.zones || []).join(";"),
         v.generation.startsWith("V1") ? "Moderate" : v.generation.startsWith("V2") ? "Low" : "Unknown",
     ]);
-    downloadCSV([headers, ...rows], "vm-migration-candidates.csv");
+    downloadCSV([headers, ...rows], "legacy-sku-migration-scope.csv");
 }
 
 // Expose for app.js subscription refresh callbacks

--- a/src/az_scout/internal_plugins/vm_migration/static/js/vm-migration-tab.js
+++ b/src/az_scout/internal_plugins/vm_migration/static/js/vm-migration-tab.js
@@ -1,0 +1,333 @@
+/* eslint-disable @microsoft/sdl/no-inner-html -- All dynamic values sanitized via escapeHtml(). HTML fragments loaded from own server. */
+/* ===================================================================
+   Azure Scout – VM v6/v7 Migration Tab  (internal plugin)
+   Requires: app.js globals: subscriptions, apiFetch, tenantQS,
+             escapeHtml, showError, hideError, downloadCSV
+   =================================================================== */
+
+// ---------------------------------------------------------------------------
+// Bootstrap – load the HTML fragment into the tab container
+// ---------------------------------------------------------------------------
+(async function initVmMigrationTab() {
+    const container = document.getElementById("plugin-tab-vm-migration");
+    if (!container) return;
+    try {
+        const resp = await fetch("/internal/vm-migration/static/html/vm-migration-tab.html");
+        if (resp.ok) container.innerHTML = await resp.text();
+    } catch { /* template already inline */ }
+
+    const filterInput = document.getElementById("vmm-sub-filter");
+    if (filterInput) {
+        filterInput.addEventListener("input", () => renderVmmSubList(filterInput.value));
+    }
+
+    if (typeof subscriptions !== "undefined" && subscriptions.length) {
+        renderVmmSubList();
+    }
+    vmmUpdateLoadButton();
+})();
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+const vmmSelectedSubs = new Set();
+let vmmAllVms = [];          // raw API results
+let vmmFilteredVms = [];     // after filter application
+let vmmSortField = "name";
+let vmmSortAsc = true;
+
+// ---------------------------------------------------------------------------
+// Subscription checklist
+// ---------------------------------------------------------------------------
+function renderVmmSubList(filter) {
+    const container = document.getElementById("vmm-sub-list");
+    if (!container) return;
+    const list = filter
+        ? subscriptions.filter(s => s.name.toLowerCase().includes(filter.toLowerCase()))
+        : subscriptions;
+
+    if (!list.length && !filter) {
+        container.innerHTML = '<span class="text-body-secondary small">No subscriptions found</span>';
+        return;
+    }
+    container.innerHTML = list.map(s => {
+        const checked = vmmSelectedSubs.has(s.id) ? "checked" : "";
+        return `<label title="${escapeHtml(s.name)}">
+            <input type="checkbox" class="form-check-input me-1" value="${escapeHtml(s.id)}" ${checked}
+                   onchange="vmmToggleSub('${escapeHtml(s.id)}')">
+            ${escapeHtml(s.name)}
+        </label>`;
+    }).join("");
+    vmmUpdateSubCount();
+}
+
+function vmmToggleSub(id) {
+    if (vmmSelectedSubs.has(id)) vmmSelectedSubs.delete(id);
+    else vmmSelectedSubs.add(id);
+    vmmUpdateSubCount();
+    vmmUpdateLoadButton();
+}
+
+function vmmSelectAllVisible() {
+    document.querySelectorAll("#vmm-sub-list input[type=checkbox]").forEach(cb => {
+        cb.checked = true;
+        vmmSelectedSubs.add(cb.value);
+    });
+    vmmUpdateSubCount();
+    vmmUpdateLoadButton();
+}
+
+function vmmDeselectAll() {
+    vmmSelectedSubs.clear();
+    document.querySelectorAll("#vmm-sub-list input[type=checkbox]").forEach(cb => {
+        cb.checked = false;
+    });
+    vmmUpdateSubCount();
+    vmmUpdateLoadButton();
+}
+
+function vmmUpdateSubCount() {
+    const el = document.getElementById("vmm-sub-count");
+    if (el) el.textContent = `${vmmSelectedSubs.size} selected`;
+}
+
+function vmmUpdateLoadButton() {
+    const btn = document.getElementById("vmm-load-btn");
+    if (btn) btn.disabled = vmmSelectedSubs.size === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Load VMs
+// ---------------------------------------------------------------------------
+async function vmmLoad() {
+    if (!vmmSelectedSubs.size) return;
+
+    vmmSetView("loading");
+
+    const subIds = [...vmmSelectedSubs].join(",");
+    const url = `/api/vms?subscriptions=${encodeURIComponent(subIds)}${tenantQS()}`;
+
+    try {
+        const data = await apiFetch(url);
+        if (data.error) {
+            vmmSetView("error");
+            document.getElementById("vmm-error").textContent = data.error;
+            return;
+        }
+        vmmAllVms = data;
+        vmmPopulateFilterDropdowns();
+        vmmApplyFilters();
+    } catch (err) {
+        vmmSetView("error");
+        document.getElementById("vmm-error").textContent = String(err);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+function vmmPopulateFilterDropdowns() {
+    const regions = [...new Set(vmmAllVms.map(v => v.region).filter(Boolean))].sort();
+    const regionSel = document.getElementById("vmm-filter-region");
+    if (regionSel) {
+        regionSel.innerHTML = '<option value="">All regions</option>' +
+            regions.map(r => `<option value="${escapeHtml(r)}">${escapeHtml(r)}</option>`).join("");
+    }
+}
+
+function vmmApplyFilters() {
+    const name = (document.getElementById("vmm-filter-name")?.value || "").toLowerCase();
+    const region = document.getElementById("vmm-filter-region")?.value || "";
+    const os = document.getElementById("vmm-filter-os")?.value || "";
+    const gen = document.getElementById("vmm-filter-gen")?.value || "";
+
+    vmmFilteredVms = vmmAllVms.filter(v => {
+        if (name && !v.name.toLowerCase().includes(name)) return false;
+        if (region && v.region !== region) return false;
+        if (os && v.os_type !== os) return false;
+        if (gen && !v.generation.startsWith(gen)) return false;
+        return true;
+    });
+
+    vmmRenderTable();
+}
+
+function vmmResetFilters() {
+    const ids = ["vmm-filter-name", "vmm-filter-region", "vmm-filter-os", "vmm-filter-gen"];
+    ids.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.value = "";
+    });
+    vmmFilteredVms = [...vmmAllVms];
+    vmmRenderTable();
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+function vmmSort(field) {
+    if (vmmSortField === field) {
+        vmmSortAsc = !vmmSortAsc;
+    } else {
+        vmmSortField = field;
+        vmmSortAsc = true;
+    }
+    vmmRenderTable();
+}
+
+function vmmSortedVms() {
+    return [...vmmFilteredVms].sort((a, b) => {
+        const va = String(a[vmmSortField] ?? "").toLowerCase();
+        const vb = String(b[vmmSortField] ?? "").toLowerCase();
+        return vmmSortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+function vmmEffortBadge(generation) {
+    if (generation.startsWith("V1")) {
+        return '<span class="badge bg-warning text-dark">Moderate</span>';
+    }
+    if (generation.startsWith("V2")) {
+        return '<span class="badge bg-info text-dark">Low</span>';
+    }
+    return '<span class="badge bg-secondary">Unknown</span>';
+}
+
+function vmmDiskBadge(controller) {
+    const cls = controller === "NVMe" ? "text-success" : "text-body-secondary";
+    return `<span class="${cls}">${escapeHtml(controller || "SCSI")}</span>`;
+}
+
+function vmmZonesBadge(zones) {
+    if (!zones || !zones.length) return '<span class="text-body-secondary">—</span>';
+    return zones.map(z => `<span class="badge bg-secondary me-1">${escapeHtml(String(z))}</span>`).join("");
+}
+
+function vmmRenderTable() {
+    const sorted = vmmSortedVms();
+    const tbody = document.getElementById("vmm-tbody");
+    if (!tbody) return;
+
+    if (!sorted.length) {
+        vmmSetView(vmmAllVms.length ? "no-filter-results" : "no-results");
+        return;
+    }
+
+    vmmSetView("results");
+
+    const countEl = document.getElementById("vmm-table-count");
+    if (countEl) countEl.textContent = sorted.length;
+
+    tbody.innerHTML = sorted.map(v => `<tr>
+        <td class="text-nowrap">${escapeHtml(v.name)}</td>
+        <td class="text-nowrap small">${escapeHtml(v.resource_group)}</td>
+        <td class="text-nowrap small">${escapeHtml(v.subscription_name)}</td>
+        <td class="text-nowrap">${escapeHtml(v.region)}</td>
+        <td class="text-nowrap"><code>${escapeHtml(v.sku)}</code></td>
+        <td class="text-nowrap">${escapeHtml(v.generation)}</td>
+        <td>${escapeHtml(v.os_type)}</td>
+        <td class="small">${escapeHtml(v.image_publisher)}</td>
+        <td>${vmmDiskBadge(v.disk_controller_type)}</td>
+        <td>${vmmZonesBadge(v.zones)}</td>
+        <td>${vmmEffortBadge(v.generation)}</td>
+    </tr>`).join("");
+
+    vmmRenderStats(sorted);
+}
+
+function vmmRenderStats(vms) {
+    const statsEl = document.getElementById("vmm-stats");
+    if (!statsEl) return;
+
+    const byGen = vms.reduce((acc, v) => {
+        const k = v.generation.startsWith("V1") ? "V1" : v.generation.startsWith("V2") ? "V2" : "Unknown";
+        acc[k] = (acc[k] || 0) + 1;
+        return acc;
+    }, {});
+
+    const byOs = vms.reduce((acc, v) => {
+        const k = v.os_type || "Unknown";
+        acc[k] = (acc[k] || 0) + 1;
+        return acc;
+    }, {});
+
+    const regions = new Set(vms.map(v => v.region)).size;
+    const subs = new Set(vms.map(v => v.subscription_id)).size;
+
+    statsEl.innerHTML = [
+        { label: "Total VMs", value: vms.length, icon: "bi-server", color: "primary" },
+        { label: "V1 Generation", value: byGen.V1 || 0, icon: "bi-exclamation-triangle", color: "warning" },
+        { label: "V2 Generation", value: byGen.V2 || 0, icon: "bi-check-circle", color: "info" },
+        { label: "Windows VMs", value: byOs.Windows || 0, icon: "bi-windows", color: "secondary" },
+        { label: "Linux VMs", value: byOs.Linux || 0, icon: "bi-ubuntu", color: "secondary" },
+        { label: "Regions", value: regions, icon: "bi-geo-alt", color: "secondary" },
+        { label: "Subscriptions", value: subs, icon: "bi-collection", color: "secondary" },
+    ].map(s => `
+        <div class="col-sm-6 col-md-4 col-lg-3 col-xl-2">
+            <div class="card text-center vmm-stat-card">
+                <div class="card-body py-2 px-3">
+                    <div class="fs-4 fw-bold text-${s.color}">${s.value}</div>
+                    <div class="small text-body-secondary"><i class="bi ${s.icon} me-1"></i>${s.label}</div>
+                </div>
+            </div>
+        </div>`).join("");
+}
+
+// ---------------------------------------------------------------------------
+// View state management
+// ---------------------------------------------------------------------------
+function vmmSetView(state) {
+    const views = {
+        "empty": "vmm-empty",
+        "loading": "vmm-loading",
+        "error": "vmm-error",
+        "results": "vmm-results",
+        "no-results": "vmm-no-results",
+        "no-filter-results": "vmm-results",
+    };
+    ["vmm-empty", "vmm-loading", "vmm-error", "vmm-results", "vmm-no-results"].forEach(id => {
+        document.getElementById(id)?.classList.add("d-none");
+    });
+    const target = views[state];
+    if (target) document.getElementById(target)?.classList.remove("d-none");
+
+    if (state === "no-filter-results") {
+        const tbody = document.getElementById("vmm-tbody");
+        if (tbody) tbody.innerHTML = `<tr><td colspan="11" class="text-center text-body-secondary py-3">
+            No VMs match the current filters.</td></tr>`;
+        const countEl = document.getElementById("vmm-table-count");
+        if (countEl) countEl.textContent = "0";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CSV export
+// ---------------------------------------------------------------------------
+function vmmExportCSV() {
+    const headers = [
+        "VM Name", "Resource Group", "Subscription", "Subscription ID",
+        "Region", "SKU", "Generation", "OS Type", "Image Publisher",
+        "Disk Controller", "Zones", "Migration Effort",
+    ];
+    const rows = vmmSortedVms().map(v => [
+        v.name,
+        v.resource_group,
+        v.subscription_name,
+        v.subscription_id,
+        v.region,
+        v.sku,
+        v.generation,
+        v.os_type,
+        v.image_publisher,
+        v.disk_controller_type || "SCSI",
+        (v.zones || []).join(";"),
+        v.generation.startsWith("V1") ? "Moderate" : v.generation.startsWith("V2") ? "Low" : "Unknown",
+    ]);
+    downloadCSV([headers, ...rows], "vm-migration-candidates.csv");
+}
+
+// Expose for app.js subscription refresh callbacks
+window.renderVmmSubList = renderVmmSubList;

--- a/src/az_scout/internal_plugins/vm_migration/tools.py
+++ b/src/az_scout/internal_plugins/vm_migration/tools.py
@@ -1,0 +1,41 @@
+"""MCP tools for the VM v6/v7 Migration internal plugin."""
+
+from __future__ import annotations
+
+from az_scout import azure_api
+from az_scout.internal_plugins.vm_migration.routes import (
+    _fetch_vms_for_subscription,
+    _is_migration_candidate,
+)
+
+
+def list_migration_candidate_vms(
+    subscription_ids: list[str],
+    tenant_id: str | None = None,
+) -> list[dict]:
+    """List all Azure VMs that are candidates for migration to the v6/v7 series.
+
+    Returns VMs currently running v2–v5 generation SKUs with fields:
+    name, resource_group, subscription_id, subscription_name, region, sku,
+    generation, os_type, image_publisher, disk_controller_type, zones.
+
+    Args:
+        subscription_ids: List of Azure subscription IDs to scan.
+        tenant_id: Optional Azure AD tenant ID to scope the request.
+    """
+    known_subs: dict[str, str] = {}
+    try:
+        all_subs = azure_api.list_subscriptions(tenant_id)
+        known_subs = {s["id"]: s.get("name", s["id"]) for s in all_subs}
+    except Exception:
+        pass
+
+    results: list[dict] = []
+    for sub_id in subscription_ids:
+        sub_name = known_subs.get(sub_id, sub_id)
+        results.extend(_fetch_vms_for_subscription(sub_id, sub_name, tenant_id))
+    return results
+
+
+# Re-export for use in unit tests
+__all__ = ["list_migration_candidate_vms", "_is_migration_candidate"]

--- a/src/az_scout/internal_plugins/vm_migration/tools.py
+++ b/src/az_scout/internal_plugins/vm_migration/tools.py
@@ -21,14 +21,15 @@ def list_migration_candidate_vms(
         Field(description="Optional Azure AD tenant ID to scope the request."),
     ] = None,
 ) -> str:
-    """List Azure VMs that are candidates for migration to the v6/v7 series.
+    """List legacy-SKU Azure VMs in scope for v6/v7 migration planning.
 
-    Returns all VMs using v2-v5 generation SKUs (e.g. Standard_D4s_v3,
-    Standard_E8ds_v5) across the given subscriptions, with fields:
+    Returns inventory records for VMs using v2-v5 SKU families
+    (e.g. Standard_D4s_v3, Standard_E8ds_v5) across the given subscriptions,
+    with fields:
     name, resource_group, subscription_id, subscription_name, region, sku,
     generation, os_type, image_publisher, disk_controller_type, zones.
 
-    Use this tool to assess migration scope before planning a v6/v7 upgrade.
+    Use this tool for migration-scope discovery before pilot and wave planning.
 
     Generation values:
     - "V2" / "V1": confirmed from security profile or image reference

--- a/src/az_scout/internal_plugins/vm_migration/tools.py
+++ b/src/az_scout/internal_plugins/vm_migration/tools.py
@@ -2,23 +2,37 @@
 
 from __future__ import annotations
 
+import json
+from typing import Annotated
+
+from pydantic import Field
+
 from az_scout import azure_api
 from az_scout.internal_plugins.vm_migration.routes import _fetch_vms_for_subscription
 
 
 def list_migration_candidate_vms(
-    subscription_ids: list[str],
-    tenant_id: str | None = None,
-) -> list[dict]:
-    """List all Azure VMs that are candidates for migration to the v6/v7 series.
+    subscription_ids: Annotated[
+        list[str],
+        Field(description="List of Azure subscription IDs to scan."),
+    ],
+    tenant_id: Annotated[
+        str | None,
+        Field(description="Optional Azure AD tenant ID to scope the request."),
+    ] = None,
+) -> str:
+    """List Azure VMs that are candidates for migration to the v6/v7 series.
 
-    Returns VMs currently running v2–v5 generation SKUs with fields:
+    Returns all VMs using v2-v5 generation SKUs (e.g. Standard_D4s_v3,
+    Standard_E8ds_v5) across the given subscriptions, with fields:
     name, resource_group, subscription_id, subscription_name, region, sku,
     generation, os_type, image_publisher, disk_controller_type, zones.
 
-    Args:
-        subscription_ids: List of Azure subscription IDs to scan.
-        tenant_id: Optional Azure AD tenant ID to scope the request.
+    Use this tool to assess migration scope before planning a v6/v7 upgrade.
+
+    Generation values:
+    - "V2" / "V1": confirmed from security profile or image reference
+    - "V2 (inferred)" / "V1 (inferred)": estimated from SKU family (v4/v5 -> V2, v2/v3 -> V1)
     """
     known_subs: dict[str, str] = {}
     try:
@@ -31,4 +45,4 @@ def list_migration_candidate_vms(
     for sub_id in subscription_ids:
         sub_name = known_subs.get(sub_id, sub_id)
         results.extend(_fetch_vms_for_subscription(sub_id, sub_name, tenant_id))
-    return results
+    return json.dumps(results, indent=2)

--- a/src/az_scout/internal_plugins/vm_migration/tools.py
+++ b/src/az_scout/internal_plugins/vm_migration/tools.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from az_scout import azure_api
-from az_scout.internal_plugins.vm_migration.routes import (
-    _fetch_vms_for_subscription,
-    _is_migration_candidate,
-)
+from az_scout.internal_plugins.vm_migration.routes import _fetch_vms_for_subscription
 
 
 def list_migration_candidate_vms(
@@ -35,7 +32,3 @@ def list_migration_candidate_vms(
         sub_name = known_subs.get(sub_id, sub_id)
         results.extend(_fetch_vms_for_subscription(sub_id, sub_name, tenant_id))
     return results
-
-
-# Re-export for use in unit tests
-__all__ = ["list_migration_candidate_vms", "_is_migration_candidate"]

--- a/tests/test_vm_migration_plugin.py
+++ b/tests/test_vm_migration_plugin.py
@@ -72,6 +72,9 @@ class TestIsMigrationCandidate:
             ("Standard_D8s_v7", False),
             ("Standard_A2_v2", True),
             ("Standard_D16_v1", False),  # v1 is not in scope
+            ("Standard_D4_v3_Promo", True),  # Promo suffix after version
+            ("Standard_A1_v2_Promo", True),  # Promo on v2 family
+            ("Standard_D4s_v6_Promo", False),  # v6 Promo is not in scope
         ],
     )
     def test_candidate_detection(self, sku: str, expected: bool) -> None:

--- a/tests/test_vm_migration_plugin.py
+++ b/tests/test_vm_migration_plugin.py
@@ -1,0 +1,296 @@
+"""Tests for the VM v6/v7 Migration internal plugin."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Helper: ARM VM response factory
+# ---------------------------------------------------------------------------
+
+
+def _make_vm(
+    name: str = "my-vm",
+    sub_id: str = "sub-123",
+    rg: str = "my-rg",
+    size: str = "Standard_D4s_v3",
+    location: str = "eastus",
+    os_type: str = "Linux",
+    publisher: str = "Canonical",
+    img_sku: str = "20_04-lts",
+    disk_controller: str = "SCSI",
+    security_type: str = "",
+    zones: list | None = None,
+) -> dict:
+    vm: dict = {
+        "id": (
+            f"/subscriptions/{sub_id}/resourceGroups/{rg}"
+            f"/providers/Microsoft.Compute/virtualMachines/{name}"
+        ),
+        "name": name,
+        "location": location,
+        "zones": zones or [],
+        "properties": {
+            "hardwareProfile": {"vmSize": size},
+            "storageProfile": {
+                "imageReference": {
+                    "publisher": publisher,
+                    "offer": "UbuntuServer",
+                    "sku": img_sku,
+                },
+                "osDisk": {
+                    "osType": os_type,
+                    "diskControllerType": disk_controller,
+                },
+            },
+            "securityProfile": {},
+        },
+    }
+    if security_type:
+        vm["properties"]["securityProfile"]["securityType"] = security_type
+    return vm
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – migration candidate detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsMigrationCandidate:
+    """Validate _is_migration_candidate SKU filter."""
+
+    @pytest.mark.parametrize(
+        "sku,expected",
+        [
+            ("Standard_D4s_v3", True),
+            ("Standard_E8ds_v4", True),
+            ("Standard_D2s_v5", True),
+            ("Standard_B2ms_v2", True),
+            ("Standard_D4s_v6", False),
+            ("Standard_D8s_v7", False),
+            ("Standard_A2_v2", True),
+            ("Standard_D16_v1", False),  # v1 is not in scope
+        ],
+    )
+    def test_candidate_detection(self, sku: str, expected: bool) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _is_migration_candidate
+
+        assert _is_migration_candidate(sku) == expected
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – generation detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectGeneration:
+    """Validate _detect_generation logic."""
+
+    def test_trusted_launch_returns_v2(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _detect_generation
+
+        vm = _make_vm(security_type="TrustedLaunch", size="Standard_D4s_v3")
+        assert _detect_generation(vm) == "V2"
+
+    def test_confidential_vm_returns_v2(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _detect_generation
+
+        vm = _make_vm(security_type="ConfidentialVM", size="Standard_D4s_v3")
+        assert _detect_generation(vm) == "V2"
+
+    def test_gen2_image_sku_returns_v2(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _detect_generation
+
+        vm = _make_vm(img_sku="2019-datacenter-gen2")
+        assert _detect_generation(vm) == "V2"
+
+    def test_v4_sku_infers_v2(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _detect_generation
+
+        vm = _make_vm(size="Standard_E8ds_v4")
+        assert _detect_generation(vm) == "V2 (inferred)"
+
+    def test_v3_sku_infers_v1(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _detect_generation
+
+        vm = _make_vm(size="Standard_D4s_v3")
+        assert _detect_generation(vm) == "V1 (inferred)"
+
+    def test_v2_sku_infers_v1(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _detect_generation
+
+        vm = _make_vm(size="Standard_D2_v2")
+        assert _detect_generation(vm) == "V1 (inferred)"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – resource group parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseResourceGroup:
+    def test_extracts_rg_from_arm_id(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _parse_resource_group
+
+        rid = (
+            "/subscriptions/sub-abc/resourceGroups/my-rg"
+            "/providers/Microsoft.Compute/virtualMachines/vm1"
+        )
+        assert _parse_resource_group(rid) == "my-rg"
+
+    def test_case_insensitive(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _parse_resource_group
+
+        rid = (
+            "/subscriptions/sub-abc/RESOURCEGROUPS/MY-RG"
+            "/providers/Microsoft.Compute/virtualMachines/vm1"
+        )
+        assert _parse_resource_group(rid) == "MY-RG"
+
+    def test_empty_id_returns_empty(self) -> None:
+        from az_scout.internal_plugins.vm_migration.routes import _parse_resource_group
+
+        assert _parse_resource_group("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – API route
+# ---------------------------------------------------------------------------
+
+
+class TestGetMigrationVmsRoute:
+    """Test the /vms API route via the FastAPI test client."""
+
+    def test_missing_subscriptions_returns_400(self, client) -> None:
+        resp = client.get("/api/vms")
+        assert resp.status_code == 400
+        assert "subscriptions" in resp.json()["error"]
+
+    def test_empty_subscriptions_returns_400(self, client) -> None:
+        resp = client.get("/api/vms?subscriptions=")
+        assert resp.status_code == 400
+
+    def test_returns_only_v2_to_v5_vms(self, client) -> None:
+        """Only v2–v5 VMs should appear; v6/v7 VMs must be filtered out."""
+        arm_vms = [
+            _make_vm(name="vm-v3", size="Standard_D4s_v3"),
+            _make_vm(name="vm-v5", size="Standard_D4s_v5"),
+            _make_vm(name="vm-v6", size="Standard_D4s_v6"),  # must be excluded
+        ]
+        mock_resp = MagicMock(status_code=200, json=lambda: {"value": arm_vms})
+        with (
+            patch("az_scout.azure_api.requests.get", return_value=mock_resp),
+            patch("az_scout.azure_api.list_subscriptions", return_value=[]),
+        ):
+            resp = client.get("/api/vms?subscriptions=sub-123")
+
+        assert resp.status_code == 200
+        names = [v["name"] for v in resp.json()]
+        assert "vm-v3" in names
+        assert "vm-v5" in names
+        assert "vm-v6" not in names
+
+    def test_response_schema(self, client) -> None:
+        """Check that every required field is present in the response."""
+        arm_vms = [_make_vm(zones=["1"])]
+        mock_resp = MagicMock(status_code=200, json=lambda: {"value": arm_vms})
+        with (
+            patch("az_scout.azure_api.requests.get", return_value=mock_resp),
+            patch("az_scout.azure_api.list_subscriptions", return_value=[]),
+        ):
+            resp = client.get("/api/vms?subscriptions=sub-123")
+
+        assert resp.status_code == 200
+        result = resp.json()
+        assert len(result) == 1
+        vm = result[0]
+        for field in [
+            "name",
+            "resource_group",
+            "subscription_id",
+            "subscription_name",
+            "region",
+            "sku",
+            "generation",
+            "os_type",
+            "image_publisher",
+            "disk_controller_type",
+            "zones",
+        ]:
+            assert field in vm, f"Missing field: {field}"
+
+    def test_arm_authorization_error_skips_subscription(self, client) -> None:
+        """403 errors on a subscription should not crash the whole request."""
+        from az_scout.azure_api._arm import ArmAuthorizationError
+
+        with (
+            patch(
+                "az_scout.azure_api.requests.get",
+                side_effect=ArmAuthorizationError("Forbidden", status_code=403),
+            ),
+            patch("az_scout.azure_api.list_subscriptions", return_value=[]),
+        ):
+            resp = client.get("/api/vms?subscriptions=sub-403")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_subscription_name_resolved(self, client) -> None:
+        """Subscription name should be resolved from list_subscriptions."""
+        arm_vms = [_make_vm(name="vm1", sub_id="sub-abc")]
+        mock_resp = MagicMock(status_code=200, json=lambda: {"value": arm_vms})
+        with (
+            patch("az_scout.azure_api.requests.get", return_value=mock_resp),
+            patch(
+                "az_scout.azure_api.list_subscriptions",
+                return_value=[{"id": "sub-abc", "name": "My Production Sub"}],
+            ),
+        ):
+            resp = client.get("/api/vms?subscriptions=sub-abc")
+
+        assert resp.status_code == 200
+        assert resp.json()[0]["subscription_name"] == "My Production Sub"
+
+    def test_multi_subscription_aggregates_results(self, client) -> None:
+        """Results from multiple subscriptions should be merged."""
+
+        def side_effect(url, *, headers, params, timeout):
+            sub_in_url = "sub-a" if "sub-a" in url else "sub-b"
+            return MagicMock(
+                status_code=200,
+                json=lambda s=sub_in_url: {"value": [_make_vm(name=f"vm-{s}", sub_id=s)]},
+            )
+
+        with (
+            patch("az_scout.azure_api.requests.get", side_effect=side_effect),
+            patch("az_scout.azure_api.list_subscriptions", return_value=[]),
+        ):
+            resp = client.get("/api/vms?subscriptions=sub-a,sub-b")
+
+        assert resp.status_code == 200
+        names = {v["name"] for v in resp.json()}
+        assert "vm-sub-a" in names
+        assert "vm-sub-b" in names
+
+
+# ---------------------------------------------------------------------------
+# Plugin protocol tests
+# ---------------------------------------------------------------------------
+
+
+class TestVmMigrationPlugin:
+    def test_plugin_protocol_surface(self) -> None:
+        from az_scout.internal_plugins.vm_migration import plugin
+
+        assert plugin.name == "vm-migration"
+        assert plugin.version
+        assert plugin.get_router() is not None
+        assert plugin.get_static_dir() is not None
+        tabs = plugin.get_tabs()
+        assert tabs and len(tabs) == 1
+        assert tabs[0].id == "vm-migration"
+        tools = plugin.get_mcp_tools()
+        assert tools and len(tools) == 1
+        assert callable(tools[0])

--- a/tests/test_vm_migration_plugin.py
+++ b/tests/test_vm_migration_plugin.py
@@ -226,7 +226,7 @@ class TestGetMigrationVmsRoute:
 
     def test_arm_authorization_error_skips_subscription(self, client) -> None:
         """403 errors on a subscription should not crash the whole request."""
-        from az_scout.azure_api._arm import ArmAuthorizationError
+        from az_scout.azure_api import ArmAuthorizationError
 
         with (
             patch(


### PR DESCRIPTION
## Summary

Adds a new internal plugin — **VM Migration** — that scans Azure subscriptions for VMs still running v2–v5 generation SKUs and surfaces them in a sortable, filterable dashboard with all the metadata needed to plan a migration to the v6/v7 series.

Ref: https://learn.microsoft.com/en-us/azure/virtual-machines/migration/sizes/sizes-v6-v7-migration-overview

---

## What's added

### Backend (`src/az_scout/internal_plugins/vm_migration/`)

| File | Role |
|---|---|
| `__init__.py` | Plugin class + module-level instance |
| `routes.py` | `GET /api/vms` — lists migration-candidate VMs |
| `tools.py` | `list_migration_candidate_vms` MCP tool |

**Candidate detection:** SKU name matches `_v[2-5]` regex (e.g. `Standard_D4s_v3`, `Standard_E8ds_v5`). v6/v7 VMs are excluded.

**Fields returned per VM:**

| Field | Source |
|---|---|
| `name` | VM resource name |
| `resource_group` | Parsed from ARM resource ID |
| `subscription_id` / `subscription_name` | ARM list + `list_subscriptions` |
| `region` | `location` |
| `sku` | `hardwareProfile.vmSize` |
| `generation` | `securityProfile.securityType` → image ref sku marker → inferred from SKU family |
| `os_type` | `storageProfile.osDisk.osType` |
| `image_publisher` | `storageProfile.imageReference.publisher` |
| `disk_controller_type` | `storageProfile.osDisk.diskControllerType` (defaults to SCSI) |
| `zones` | `zones` array |

**Generation inference logic:**
- `TrustedLaunch` / `ConfidentialVM` → **V2**
- Image SKU contains `gen2` / `-g2` → **V2**
- SKU family v4/v5 → **V2 (inferred)**
- SKU family v2/v3 → **V1 (inferred)**

### Frontend (`static/`)

- Subscription multi-select (same UX as AZ Topology)
- Filters: VM name, region, OS type, generation
- Summary stat cards (total, V1/V2 count, Windows/Linux, regions, subscriptions)
- Sortable table with all 11 columns
- **Migration effort** badge per row (Moderate for V1, Low for V2)
- CSV export via `downloadCSV()`

### Tests (`tests/test_vm_migration_plugin.py`)

25 tests — all pass:
- SKU candidate detection (8 parametrized cases)
- Generation detection (6 cases)
- Resource group parsing (3 cases)
- API route (7 integration tests via `TestClient`)
- Plugin protocol surface (1 test)