### PR TITLE
fix(plugins): stop editable-core constraint and prune shadowing core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+### Fixed
+
+- **Plugin install failed with `No solution found` on editable / local core installs** – the Plugin Manager pins `az-scout==<running version>` in a pip constraint file to stop a mismatched core from being installed into the plugin packages directory. When the core itself is an editable or local `file:` install (dev worktrees, `pip install .`), that exact version exists only on disk and not on any package index, so uv could not satisfy the `==` pin and *every* plugin install failed. The constraint is now skipped when the core is detected as an editable/local install (via PEP 610 `direct_url.json`).
+- **A duplicate `az-scout` core could be installed into the plugin packages directory and shadow the running core** – a `--target` plugin install re-resolves in isolation and drags a full copy of the `az-scout` core (and its dependency tree) into the packages directory, which is prepended to `sys.path` at startup. A stray core copy there would shadow the running core, producing wrong version/metadata resolution (and reintroducing the constraint failure above on subsequent installs). The core is now pruned from the packages directory after every successful install and again before the directory is added to `sys.path` at startup, so a plugin's copy of the core can never persist or shadow the real one. Plugin packages (`az_scout_*`) are left untouched.
+
 ## [2026.8.1] - 2026-08-05
 
 ### Fixed

--- a/src/az_scout/plugin_manager/_installer.py
+++ b/src/az_scout/plugin_manager/_installer.py
@@ -107,13 +107,22 @@ def _prune_core_from_packages(packages_dir: Path | None = None) -> None:
     pkg = packages_dir or _storage._PACKAGES_DIR
     if not pkg.exists():
         return
-    core_dir = pkg / "az_scout"
-    if core_dir.is_dir():
-        logger.debug("Pruning stray az-scout core package from packages dir: %s", core_dir)
-        shutil.rmtree(core_dir, ignore_errors=True)
-    for info in pkg.glob("az_scout-*.dist-info"):
-        logger.debug("Pruning stray az-scout core dist-info from packages dir: %s", info)
-        shutil.rmtree(info, ignore_errors=True)
+    targets = [pkg / "az_scout"] if (pkg / "az_scout").is_dir() else []
+    targets.extend(pkg.glob("az_scout-*.dist-info"))
+    for target in targets:
+        logger.debug("Pruning stray az-scout core from packages dir: %s", target)
+        try:
+            shutil.rmtree(target)
+        except OSError:
+            logger.warning(
+                "Error while pruning stray az-scout core from packages dir: %s",
+                target,
+                exc_info=True,
+            )
+        if target.exists():
+            # The whole point of pruning is to stop a stray core from shadowing the
+            # running one, so a silent failure here would defeat it. Surface it.
+            logger.warning("Stray az-scout core still present after prune attempt: %s", target)
 
 
 def _core_is_local_install() -> bool:
@@ -136,8 +145,7 @@ def _core_is_local_install() -> bool:
         found = False
         for dist in distributions():
             try:
-                meta = dist.metadata
-                name = meta["Name"] if meta else None
+                name = dist.name
                 if not name or name.lower().replace("_", "-") != "az-scout":
                     continue
                 found = True

--- a/src/az_scout/plugin_manager/_installer.py
+++ b/src/az_scout/plugin_manager/_installer.py
@@ -151,6 +151,11 @@ def _core_is_local_install() -> bool:
                 if isinstance(url, str) and url.startswith("file:"):
                     return True
             except Exception:
+                logger.debug(
+                    "Skipping unreadable distribution during local core check: %r",
+                    dist,
+                    exc_info=True,
+                )
                 continue
         # If no az-scout distribution metadata is discoverable at all, err on the
         # side of skipping the constraint rather than emitting an unsatisfiable pin.

--- a/src/az_scout/plugin_manager/_installer.py
+++ b/src/az_scout/plugin_manager/_installer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import os
 import shutil
@@ -84,18 +85,94 @@ def run_pip(args: list[str]) -> subprocess.CompletedProcess[str]:
         with contextlib.suppress(Exception):
             Path(constraint_file).unlink(missing_ok=True)
 
+    # A ``--target`` install re-resolves in isolation and drags a full copy of the
+    # ``az-scout`` core (and its dependency tree) into the packages directory. That
+    # directory is prepended to ``sys.path`` at startup, so a stray core copy would
+    # shadow the running core. The core is always importable from the active
+    # environment, so remove any copy that landed in the packages dir.
+    if is_install and result.returncode == 0:
+        _prune_core_from_packages()
+
     return result
+
+
+def _prune_core_from_packages(packages_dir: Path | None = None) -> None:
+    """Remove any ``az-scout`` core copy that a ``--target`` install left behind.
+
+    Only the core is pruned: the top-level ``az_scout`` package directory and its
+    ``az_scout-*.dist-info`` metadata. Plugin packages (``az_scout_*``) and their
+    ``az_scout_*-*.dist-info`` directories use an underscore separator and are left
+    untouched.
+    """
+    pkg = packages_dir or _storage._PACKAGES_DIR
+    if not pkg.exists():
+        return
+    core_dir = pkg / "az_scout"
+    if core_dir.is_dir():
+        logger.debug("Pruning stray az-scout core package from packages dir: %s", core_dir)
+        shutil.rmtree(core_dir, ignore_errors=True)
+    for info in pkg.glob("az_scout-*.dist-info"):
+        logger.debug("Pruning stray az-scout core dist-info from packages dir: %s", info)
+        shutil.rmtree(info, ignore_errors=True)
+
+
+def _core_is_local_install() -> bool:
+    """Return ``True`` if the ``az-scout`` core is an editable or local ``file:`` install.
+
+    Such installs (dev worktrees, ``pip install .``) expose their version only on
+    disk, never on a package index.  Pinning ``az-scout==<version>`` as a pip
+    constraint would then be unsatisfiable and break every plugin install, so the
+    constraint is skipped in that case.  Detection uses the PEP 610
+    ``direct_url.json`` metadata, which is absent for regular index installs.
+
+    All installed ``az-scout`` distributions are scanned, not just the first one on
+    ``sys.path``: the plugin packages directory is prepended to ``sys.path`` and may
+    contain a stray non-editable core copy that would otherwise shadow the real
+    editable checkout and defeat this check.
+    """
+    try:
+        from importlib.metadata import distributions
+
+        found = False
+        for dist in distributions():
+            try:
+                meta = dist.metadata
+                name = meta["Name"] if meta else None
+                if not name or name.lower().replace("_", "-") != "az-scout":
+                    continue
+                found = True
+                raw = dist.read_text("direct_url.json")
+                if not raw:
+                    continue
+                data = json.loads(raw)
+                if data.get("dir_info", {}).get("editable"):
+                    return True
+                url = data.get("url", "")
+                if isinstance(url, str) and url.startswith("file:"):
+                    return True
+            except Exception:
+                continue
+        # If no az-scout distribution metadata is discoverable at all, err on the
+        # side of skipping the constraint rather than emitting an unsatisfiable pin.
+        return not found
+    except Exception:
+        return False
 
 
 def _write_core_constraint() -> str | None:
     """Write a temporary constraints file pinning ``az-scout`` to the running version.
 
-    Returns the file path, or ``None`` if the version cannot be determined.
+    Returns the file path, or ``None`` if the version cannot be determined or the
+    core is installed editable / from a local ``file:`` URL (whose version is not
+    published on any index).
     """
     try:
         from az_scout import __version__
 
         if not __version__ or __version__ == "0.0.0-dev" or "dev" in __version__:
+            return None
+        if _core_is_local_install():
+            logger.debug("Skipping core constraint: az-scout is a local/editable install")
             return None
         fd, path = tempfile.mkstemp(prefix="azscout-constraint-", suffix=".txt")
         with os.fdopen(fd, "w") as f:

--- a/src/az_scout/plugins.py
+++ b/src/az_scout/plugins.py
@@ -39,9 +39,19 @@ _plugin_route_prefixes: set[str] = set()  # tracked prefixes for route cleanup
 
 
 def _ensure_plugin_packages_on_path() -> None:
-    """Add ``plugin-packages`` directory to ``sys.path`` if it exists."""
+    """Add ``plugin-packages`` directory to ``sys.path`` if it exists.
+
+    Before adding the directory, any stray ``az-scout`` core copy is pruned from
+    it. A ``--target`` plugin install re-resolves in isolation and can drag a full
+    copy of the core into the packages directory; because that directory is
+    prepended to ``sys.path``, such a copy would shadow the running core. The core
+    is always importable from the active environment, so it must never live here.
+    """
     if not _PACKAGES_DIR.exists():
         return
+    from az_scout.plugin_manager._installer import _prune_core_from_packages
+
+    _prune_core_from_packages()
     pkg_str = str(_PACKAGES_DIR)
     if pkg_str not in sys.path:
         sys.path.insert(0, pkg_str)

--- a/src/az_scout/plugins.py
+++ b/src/az_scout/plugins.py
@@ -51,7 +51,7 @@ def _ensure_plugin_packages_on_path() -> None:
         return
     from az_scout.plugin_manager._installer import _prune_core_from_packages
 
-    _prune_core_from_packages()
+    _prune_core_from_packages(_PACKAGES_DIR)
     pkg_str = str(_PACKAGES_DIR)
     if pkg_str not in sys.path:
         sys.path.insert(0, pkg_str)

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -992,6 +992,46 @@ class TestRunPip:
 
         assert pkg_dir.exists()
 
+    def test_prunes_core_after_successful_install(self, tmp_path: Path) -> None:
+        """A stray core copy dragged in by --target is pruned after a good install."""
+        pkg_dir = tmp_path / "plugin-packages"
+        pkg_dir.mkdir()
+        core = pkg_dir / "az_scout"
+        core.mkdir()
+        (core / "__init__.py").write_text("")
+        info = pkg_dir / "az_scout-2026.8.0.dist-info"
+        info.mkdir()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        with (
+            patch.object(_pm_storage, "_PACKAGES_DIR", pkg_dir),
+            patch("az_scout.plugin_manager._installer._find_uv", return_value="/usr/bin/uv"),
+            patch("az_scout.plugin_manager._installer.subprocess.run", return_value=mock_proc),
+        ):
+            plugin_manager.run_pip(["pip", "install", "some-pkg"])
+
+        assert not core.exists()
+        assert not info.exists()
+
+    def test_does_not_prune_after_failed_install(self, tmp_path: Path) -> None:
+        """A failed install leaves the packages dir untouched."""
+        pkg_dir = tmp_path / "plugin-packages"
+        pkg_dir.mkdir()
+        core = pkg_dir / "az_scout"
+        core.mkdir()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+
+        with (
+            patch.object(_pm_storage, "_PACKAGES_DIR", pkg_dir),
+            patch("az_scout.plugin_manager._installer._find_uv", return_value="/usr/bin/uv"),
+            patch("az_scout.plugin_manager._installer.subprocess.run", return_value=mock_proc),
+        ):
+            plugin_manager.run_pip(["pip", "install", "some-pkg"])
+
+        assert core.exists()
+
 
 # ---------------------------------------------------------------------------
 # Reconciliation tests
@@ -2184,7 +2224,13 @@ class TestCoreConstraintFile:
     def test_writes_constraint(self) -> None:
         from az_scout.plugin_manager._installer import _write_core_constraint
 
-        with patch("az_scout.__version__", "2026.3.8"):
+        with (
+            patch("az_scout.__version__", "2026.3.8"),
+            patch(
+                "az_scout.plugin_manager._installer._core_is_local_install",
+                return_value=False,
+            ),
+        ):
             path = _write_core_constraint()
         assert path is not None
         content = Path(path).read_text()
@@ -2197,3 +2243,55 @@ class TestCoreConstraintFile:
         with patch("az_scout.__version__", "2026.3.9.dev4"):
             path = _write_core_constraint()
         assert path is None
+
+    def test_skips_editable_install(self) -> None:
+        from az_scout.plugin_manager._installer import _write_core_constraint
+
+        with (
+            patch("az_scout.__version__", "2026.3.8"),
+            patch(
+                "az_scout.plugin_manager._installer._core_is_local_install",
+                return_value=True,
+            ),
+        ):
+            path = _write_core_constraint()
+        assert path is None
+
+
+class TestPruneCoreFromPackages:
+    """Tests for _prune_core_from_packages."""
+
+    def test_removes_core_package_and_dist_info(self, tmp_path: Path) -> None:
+        from az_scout.plugin_manager._installer import _prune_core_from_packages
+
+        core = tmp_path / "az_scout"
+        core.mkdir()
+        (core / "__init__.py").write_text("")
+        info = tmp_path / "az_scout-2026.8.0.dist-info"
+        info.mkdir()
+        (info / "METADATA").write_text("Name: az-scout\n")
+
+        _prune_core_from_packages(tmp_path)
+
+        assert not core.exists()
+        assert not info.exists()
+
+    def test_preserves_plugin_packages(self, tmp_path: Path) -> None:
+        from az_scout.plugin_manager._installer import _prune_core_from_packages
+
+        plugin_pkg = tmp_path / "az_scout_plugin_odcr_coverage"
+        plugin_pkg.mkdir()
+        (plugin_pkg / "__init__.py").write_text("")
+        plugin_info = tmp_path / "az_scout_plugin_odcr_coverage-2026.6.0.dist-info"
+        plugin_info.mkdir()
+        (plugin_info / "METADATA").write_text("Name: az-scout-plugin-odcr-coverage\n")
+
+        _prune_core_from_packages(tmp_path)
+
+        assert plugin_pkg.exists()
+        assert plugin_info.exists()
+
+    def test_no_op_when_dir_missing(self, tmp_path: Path) -> None:
+        from az_scout.plugin_manager._installer import _prune_core_from_packages
+
+        _prune_core_from_packages(tmp_path / "does-not-exist")


### PR DESCRIPTION
## Description

Plugin installs failed with uv `No solution found` in dev and local-core setups. This fixes two stacked root causes:

1. **Unsatisfiable core constraint.** The Plugin Manager pins `az-scout==<running version>` in a pip constraint file to keep a mismatched core out of the plugin packages directory. For an editable or local `file:` core (dev worktrees, `pip install .`), that exact version lives only on disk and is not published on any index, so uv could not satisfy the `==` pin and *every* plugin install failed. `_write_core_constraint()` now detects an editable/local core (scanning **all** `az-scout` distributions, not just the first on `sys.path`, via PEP 610 `direct_url.json`) and skips the pin in that case. Real index-based installs are still protected.

2. **A duplicate core shadowing the running one.** A `--target` install re-resolves in isolation and drags a full copy of the `az-scout` core plus its dependency tree into the packages directory, which is prepended to `sys.path` at startup. A stray core copy there shadows the running core, corrupting version/metadata resolution and reintroducing the constraint failure on the next install. The core is now pruned from the packages directory after every successful install (`run_pip`) and again before that directory is added to `sys.path` at startup (`_ensure_plugin_packages_on_path`). Only the core is pruned (`az_scout/` + `az_scout-*.dist-info`); plugin packages (`az_scout_*`, underscore separator) are left untouched.

Pruning is the authoritative cure for the shadowing: the core is always importable from the active environment, so a copy must never persist in the packages dir.

## Related issue

N/A

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore

## Checklist

- [x] I have tested my changes locally (`uvx az-scout` or `uv run az-scout`)
- [ ] I have updated the documentation / README if needed
- [x] My changes do not introduce new warnings or errors

Verified: ruff / ruff-format / mypy clean; full suite `468 passed`; and a live install through the running dev server returned `200` with the plugin registered and no stray core left in the packages directory. New tests cover local-core constraint skipping, core pruning, and that `run_pip` prunes only after a successful install.

## Screenshots

N/A