### PR TITLE
release: v2026.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+## [2026.8.1] - 2026-08-05
+
 ### Fixed
 
 - **`Install error: cannot access local variable 'InvalidSpecifier' where it is not associated with a value`** – installing any plugin from the Plugin Manager failed on isolated installs (`uv tool install az-scout`, `uvx az-scout`, `pipx`). The plugin core-version compatibility check imported `packaging` *inside* a `try` block but referenced `InvalidSpecifier` in the matching `except (InvalidSpecifier, Exception)` clause. `packaging` was never a declared runtime dependency — it only reached dev environments transitively via `mkdocs`/`pytest` — so on a clean install the import raised `ImportError`, evaluating the `except` tuple raised `UnboundLocalError`, and the error surfaced in the UI instead of the real cause. `packaging>=24.0` is now a declared runtime dependency, and the check was restructured so exception names are only referenced after their import succeeds. When `packaging` is genuinely unavailable the check now logs a warning and allows the install rather than crashing, and malformed version specifiers no longer block installs.


### PR DESCRIPTION
Finalizes the changelog for the **2026.8.1** release.

## Changes

- Moved the `## Unreleased` entry (plugin-manager `InvalidSpecifier` install fix, #181) into a new `## [2026.8.1] - 2026-08-05` section.
- Left `## Unreleased` empty.

No source changes — `CHANGELOG.md` only.

## Quality gate

All four checks pass on this branch:

| Check | Result |
|---|---|
| `ruff check src/ tests/` | ✅ All checks passed |
| `ruff format --check src/ tests/` | ✅ 72 files already formatted |
| `mypy src/` | ✅ no issues in 56 source files |
| `pytest` | ✅ 462 passed, 18 deselected |

## After merge

The `v2026.8.1` tag will be pushed to `main`, which triggers the **Publish** workflow: CI across Python 3.11–3.13, CalVer + package-version validation, GitHub Release with auto-generated notes, and PyPI publish via trusted publishing (OIDC).