### PR TITLE
release: v2026.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.MICRO`).
 
 ## Unreleased
 
+## [2026.8.2] - 2026-08-11
+
 ### Changed
 
 - **Vendored all frontend CDN assets into the app bundle (core app works offline/air-gapped)** – Bootstrap, Bootstrap Icons (+ fonts), simple-datatables, highlight.js (+ both themes and the JSON language), marked, and D3 are now served from `src/az_scout/static/vendor/` via the existing `/static` mount instead of `cdn.jsdelivr.net` / `d3js.org`. The core UI now works fully offline/air-gapped and identically across local dev, SaaS publishing (the files ship in the wheel), and customer self-hosting — with no per-mode configuration. A new dependency-free maintenance script, `tools/vendor_assets.py`, (re)downloads the pinned versions when they are bumped (`python tools/vendor_assets.py`, `--check` to verify presence); the committed files remain the source of truth, so no build tooling is added to the normal dev/install/publish flows.


### PR DESCRIPTION
## Release v2026.8.2

Finalizes the changelog for the `2026.8.2` release. This branch was identical to `origin/main`; the only change here is moving the `## Unreleased` entries under a dated `## [2026.8.2] - 2026-08-11` heading.

### Included changes (from Unreleased)

**Changed**
- Vendored all frontend CDN assets into the app bundle (core app works offline/air-gapped).
- Vendoring third-party assets is now a recommended (optional) convention for plugins.
- Removed the restrictive `'self'`-only Content-Security-Policy.

**Fixed**
- Plugin install failed with `No solution found` on editable / local core installs.
- A duplicate `az-scout` core could be installed into the plugin packages directory and shadow the running core.

### Quality gate

- `ruff check` ✓
- `ruff format --check` ✓
- `mypy src/` ✓
- `pytest` — 468 passed ✓

### After merge

Tag `v2026.8.2` will be created on the merged `main` commit and pushed, triggering the Publish workflow (CI → CalVer/version validation → GitHub Release → PyPI trusted publishing).